### PR TITLE
Added Blip Wrapper and Prop Class for Objects

### DIFF
--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -85,6 +85,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="source\Blip.cpp" />
     <ClCompile Include="source\Camera.cpp" />
     <ClCompile Include="source\Entity.cpp" />
     <ClCompile Include="source\Game.cpp" />
@@ -96,6 +97,7 @@
     <ClCompile Include="source\Native.cpp" />
     <ClCompile Include="source\Ped.cpp" />
     <ClCompile Include="source\Player.cpp" />
+    <ClCompile Include="source\Prop.cpp" />
     <ClCompile Include="source\Quaternion.cpp" />
     <ClCompile Include="source\Script.cpp" />
     <ClCompile Include="source\ScriptDomain.cpp" />
@@ -111,6 +113,7 @@
     <ClCompile Include="source\World.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="source\Blip.hpp" />
     <ClInclude Include="source\Camera.hpp" />
     <ClInclude Include="source\Entity.hpp" />
     <ClInclude Include="source\Game.hpp" />
@@ -123,6 +126,7 @@
     <ClInclude Include="source\Ped.hpp" />
     <ClInclude Include="source\PedHashes.hpp" />
     <ClInclude Include="source\Player.hpp" />
+    <ClInclude Include="source\Prop.hpp" />
     <ClInclude Include="source\Quaternion.hpp" />
     <ClInclude Include="source\Script.hpp" />
     <ClInclude Include="source\ScriptDomain.hpp" />

--- a/ScriptHookVDotNet.vcxproj.filters
+++ b/ScriptHookVDotNet.vcxproj.filters
@@ -87,6 +87,12 @@
     <ClCompile Include="source\GameplayCamera.cpp">
       <Filter>Scripting</Filter>
     </ClCompile>
+    <ClCompile Include="source\Blip.cpp">
+      <Filter>Scripting</Filter>
+    </ClCompile>
+    <ClCompile Include="source\Prop.cpp">
+      <Filter>Scripting</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\Log.hpp">
@@ -172,6 +178,12 @@
     </ClInclude>
     <ClInclude Include="source\UIText.hpp">
       <Filter>Scripting\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="source\Blip.hpp">
+      <Filter>Scripting</Filter>
+    </ClInclude>
+    <ClInclude Include="source\Prop.hpp">
+      <Filter>Scripting</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/source/Blip.cpp
+++ b/source/Blip.cpp
@@ -1,0 +1,39 @@
+#include "Blip.hpp"
+#include "Native.hpp"
+
+namespace GTA
+{
+	Blip::Blip(int id) : mID(id)
+	{
+	}
+
+	int Blip::ID::get()
+	{
+		return this->mID;
+	}
+	Math::Vector3 Blip::Position::get()
+	{
+		return Native::Function::Call<Math::Vector3>(Native::Hash::GET_BLIP_INFO_ID_COORD, this->ID);
+	}
+	void Blip::Position::set(Math::Vector3 value)
+	{
+		Native::Function::Call(Native::Hash::SET_BLIP_COORDS, this->ID, value.X, value.Y, value.Z);
+	}
+	bool Blip::Exists()
+	{
+		return Native::Function::Call<bool>(Native::Hash::DOES_BLIP_EXIST, this->ID);
+	}
+	void Blip::Remove()
+	{
+		int id = this->ID;
+		Native::Function::Call(Native::Hash::REMOVE_BLIP, &id);
+	}
+	void Blip::SetAsFriendly()
+	{
+		Native::Function::Call(Native::Hash::SET_BLIP_AS_FRIENDLY, this->ID, 1);
+	}
+	void Blip::SetAsHostile()
+	{
+		Native::Function::Call(Native::Hash::SET_BLIP_AS_FRIENDLY, this->ID, 0);
+	}
+}

