### PR TITLE
Read assembly file in memory first so it won't be locked.

### DIFF
--- a/src/ScriptDomain.cpp
+++ b/src/ScriptDomain.cpp
@@ -199,7 +199,8 @@ namespace GTA
 
 		try
 		{
-			assembly = Reflection::Assembly::LoadFrom(filename);
+			auto file = System::IO::File::ReadAllBytes(filename);
+			assembly = Reflection::Assembly::Load(file);
 		}
 		catch (Exception ^ex)
 		{


### PR DESCRIPTION
Reading assembly file into memory first so file won't be locked, allowing hot reloading of .dlls.