### PR TITLE
Fixed time-based crash

### DIFF
--- a/source/ScriptDomain.cpp
+++ b/source/ScriptDomain.cpp
@@ -407,4 +407,8 @@ namespace GTA
 
 		this->mPinnedStrings->Clear();
 	}
+	System::Object ^ScriptDomain::InitializeLifetimeService()
+	{
+		return nullptr;
+	}
 }

--- a/source/ScriptDomain.hpp
+++ b/source/ScriptDomain.hpp
@@ -61,6 +61,7 @@ namespace GTA
 		bool IsKeyPressed(System::Windows::Forms::Keys key);
 		System::IntPtr PinString(System::String ^string);
 		void CleanupStrings();
+		System::Object ^InitializeLifetimeService() override;
 
 	private:
 		bool LoadScript(System::String ^filename);


### PR DESCRIPTION
This should fix the time-based crash.

When you Tab out of the game and return to it after some minutes, our hook will crash and won't function anymore.