### PR TITLE
Fixed padding issue with World::GetNearbyPeds()

### DIFF
--- a/source/World.cpp
+++ b/source/World.cpp
@@ -52,7 +52,7 @@ namespace GTA
 	{
 		const Math::Vector3 position = ped->Position;
 		System::Collections::Generic::List<Ped ^> ^result = gcnew System::Collections::Generic::List<Ped ^>();
-		int *handles = new int[maxAmount + 1];
+		int *handles = new int[maxAmount * 2 + 2];
 
 		try
 		{
@@ -62,7 +62,7 @@ namespace GTA
 
 			for (int i = 0; i < amount; ++i)
 			{
-				const int index = i + 1;
+				const int index = i * 2 + 2;
 
 				if (handles[index] != 0 && Native::Function::Call<bool>(Native::Hash::DOES_ENTITY_EXIST, handles[index]))
 				{


### PR DESCRIPTION
World::GetNearbyPeds() was throwing an exception.  I found the solution thanks to moment0 at gtaforums in this thread: http://gtaforums.com/topic/789788-function-args-to-pedget-ped-nearby-peds/?p=1067386687

Each Ped handle (and the first value, which is the maxAmount) is padded by 1, so the array actually needs twice the size, and each ped handle is accessed at even indexes starting at 2:

Layout of the handles array after call to GET_NEARBY_PEDS:

`handles[0] = maxAmount`
`handles[1] = unknown`
`handles[2] = pedHandle1`
`handles[3] = unknown`
`handles[4] = pedHandle2`
`handles[5] = unknown`
`...`