### PR TITLE
Implemented some vehicle properties and methods

### DIFF
--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -263,6 +263,18 @@ namespace GTA
 	{
 		return Native::Function::Call<bool>(Native::Hash::_DOES_VEHICLE_HAVE_SECONDARY_COLOUR, this->ID);
 	}
+	void Vehicle::CustomSecondaryColor::set(System::Drawing::Color color)
+	{
+		Native::Function::Call(Native::Hash::SET_VEHICLE_CUSTOM_SECONDARY_COLOUR, this->ID, color.R, color.G, color.B);
+	}
+	void Vehicle::ClearCustomSecondaryColor()
+	{
+		Native::Function::Call(Native::Hash::CLEAR_VEHICLE_CUSTOM_SECONDARY_COLOUR, this->ID);
+	}
+	bool Vehicle::IsSecondaryColorCustom::get()
+	{
+		return Native::Function::Call<bool>(Native::Hash::_0x910A32E7AAD2656C, this->ID);
+	}
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -237,6 +237,10 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::SET_VEHICLE_WINDOW_TINT, this->ID, static_cast<int>(windowTint));
 	}
+	void Vehicle::ToggleMod(VehicleToggleMod toggleMod, bool toggle)
+	{
+		Native::Function::Call(Native::Hash::TOGGLE_VEHICLE_MOD, this->ID, static_cast<int>(toggleMod), toggle);
+	}
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -245,6 +245,24 @@ namespace GTA
 	{
 		return Native::Function::Call<bool>(Native::Hash::IS_TOGGLE_MOD_ON, this->ID, static_cast<int>(toggleMod));
 	}
+	System::Drawing::Color Vehicle::CustomPrimaryColor::get()
+	{
+		int r = 0, g = 0, b = 0;
+		Native::Function::Call(Native::Hash::GET_VEHICLE_CUSTOM_PRIMARY_COLOUR, this -> ID, r, g, b);
+		return System::Drawing::Color::FromArgb(r, g, b);
+	}
+	void Vehicle::CustomPrimaryColor::set(System::Drawing::Color color)
+	{
+		Native::Function::Call(Native::Hash::SET_VEHICLE_CUSTOM_PRIMARY_COLOUR, this->ID, color.R, color.G, color.B);
+	}
+	void Vehicle::ClearCustomPrimaryColor()
+	{
+		Native::Function::Call(Native::Hash::CLEAR_VEHICLE_CUSTOM_PRIMARY_COLOUR, this->ID);
+	}
+	/*bool Vehicle::IsPrimaryColorCustom::get()
+	{
+		return Native::Function::Call(Native::Hash::GET_IS_VEHICLE_PRIMARY_COLOUR_CUSTOM,)
+	}*/
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -227,7 +227,16 @@ namespace GTA
 	void Vehicle::WheelType::set(VehicleWheelType wheelType)
 	{
 		Native::Function::Call(Native::Hash::SET_VEHICLE_WHEEL_TYPE, this->ID, static_cast<int>(wheelType));
-	}	
+	}
+	VehicleWindowTint Vehicle::WindowTint::get()
+	{
+		int windowTint = Native::Function::Call<int>(Native::Hash::GET_VEHICLE_WINDOW_TINT, this->ID);
+		return static_cast<VehicleWindowTint>(windowTint);
+	}
+	void Vehicle::WindowTint::set(VehicleWindowTint windowTint)
+	{
+		Native::Function::Call(Native::Hash::SET_VEHICLE_WINDOW_TINT, this->ID, static_cast<int>(windowTint));
+	}
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -277,6 +277,30 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::SET_VEHICLE_DOOR_SHUT, this->ID, static_cast<int>(door), closeInstantly);
 	}
+	void Vehicle::FixWindow(VehicleWindow window)
+	{
+		Native::Function::Call(Native::Hash::FIX_VEHICLE_WINDOW, this->ID, static_cast<int>(window));
+	}
+	void Vehicle::SmashWindow(VehicleWindow window)
+	{
+		Native::Function::Call(Native::Hash::SMASH_VEHICLE_WINDOW, this->ID, static_cast<int>(window));
+	}
+	void Vehicle::RollUpWindow(VehicleWindow window)
+	{
+		Native::Function::Call(Native::Hash::ROLL_UP_WINDOW, this->ID, static_cast<int>(window));
+	}
+	void Vehicle::RollDownWindow(VehicleWindow window)
+	{
+		Native::Function::Call(Native::Hash::ROLL_DOWN_WINDOW, this->ID, static_cast<int>(window));
+	}
+	void Vehicle::RollDownWindows()
+	{
+		Native::Function::Call(Native::Hash::ROLL_DOWN_WINDOWS, this->ID);
+	}
+	void Vehicle::RemoveWindow(VehicleWindow window)
+	{
+		Native::Function::Call(Native::Hash::REMOVE_VEHICLE_WINDOW, this->ID, static_cast<int>(window));
+	}
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -219,6 +219,15 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::SET_VEHICLE_MOD, this->ID, static_cast<int>(modType), modIndex, variations);
 	}
