### PR TITLE
added vehicle hashes for two missing trailers

### DIFF
--- a/source/VehicleHashes.hpp
+++ b/source/VehicleHashes.hpp
@@ -291,6 +291,8 @@ namespace GTA
 			TR4 = 0x7CAB34D0,
 			TRFlat = 0xAF62F6B2,
 			TrailerSmall = 0x2A72BEAB,
+			FreightTrailer = 0xD1ABB666,
+			DockTrailer = 0x806EFBEE,
 			Velum = 0x9C429B6A,
 			Adder = 0xB779A091,
 			Voltic = 0x9F4B77BE,


### PR DESCRIPTION
I noticed that two vehicle hashes were missing.
One of them is of the [docktrailer](http://img2.wikia.nocookie.net/__cb20140403005056/gtawiki/images/4/4d/Trailer-GTAV-Front-ContainerLong.png) and the other of the [freighttrailer](http://img3.wikia.nocookie.net/__cb20140511231751/gtawiki/images/b/b4/XL-trailer-frieght-gtav.png).