### PR TITLE
Blip upd

### DIFF
--- a/source/Blip.cpp
+++ b/source/Blip.cpp
@@ -51,6 +51,15 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::SET_BLIP_ROUTE, this->Handle, value);
 	}
+	int Blip::Sprite::get()
+	{
+		return Native::Function::Call<int>(Native::Hash::GET_BLIP_SPRITE, this->Handle);
+	}
+	void Blip::Sprite::set(int value)
+	{
+		Native::Function::Call(Native::Hash::SET_BLIP_SPRITE, this->Handle, value);
+	}
+
 	bool Blip::Exists()
 	{
 		return Native::Function::Call<bool>(Native::Hash::DOES_BLIP_EXIST, this->Handle);

--- a/source/Blip.cpp
+++ b/source/Blip.cpp
@@ -59,6 +59,11 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::SET_BLIP_SPRITE, this->Handle, value);
 	}
+	int Blip::Type::get()
+	{
+		return Native::Function::Call<int>(Native::Hash::GET_BLIP_INFO_ID_TYPE, this->Handle);
+	}
+
 	void Blip::ShowNumber(int number)
 	{
 		Native::Function::Call(Native::Hash::SHOW_NUMBER_ON_BLIP, this->Handle, number);
@@ -67,7 +72,6 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::HIDE_NUMBER_ON_BLIP, this->Handle);
 	}
-
 	bool Blip::Exists()
 	{
 		return Native::Function::Call<bool>(Native::Hash::DOES_BLIP_EXIST, this->Handle);

--- a/source/Blip.cpp
+++ b/source/Blip.cpp
@@ -59,6 +59,14 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::SET_BLIP_SPRITE, this->Handle, value);
 	}
+	void Blip::ShowNumber(int number)
+	{
+		Native::Function::Call(Native::Hash::SHOW_NUMBER_ON_BLIP, this->Handle, number);
+	}
+	void Blip::HideNumber()
+	{
+		Native::Function::Call(Native::Hash::HIDE_NUMBER_ON_BLIP, this->Handle);
+	}
 
 	bool Blip::Exists()
 	{

--- a/source/Blip.hpp
+++ b/source/Blip.hpp
@@ -55,6 +55,10 @@ namespace GTA
 			int get();
 			void set(int sprite);
 		}
+		property int Type
+		{
+			int get();
+		}
 
 		bool Exists(); // BOOL DOES_BLIP_EXIST(Any p0) // 0xAE92DD96
 		void SetAsFriendly(); // void SET_BLIP_AS_FRIENDLY(int BlipID, BOOL toggle) // 0xF290CFD8

--- a/source/Blip.hpp
+++ b/source/Blip.hpp
@@ -60,6 +60,8 @@ namespace GTA
 		void SetAsFriendly(); // void SET_BLIP_AS_FRIENDLY(int BlipID, BOOL toggle) // 0xF290CFD8
 		void SetAsHostile(); // void SET_BLIP_AS_FRIENDLY(int BlipID, BOOL toggle) // 0xF290CFD8
 		void Remove(); // void REMOVE_BLIP(int BlipID) // 0xD8C3C1CD
+		void ShowNumber(int number);
+		void HideNumber();
 		
 		
 		// BOOL IS_BLIP_ON_MINIMAP(Any p0) // 0x258CBA3A

--- a/source/Blip.hpp
+++ b/source/Blip.hpp
@@ -50,6 +50,11 @@ namespace GTA
 		{
 			void set(bool value); // void SET_BLIP_ROUTE(Object blip, BOOL enabled) // 0x3E160C90
 		}
+		property int Sprite
+		{
+			int get();
+			void set(int sprite);
+		}
 
 		bool Exists(); // BOOL DOES_BLIP_EXIST(Any p0) // 0xAE92DD96
 		void SetAsFriendly(); // void SET_BLIP_AS_FRIENDLY(int BlipID, BOOL toggle) // 0xF290CFD8

--- a/source/Entity.cpp
+++ b/source/Entity.cpp
@@ -140,6 +140,11 @@ namespace GTA
 			MarkAsNoLongerNeeded();
 		}
 	}
+	Blip ^Entity::CurrentBlip::get()
+	{
+		int blipHandle = Native::Function::Call<int>(Native::Hash::GET_BLIP_FROM_ENTITY, this->Handle);
+		return blipHandle == 0 ? nullptr : gcnew Blip(blipHandle);
+	}
 
 	void Entity::ApplyForce(Math::Vector3 direction)
 	{

--- a/source/Entity.hpp
+++ b/source/Entity.hpp
@@ -120,6 +120,10 @@ namespace GTA
 			bool get();
 			void set(bool value);
 		}
+		property Blip ^CurrentBlip
+		{
+			Blip ^get();
+		}
 
 		void ApplyForce(Math::Vector3 direction);
 		void ApplyForce(Math::Vector3 direction, Math::Vector3 rotation);

--- a/source/World.cpp
+++ b/source/World.cpp
@@ -43,6 +43,18 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::SET_GRAVITY_LEVEL, value);
 	}
+	array<Blip ^> ^World::ActiveBlips::get()
+	{
+		System::Collections::Generic::List<Blip ^> ^res = gcnew System::Collections::Generic::List<Blip ^>();
+		int blipIterator = Native::Function::Call<int>(Native::Hash::_GET_BLIP_INFO_ID_ITERATOR);
+		int blipHandle = Native::Function::Call<int>(Native::Hash::GET_FIRST_BLIP_INFO_ID, blipIterator);
+		while (Native::Function::Call<bool>(Native::Hash::DOES_BLIP_EXIST, blipHandle))
+		{
+			res->Add(gcnew Blip(blipHandle));
+			blipHandle = Native::Function::Call<int>(Native::Hash::GET_NEXT_BLIP_INFO_ID, blipIterator);
+		}
+		return res->ToArray();
+	}
 
 	array<Ped ^> ^World::GetNearbyPeds(Ped ^ped, float radius)
 	{

--- a/source/World.hpp
+++ b/source/World.hpp
@@ -65,6 +65,10 @@ namespace GTA
 		{
 			void set(int value);
 		}
+		static property array<Blip ^> ^ActiveBlips
+		{
+			array<Blip ^> ^get();
+		}
 
 		static array<Ped ^> ^GetNearbyPeds(Ped ^ped, float radius);
 		static array<Ped ^> ^GetNearbyPeds(Ped ^ped, float radius, int maxAmount);


### PR DESCRIPTION
Added:
* Blip::Sprite (getter, setter)
* Blip::ShowNumber and Blip::HideNumber
* Blip::Type (getter)
* Entity::CurrentBlip
* World::ActiveBlips

Example:
```c#
// type 4 - player's marker
Blip blip = World.ActiveBlips.FirstOrDefault( b => b.Type == 4 );
if ( blip != null )
{
	player.Position = blip.Position;
	UI.ShowSubtitle( "Done", 2000 );
}
else
{
	UI.ShowSubtitle( "Not found", 2000 );
}
```