--- a/source/Blip.hpp
+++ b/source/Blip.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "Vector3.hpp"
+
+namespace GTA
+{
+	public ref class Blip sealed
+	{
+	public:
+		Blip(int id);
+
+		property int ID
+		{
+			int get();
+		}
+		property Math::Vector3 Position 
+		{
+			Math::Vector3 get(); // Vector3 GET_BLIP_INFO_ID_COORD(Any p0) // 0xB7374A66
+			void set(Math::Vector3 value); // void SET_BLIP_COORDS(Any p0, Any p1, Any p2, Any p3) // 0x680A34D4
+		}
+
+		bool Exists(); // BOOL DOES_BLIP_EXIST(Any p0) // 0xAE92DD96
+		void SetAsFriendly(); // void SET_BLIP_AS_FRIENDLY(int BlipID, BOOL toggle) // 0xF290CFD8
+		void SetAsHostile(); // void SET_BLIP_AS_FRIENDLY(int BlipID, BOOL toggle) // 0xF290CFD8
+		void Remove(); // void REMOVE_BLIP(int BlipID) // 0xD8C3C1CD
+		
+		
+		// BOOL IS_BLIP_ON_MINIMAP(Any p0) // 0x258CBA3A
+		// void SET_BLIP_AS_SHORT_RANGE(Any p0, Any p1) // 0x5C67725E 
+		// Vector3 GET_BLIP_COORDS(Any p0) // 0xEF6FF47B
+		// void SHOW_NUMBER_ON_BLIP(Any p0, Any p1) // 0x7BFC66C6
+		// void HIDE_NUMBER_ON_BLIP(Any p0) // 0x0B6D610D
+		// void SET_NEW_WAYPOINT(Any p0, Any p1) // 0x8444E1F0
+		// BOOL IS_WAYPOINT_ACTIVE() // 0x5E4DF47B
+		// void SET_WAYPOINT_OFF() // 0xB3496E1B
+		// void SET_POLICE_RADAR_BLIPS(BOOL Toggle) // 0x8E114B10
+		// void SET_THIS_SCRIPT_CAN_REMOVE_BLIPS_CREATED_BY_ANY_SCRIPT(Any p0) // 0xD06F1720
+		// void BLIP_SIREN(Any p0) // 0xC0EB6924
+		// void SET_BLIP_ROUTE(Object blip, int enabled) // 0x3E160C90
+		// Any GET_NUMBER_OF_ACTIVE_BLIPS() // 0x144020FA
+		// Any GET_NEXT_BLIP_INFO_ID(Any p0) // 0x9356E92F
+		// Any GET_FIRST_BLIP_INFO_ID(Any p0) // 0x64C0273D 
+		// Object GET_BLIP_FROM_ENTITY(Entity entity) // 0x005A2A47
+		//  Any ADD_BLIP_FOR_ENTITY(Entity entity) // 0x30822554
+		// Any ADD_BLIP_FOR_COORD(float x, float y, float z) // 0xC6F43D0E
+		// void SET_BLIP_SPRITE(Object blip, int spriteId) // 0x8DBBB0B9
+		// Any GET_BLIP_SPRITE(Any p0) // 0x72FF2E73
+		// void SET_BLIP_ALPHA(Any p0, Any p1) // 0xA791FCCD
+		// Any GET_BLIP_ALPHA(Any p0) // 0x297AF6C8
+		// BOOL DOES_PED_HAVE_AI_BLIP(Any p0) // 0x3BE1257F
+	private:
+		int mID;
+	};
+}

--- a/source/Entity.cpp
+++ b/source/Entity.cpp
@@ -174,4 +174,9 @@ namespace GTA
 	{
 		return this->ID;
 	}
+
+	Blip ^Entity::AddBlip()
+	{
+		return gcnew Blip(Native::Function::Call<int>(Native::Hash::ADD_BLIP_FOR_ENTITY, this->ID));
+	}
 }

--- a/source/Entity.hpp
+++ b/source/Entity.hpp
@@ -2,6 +2,7 @@
 
 #include "Model.hpp"
 #include "Vector3.hpp"
