### PR TITLE
Examples patch

### DIFF
--- a/ScriptHookVDotNet.sln
+++ b/ScriptHookVDotNet.sln
@@ -1,20 +1,33 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.30324.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ScriptHookVDotNet", "ScriptHookVDotNet.vcxproj", "{019193A7-50C0-444A-84CA-777595E702CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptHookVDotNetExample", "example\ScriptHookVDotNetExample.csproj", "{A717AD5D-C5B5-4769-BD40-F14C09F269BB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{019193A7-50C0-444A-84CA-777595E702CD}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{019193A7-50C0-444A-84CA-777595E702CD}.Debug|x64.ActiveCfg = Debug|x64
 		{019193A7-50C0-444A-84CA-777595E702CD}.Debug|x64.Build.0 = Debug|x64
+		{019193A7-50C0-444A-84CA-777595E702CD}.Release|Any CPU.ActiveCfg = Release|x64
 		{019193A7-50C0-444A-84CA-777595E702CD}.Release|x64.ActiveCfg = Release|x64
 		{019193A7-50C0-444A-84CA-777595E702CD}.Release|x64.Build.0 = Release|x64
+		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Debug|x64.ActiveCfg = Debug|x64
+		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Debug|x64.Build.0 = Debug|x64
+		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Release|x64.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -42,7 +42,7 @@
     <OutDir>bin\$(Configuration)\</OutDir>
     <IntDir>obj\$(Configuration)\</IntDir>
     <TargetName>ScriptHookVDotNet</TargetName>
-    <TargetExt>.asi</TargetExt>
+    <TargetExt>.dll</TargetExt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -62,6 +62,9 @@
       <AdditionalLibraryDirectories>sdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>ScriptHookV.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>cp $(TargetDir)$(AssemblyName).dll $(TargetDir)$(AssemblyName).asi</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/example/MainScript.cs
+++ b/example/MainScript.cs
@@ -6,13 +6,12 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GTA;
-using GTA.Native;
 
 namespace ScriptHookVDotNetExample
 {
-    public class Script : GTA.Script
+    public class MainScript : Script
     {
-        public Script()
+        public MainScript()
         {
             Tick += OnTick; // Main loop event, called every few milliseconds specified via the Interval property.
             KeyUp += OnKeyUp; // Called when a key or mouse button is released.
@@ -26,18 +25,16 @@ namespace ScriptHookVDotNetExample
 
         void OnTick(object sender, EventArgs e)
         {
-            File.AppendAllText("log.txt", "TICK");
             // Calling native functions:
             // - No return type: GTA.Native.Function.Call(GTA.Native.Hash.SET_MAX_WANTED_LEVEL, 0);
             // - With return type: int id = GTA.Native.Function.Call<int>(GTA.Native.Hash.PLAYER_PED_ID);
         }
         void OnKeyUp(object sender, KeyEventArgs e)
         {
-            File.AppendAllText("log.txt", e.KeyCode.ToString() + System.Environment.NewLine);
+
         }
         void OnKeyDown(object sender, KeyEventArgs e)
         {
-            File.AppendAllText("log.txt", e.KeyCode.ToString() + System.Environment.NewLine);
             Ped player = Game.Player.Character;
 
             if (player.IsInVehicle())
@@ -51,9 +48,6 @@ namespace ScriptHookVDotNetExample
                         break;
                     case Keys.E:
                         vehicle.RightIndicatorLightOn = mIndicatorRight = !mIndicatorRight;
-                        break;
-                    case Keys.Z:
-                        vehicle.Explode();
                         break;
                 }
             }

--- a/example/Properties/AssemblyInfo.cs
+++ b/example/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über die folgenden 
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die mit einer Assembly verknüpft sind.
+[assembly: AssemblyTitle("ScriptHookVDotNetExample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ScriptHookVDotNetExample")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Durch Festlegen von ComVisible auf "false" werden die Typen in dieser Assembly unsichtbar 
+// für COM-Komponenten.  Wenn Sie auf einen Typ in dieser Assembly von 
+// COM zugreifen müssen, legen Sie das ComVisible-Attribut für diesen Typ auf "true" fest.
+[assembly: ComVisible(false)]
+
+// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+[assembly: Guid("e5976a01-baaf-492f-8f30-ebecdda13f55")]
+
+// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
+//
+//      Hauptversion
+//      Nebenversion 
+//      Buildnummer
+//      Revision
+//
+// Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
+// übernehmen, indem Sie "*" eingeben:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/example/Script.cs
+++ b/example/Script.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using GTA;
+using GTA.Native;
+
+namespace ScriptHookVDotNetExample
+{
+    public class Script : GTA.Script
+    {
+        public Script()
+        {
+            Tick += OnTick; // Main loop event, called every few milliseconds specified via the Interval property.
+            KeyUp += OnKeyUp; // Called when a key or mouse button is released.
+            KeyDown += OnKeyDown; // Called when a key or mouse button is pressed.
+
+            Interval = 10; // Tick interval in milliseconds. Set to zero to run as fast as possible.
+        }
+
+        bool mIndicatorLeft = false;
+        bool mIndicatorRight = false;
+
+        void OnTick(object sender, EventArgs e)
+        {
+            File.AppendAllText("log.txt", "TICK");
+            // Calling native functions:
+            // - No return type: GTA.Native.Function.Call(GTA.Native.Hash.SET_MAX_WANTED_LEVEL, 0);
+            // - With return type: int id = GTA.Native.Function.Call<int>(GTA.Native.Hash.PLAYER_PED_ID);
+        }
+        void OnKeyUp(object sender, KeyEventArgs e)
+        {
+            File.AppendAllText("log.txt", e.KeyCode.ToString() + System.Environment.NewLine);
+        }
+        void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            File.AppendAllText("log.txt", e.KeyCode.ToString() + System.Environment.NewLine);
+            Ped player = Game.Player.Character;
+
+            if (player.IsInVehicle())
+            {
+                Vehicle vehicle = player.CurrentVehicle;
+
+                switch (e.KeyCode)
+                {
+                    case Keys.Q:
+                        vehicle.LeftIndicatorLightOn = mIndicatorLeft = !mIndicatorLeft;
+                        break;
+                    case Keys.E:
+                        vehicle.RightIndicatorLightOn = mIndicatorRight = !mIndicatorRight;
+                        break;
+                    case Keys.Z:
+                        vehicle.Explode();
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/example/ScriptHookVDotNetExample.csproj
+++ b/example/ScriptHookVDotNetExample.csproj
@@ -58,7 +58,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Script.cs" />
+    <Compile Include="MainScript.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/example/ScriptHookVDotNetExample.csproj
+++ b/example/ScriptHookVDotNetExample.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A717AD5D-C5B5-4769-BD40-F14C09F269BB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ScriptHookVDotNetExample</RootNamespace>
+    <AssemblyName>ScriptHookVDotNetExample</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin\Debug\scripts\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\bin\Debug\scripts\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Script.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ScriptHookVDotNet.vcxproj">
+      <Project>{019193a7-50c0-444a-84ca-777595e702cd}</Project>
+      <Name>ScriptHookVDotNet</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Hey,

I thought about adding a example-script right into the project, so people can see how it works.

Two changes:
* Added example script project
* Modified TargetExt (.asi to .dll) and added PostBuildEvent (copy dll to asi) so VS can register the dll as dependecy

If you want something changed, just let me know :+1: 