+	VehicleWheelType Vehicle::WheelType::get()
+	{
+		int wheelType = Native::Function::Call<int>(Native::Hash::GET_VEHICLE_WHEEL_TYPE, this->ID);
+		return static_cast<VehicleWheelType>(wheelType);
+	}
+	void Vehicle::WheelType::set(VehicleWheelType wheelType)
+	{
+		Native::Function::Call(Native::Hash::SET_VEHICLE_WHEEL_TYPE, this->ID, static_cast<int>(wheelType));
+	}	
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -245,12 +245,6 @@ namespace GTA
 	{
 		return Native::Function::Call<bool>(Native::Hash::IS_TOGGLE_MOD_ON, this->ID, static_cast<int>(toggleMod));
 	}
-	System::Drawing::Color Vehicle::CustomPrimaryColor::get()
-	{
-		int r = 0, g = 0, b = 0;
-		Native::Function::Call(Native::Hash::GET_VEHICLE_CUSTOM_PRIMARY_COLOUR, this->ID, r, g, b);
-		return System::Drawing::Color::FromArgb(r, g, b);
-	}
 	void Vehicle::CustomPrimaryColor::set(System::Drawing::Color color)
 	{
 		Native::Function::Call(Native::Hash::SET_VEHICLE_CUSTOM_PRIMARY_COLOUR, this->ID, color.R, color.G, color.B);

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -89,14 +89,14 @@ namespace GTA
 	{
 		switch (value)
 		{
-			case VehicleRoofState::Closed:
-			case VehicleRoofState::Closing:
-				Native::Function::Call(Native::Hash::RAISE_CONVERTIBLE_ROOF, this->ID, 0);
-				break;
-			case VehicleRoofState::Opened:
-			case VehicleRoofState::Opening:
-				Native::Function::Call(Native::Hash::LOWER_CONVERTIBLE_ROOF, this->ID, 0);
-				break;
+		case VehicleRoofState::Closed:
+		case VehicleRoofState::Closing:
+			Native::Function::Call(Native::Hash::RAISE_CONVERTIBLE_ROOF, this->ID, 0);
+			break;
+		case VehicleRoofState::Opened:
+		case VehicleRoofState::Opening:
+			Native::Function::Call(Native::Hash::LOWER_CONVERTIBLE_ROOF, this->ID, 0);
+			break;
 		}
 	}
 	float Vehicle::EngineHealth::get()
@@ -248,7 +248,7 @@ namespace GTA
 	System::Drawing::Color Vehicle::CustomPrimaryColor::get()
 	{
 		int r = 0, g = 0, b = 0;
-		Native::Function::Call(Native::Hash::GET_VEHICLE_CUSTOM_PRIMARY_COLOUR, this -> ID, r, g, b);
+		Native::Function::Call(Native::Hash::GET_VEHICLE_CUSTOM_PRIMARY_COLOUR, this->ID, r, g, b);
 		return System::Drawing::Color::FromArgb(r, g, b);
 	}
 	void Vehicle::CustomPrimaryColor::set(System::Drawing::Color color)
@@ -259,10 +259,10 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::CLEAR_VEHICLE_CUSTOM_PRIMARY_COLOUR, this->ID);
 	}
-	/*bool Vehicle::IsPrimaryColorCustom::get()
+	bool Vehicle::IsPrimaryColorCustom::get()
 	{
-		return Native::Function::Call(Native::Hash::GET_IS_VEHICLE_PRIMARY_COLOUR_CUSTOM,)
-	}*/
+		return Native::Function::Call<bool>(Native::Hash::_DOES_VEHICLE_HAVE_SECONDARY_COLOUR, this->ID);
+	}
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -241,6 +241,10 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::TOGGLE_VEHICLE_MOD, this->ID, static_cast<int>(toggleMod), toggle);
 	}
+	bool Vehicle::IsToggleModOn(VehicleToggleMod toggleMod)
+	{
+		return Native::Function::Call<bool>(Native::Hash::IS_TOGGLE_MOD_ON, this->ID, static_cast<int>(toggleMod));
+	}
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -269,6 +269,14 @@ namespace GTA
 	{
 		return Native::Function::Call<bool>(Native::Hash::_0x910A32E7AAD2656C, this->ID);
 	}
