### PR TITLE
Refactored Log function into its own class

### DIFF
--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -87,6 +87,7 @@
   <ItemGroup>
     <ClCompile Include="source\Entity.cpp" />
     <ClCompile Include="source\Game.cpp" />
+    <ClCompile Include="source\Log.cpp" />
     <ClCompile Include="source\Main.cpp" />
     <ClCompile Include="source\Matrix.cpp" />
     <ClCompile Include="source\Model.cpp" />
@@ -105,6 +106,7 @@
   <ItemGroup>
     <ClInclude Include="source\Entity.hpp" />
     <ClInclude Include="source\Game.hpp" />
+    <ClInclude Include="source\Log.hpp" />
     <ClInclude Include="source\Matrix.hpp" />
     <ClInclude Include="source\Model.hpp" />
     <ClInclude Include="source\Native.hpp" />

--- a/ScriptHookVDotNet.vcxproj.filters
+++ b/ScriptHookVDotNet.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="source\World.cpp">
       <Filter>Scripting</Filter>
     </ClCompile>
+    <ClCompile Include="source\Log.cpp">
+      <Filter>Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\Native.hpp">
@@ -109,6 +112,9 @@
     </ClInclude>
     <ClInclude Include="source\World.hpp">
       <Filter>Scripting</Filter>
+    </ClInclude>
+    <ClInclude Include="source\Log.hpp">
+      <Filter>Core</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/source/Log.cpp
+++ b/source/Log.cpp
@@ -1,0 +1,36 @@
+#include "Log.hpp"
+
+namespace GTA
+{
+	using namespace System;
+	using namespace System::Collections::Generic;
+
+	void Log::Debug(... array<System::String ^> ^message)
+	{
+		LogToFile("[DEBUG]", message);
+	}
+
+	void Log::Error(... array<System::String ^> ^message)
+	{
+		LogToFile("[ERROR]", message);
+	}
+
+	void Log::LogToFile(System::String ^logLevel, ... array<System::String ^> ^message)
+	{
+		String ^logpath = IO::Path::ChangeExtension(Reflection::Assembly::GetExecutingAssembly()->Location, ".log");
+		IO::FileStream ^fs = gcnew IO::FileStream(logpath, IO::FileMode::Append, IO::FileAccess::Write, IO::FileShare::Read);
+		IO::StreamWriter ^sw = gcnew IO::StreamWriter(fs);
+
+		sw->Write(String::Concat(logLevel, " [", DateTime::Now.ToString("HH:mm:ss"), "] "));
+
+		for each (String ^string in message)
+		{
+			sw->Write(string);
+		}
+
+		sw->WriteLine();
+
+		sw->Close();
+		fs->Close();
+	}
+}

--- a/source/Log.hpp
+++ b/source/Log.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace GTA
+{
+	public ref class Log sealed abstract
+	{
+	public:
+		static void Debug(... array<System::String ^> ^message);
+		static void Error(... array<System::String ^> ^message);
+
+	private:
+		static void LogToFile(System::String ^logLevel, ... array<System::String ^> ^message);
+	};
+}


### PR DESCRIPTION
I took the Log function out of ScriptDomain.cpp, so that it could be used elsewhere, including the .NET API (though maybe we actually want to keep that separate)

 I also split it into 2 static methods for different log levels, Debug and Error. Log messages are now prefixed with their log level, eg: 

`[DEBUG] [03:39:17] Created script domain 'ScriptDomain_D63EA64B'.`