### PR TITLE
Fixed CanRagdoll

### DIFF
--- a/source/Ped.cpp
+++ b/source/Ped.cpp
@@ -132,7 +132,7 @@ namespace GTA
 	}
 	void Ped::CanRagdoll::set(bool value)
 	{
-		Native::Function::Call(Native::Hash::CAN_PED_RAGDOLL, this->Handle, value);
+		Native::Function::Call(Native::Hash::SET_PED_CAN_RAGDOLL, this->Handle, value);
 	}
 	void Ped::CanSwitchWeapons::set(bool value)
 	{


### PR DESCRIPTION
CanRagdoll is ineffective because CAN_PED_RAGDOLL does not toggle whether Ped can ragdoll but returns the value whether Ped can ragdoll.