+	void Vehicle::OpenDoor(VehicleDoor door, bool loose, bool openInstantly)
+	{
+		Native::Function::Call(Native::Hash::SET_VEHICLE_DOOR_OPEN, this->ID, static_cast<int>(door), loose, openInstantly);
+	}
+	void Vehicle::CloseDoor(VehicleDoor door, bool closeInstantly)
+	{
+		Native::Function::Call(Native::Hash::SET_VEHICLE_DOOR_SHUT, this->ID, static_cast<int>(door), closeInstantly);
+	}
 	Ped ^Vehicle::GetPedOnSeat(VehicleSeat seat)
 	{
 		const int handle = Native::Function::Call<int>(Native::Hash::GET_PED_IN_VEHICLE_SEAT, this->ID, static_cast<int>(seat));

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -205,6 +205,17 @@ namespace GTA
 		LeftRear = 1,
 		RightRear = 2,
 	};
+	public enum class VehicleWheelType
+	{
+		Sport = 0,
+		Muscle = 1,
+		Lowrider = 2,
+		SUV = 3,
+		Offroad = 4,
+		Tuner = 5,
+		BikeWheels = 6,
+		HighEnd = 7
+	};
 
 	public ref class Vehicle sealed : public Entity
 	{
@@ -345,6 +356,11 @@ namespace GTA
 		property bool PreviouslyOwnedByPlayer
 		{
 			void set(bool value);
+		}
+		property VehicleWheelType WheelType
+		{
+			VehicleWheelType get();
+			void set(VehicleWheelType wheelType);
 		}
 
 		int GetMod(VehicleMod modType);

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -388,10 +388,10 @@ namespace GTA
 			System::Drawing::Color get();
 			void set(System::Drawing::Color color);
 		}
-		/*property bool IsPrimaryColorCustom
+		property bool IsPrimaryColorCustom
 		{
 			bool get();
-		}*/
+		}
 
 		int GetMod(VehicleMod modType);
 		void SetMod(VehicleMod modType, int modIndex, bool variations);

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -232,6 +232,16 @@ namespace GTA
 		TireSmoke = 20,
 		XenonHeadlights = 22
 	};
+	public enum class VehicleDoor
+	{
+		FrontRightDoor = 1,
+		FrontLeftDoor = 0,
+		BackRightDoor = 3,
+		BackLeftDoor = 2,
+		Hood = 4,
+		Trunk = 5,
+		Trunk2 = 6,
+	};
 
 	public ref class Vehicle sealed : public Entity
 	{
@@ -406,6 +416,8 @@ namespace GTA
 		bool IsToggleModOn(VehicleToggleMod toggleMod);
 		void ClearCustomPrimaryColor();
 		void ClearCustomSecondaryColor();
+		void OpenDoor(VehicleDoor door, bool loose, bool openInstantly);
+		void CloseDoor(VehicleDoor door, bool closeInstantly);
 		Ped ^GetPedOnSeat(VehicleSeat seat);
 
 		void Repair();

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -392,12 +392,21 @@ namespace GTA
 		{
 			bool get();
 		}
+		property System::Drawing::Color CustomSecondaryColor
+		{
+			void set(System::Drawing::Color color);
+		}
+		property bool IsSecondaryColorCustom
+		{
+			bool get();
+		}
 
 		int GetMod(VehicleMod modType);
 		void SetMod(VehicleMod modType, int modIndex, bool variations);
 		void ToggleMod(VehicleToggleMod toggleMod, bool toggle);
 		bool IsToggleModOn(VehicleToggleMod toggleMod);
-		void ClearCustomPrimaryColor();		
+		void ClearCustomPrimaryColor();
+		void ClearCustomSecondaryColor();
 		Ped ^GetPedOnSeat(VehicleSeat seat);
 
 		void Repair();

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -216,6 +216,16 @@ namespace GTA
 		BikeWheels = 6,
 		HighEnd = 7
 	};
+	public enum class VehicleWindowTint
+	{
+		None = 0,
+		PureBlack = 1,
+		DarkSmoke = 2,
+		LightSmoke = 3,
+		Stock = 4,
+		Limo = 5,
+		Green = 6
+	};
 
 	public ref class Vehicle sealed : public Entity
 	{
@@ -361,6 +371,11 @@ namespace GTA
 		{
 			VehicleWheelType get();
 			void set(VehicleWheelType wheelType);
+		}
+		property VehicleWindowTint WindowTint
+		{
+			VehicleWindowTint get();
+			void set(VehicleWindowTint windowTint);
 		}
 
 		int GetMod(VehicleMod modType);

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -226,6 +226,12 @@ namespace GTA
 		Limo = 5,
 		Green = 6
 	};
