### PR TITLE
Fixed Entity.IsInAir

### DIFF
--- a/source/Entity.cpp
+++ b/source/Entity.cpp
@@ -115,7 +115,7 @@ namespace GTA
 	}
 	bool Entity::IsInAir::get()
 	{
-		return Native::Function::Call<bool>(Native::Hash::IS_PED_GETTING_INTO_A_VEHICLE, this->Handle);
+		return Native::Function::Call<bool>(Native::Hash::IS_ENTITY_IN_AIR, this->Handle);
 	}
 	bool Entity::IsInWater::get()
 	{


### PR DESCRIPTION
The IsInAir boolean in the Entity class was returning wether it was getting into a vehicle or not instead of it being in air or not.