+#include "Blip.hpp"
 
 namespace GTA
 {
@@ -119,6 +120,7 @@ namespace GTA
 		static bool Exists(Entity ^entity);
 		void MarkAsNoLongerNeeded();
 		virtual bool Equals(Entity ^entity);
+		Blip ^AddBlip();
 
 		virtual int GetHashCode() override;
 		static inline bool operator ==(Entity ^left, Entity ^right)

--- a/source/Native.cpp
+++ b/source/Native.cpp
@@ -19,6 +19,8 @@
 #include "ScriptDomain.hpp"
 
 #include "Entity.hpp"
+#include "Prop.hpp"
+#include "Blip.hpp"
 #include "Ped.hpp"
 #include "Player.hpp"
 #include "Vector2.hpp"
@@ -63,6 +65,12 @@ namespace GTA
 		{
 		}
 		InputArgument::InputArgument(Vehicle ^object) : mData(object->ID)
+		{
+		}
+		InputArgument::InputArgument(Blip ^object) : mData(object->ID)
+		{
+		}
+		InputArgument::InputArgument(Prop ^object) : mData(object->ID)
 		{
 		}
 		OutputArgument::OutputArgument() : mStorage(new unsigned char[16]()), InputArgument(IntPtr(this->mStorage))
@@ -135,6 +143,14 @@ namespace GTA
 			if (type == Vehicle::typeid)
 			{
 				return gcnew Vehicle(*reinterpret_cast<int *>(value));
+			}
+			if (type == Blip::typeid)
+			{
+				return gcnew Blip(*reinterpret_cast<int *>(value));
+			}
+			if (type == Prop::typeid)
+			{
+				return gcnew Prop(*reinterpret_cast<int *>(value));
 			}
 
 			throw gcnew InvalidCastException(String::Concat("Unable to cast native value to object of type '", type->FullName, "'"));

--- a/source/Native.hpp
+++ b/source/Native.hpp
@@ -24,6 +24,8 @@ namespace GTA
 	ref class Ped;
 	ref class Player;
 	ref class Vehicle;
+	ref class Blip;
+	ref class Prop;
 
 	namespace Native
 	{
@@ -41,6 +43,8 @@ namespace GTA
 			InputArgument(Ped ^object);
 			InputArgument(Player ^object);
 			InputArgument(Vehicle ^object);
+			InputArgument(Blip ^object);
+			InputArgument(Prop ^object);
 
 			static inline operator InputArgument ^ (bool value)
 			{
@@ -87,6 +91,14 @@ namespace GTA
 				return gcnew InputArgument(object);
 			}
 			static inline operator InputArgument ^ (Vehicle ^object)
+			{
+				return gcnew InputArgument(object);
+			}
+			static inline operator InputArgument ^ (Blip ^object)
+			{
+				return gcnew InputArgument(object);
+			}
+			static inline operator InputArgument ^ (Prop ^object)
 			{
 				return gcnew InputArgument(object);
 			}

--- a/source/Player.cpp
+++ b/source/Player.cpp
@@ -81,7 +81,21 @@ namespace GTA
 	{
 		return gcnew Vehicle(Native::Function::Call<int>(Native::Hash::GET_PLAYERS_LAST_VEHICLE));
 	}
-
+	int Player::Money::get()
+	{
+		int hash = Native::Function::Call<int>(Native::Hash::GET_HASH_KEY, "SP0_TOTAL_CASH");
+		int val;
+		Native::Function::Call(Native::Hash::STAT_GET_INT, hash, &val, -1);
+		return val;
+	}
+	void Player::Money::set(int value)
+	{
+		for (int i = 0; i < 3; i++)
+		{
+			int hash = Native::Function::Call<int>(Native::Hash::GET_HASH_KEY, "SP" + i + "_TOTAL_CASH");
+			Native::Function::Call(Native::Hash::STAT_SET_INT, hash, value, 1);
+		}
+	}
 	void Player::IgnoredByEveryone::set(bool value)
 	{
 		Native::Function::Call(Native::Hash::SET_EVERYONE_IGNORE_PLAYER, this->ID, value);
@@ -133,12 +147,10 @@ namespace GTA
 
 		return nullptr;
 	}
-
 	bool Player::Equals(Player ^player)
 	{
 		return !System::Object::ReferenceEquals(player, nullptr) && this->ID == player->ID;
 	}
-
 	int Player::GetHashCode()
 	{
 		return this->ID;

--- a/source/Player.hpp
+++ b/source/Player.hpp
@@ -76,7 +76,11 @@ namespace GTA
 		{
 			Vehicle ^get();
 		}
-
+		property int Money
+		{
+			int get();
+			void set(int value);
+		}
 		property bool IgnoredByEveryone
 		{
 			void set(bool value);
@@ -101,6 +105,7 @@ namespace GTA
 		}
 		bool IsTargetting(Entity ^entity);
 		Entity ^GetTargetedEntity();
+
 
 		virtual bool Equals(Player ^player);
 

--- a/source/Prop.cpp
+++ b/source/Prop.cpp
@@ -1,0 +1,14 @@
+#include "Native.hpp"
+#include "Prop.hpp"
+
+namespace GTA
+{
+	Prop::Prop(int id) : Entity(id)
+	{
+	}
+
+	Prop ^Prop::Any::get()
+	{
+		return gcnew Prop(0);
+	}
+}

--- a/source/Prop.hpp
+++ b/source/Prop.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Entity.hpp"
+
+namespace GTA
+{
+	public ref class Prop sealed : public Entity
+	{
+	public:
+		Prop(int id);
+
+		static property Prop ^Any
+		{
+			Prop ^get();
+		}
+
+	private:
+		int mID;
+	};
+}


### PR DESCRIPTION
The purpose of the Blip (wrapper) class is to make handling Blips easier. It is
still missing many Blip Natives and should be extended in the future.

The purpose of the Prop class is to enable the management of (static)
Objects in the game. Objects are Entities, but not Peds or Vehicles.
Since Entity is abstract we have no means of handling them at the
moment. There is a (most likely incomplete) list of object hashes (see 
ecb2.biz/releases/GTAV/lists/ ) which I could be included as an enum
(PropHash - i.e. in the same way we have the PedHash and VehicleHash
enum).