+	public enum class VehicleToggleMod
+	{
+		Turbo = 18,
+		TireSmoke = 20,
+		XenonHeadlights = 22
+	};
 
 	public ref class Vehicle sealed : public Entity
 	{
@@ -380,6 +386,7 @@ namespace GTA
 
 		int GetMod(VehicleMod modType);
 		void SetMod(VehicleMod modType, int modIndex, bool variations);
+		void ToggleMod(VehicleToggleMod toggleMod, bool toggle);
 		Ped ^GetPedOnSeat(VehicleSeat seat);
 
 		void Repair();

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -387,6 +387,7 @@ namespace GTA
 		int GetMod(VehicleMod modType);
 		void SetMod(VehicleMod modType, int modIndex, bool variations);
 		void ToggleMod(VehicleToggleMod toggleMod, bool toggle);
+		bool IsToggleModOn(VehicleToggleMod toggleMod);
 		Ped ^GetPedOnSeat(VehicleSeat seat);
 
 		void Repair();

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -385,7 +385,6 @@ namespace GTA
 		}
 		property System::Drawing::Color CustomPrimaryColor
 		{
-			System::Drawing::Color get();
 			void set(System::Drawing::Color color);
 		}
 		property bool IsPrimaryColorCustom

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -383,11 +383,21 @@ namespace GTA
 			VehicleWindowTint get();
 			void set(VehicleWindowTint windowTint);
 		}
+		property System::Drawing::Color CustomPrimaryColor
+		{
+			System::Drawing::Color get();
+			void set(System::Drawing::Color color);
+		}
+		/*property bool IsPrimaryColorCustom
+		{
+			bool get();
+		}*/
 
 		int GetMod(VehicleMod modType);
 		void SetMod(VehicleMod modType, int modIndex, bool variations);
 		void ToggleMod(VehicleToggleMod toggleMod, bool toggle);
 		bool IsToggleModOn(VehicleToggleMod toggleMod);
+		void ClearCustomPrimaryColor();		
 		Ped ^GetPedOnSeat(VehicleSeat seat);
 
 		void Repair();

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -242,6 +242,13 @@ namespace GTA
 		Trunk = 5,
 		Trunk2 = 6,
 	};
+	public enum class VehicleWindow
+	{
+		FrontRightWindow = 1,
+		FrontLeftWindow = 0,
+		BackRightWindow = 3,
+		BackLeftWindow = 2
+	};
 
 	public ref class Vehicle sealed : public Entity
 	{
@@ -418,6 +425,12 @@ namespace GTA
 		void ClearCustomSecondaryColor();
 		void OpenDoor(VehicleDoor door, bool loose, bool openInstantly);
 		void CloseDoor(VehicleDoor door, bool closeInstantly);
+		void FixWindow(VehicleWindow window);
+		void SmashWindow(VehicleWindow window);
+		void RollUpWindow(VehicleWindow window);
+		void RollDownWindow(VehicleWindow window);
+		void RollDownWindows();
+		void RemoveWindow(VehicleWindow window);
 		Ped ^GetPedOnSeat(VehicleSeat seat);
 
 		void Repair();


### PR DESCRIPTION
Properties:
* WheelType
* WindowTint
* CustomPrimaryColor (only setter, GET_VEHICLE_CUSTOM_PRIMARY_COLOUR doesn't work for me)
* CustomSecondaryColor (only setter, GET_VEHICLE_CUSTOM_SECONDARY_COLOUR doesn't work for me)
* IsPrimaryColorCustom
* IsSecondaryColorCustom

Methods:
* ToggleMod
* IsToggleModOn
* ClearCustomPrimaryColor
* ClearCustomSecondaryColor
* OpenDoor
* CloseDoor
* FixWindow
* SmashWindow
* RollUpWindow
* RollDownWindow
* RollDownWindows
* RemoveWindow

Examples:
```c#
Vehicle veh = player.CurrentVehicle;
// wheels
veh.WheelType = VehicleWheelType.Lowrider;
for ( int i = 0; i < 10; i++ )
{
    veh.SetMod( VehicleMod.FrontWheels, i, true );
    Wait( 1500 );
}
// tint
foreach ( VehicleWindowTint windowTint in Enum.GetValues( typeof( VehicleWindowTint ) ) )
{
    veh.WindowTint = windowTint;
    Wait( 1500 );
}
// toggle mod
veh.ToggleMod( VehicleToggleMod.XenonHeadlights, !veh.IsToggleModOn( VehicleToggleMod.XenonHeadlights ) );
// custom color
Color customColor = Color.Aqua;
veh.CustomPrimaryColor = customColor;
Wait( 3000 );
veh.ClearCustomPrimaryColor();
veh.PrimaryColor = VehicleColor.MatteBlack;
// doors
veh.OpenDoor( VehicleDoor.FrontRightDoor, false, false );
Wait( 3000 );
veh.CloseDoor( VehicleDoor.FrontRightDoor, false );
```

P.S. Native _DOES_VEHICLE_HAVE_SECONDARY_COLOUR for primary color, for secondary - _0x910A32E7AAD2656C