### PR TITLE
Add InOutArgument class that lets you set what the output argument po…

### DIFF
--- a/source/Native.cpp
+++ b/source/Native.cpp
@@ -100,6 +100,52 @@ namespace GTA
 			delete[] this->mStorage;
 		}
 
+		InOutArgument::InOutArgument(bool value) : OutputArgument()
+		{
+			*reinterpret_cast<bool *>(mStorage) = value;
+		}
+		InOutArgument::InOutArgument(int value) : OutputArgument()
+		{
+			*reinterpret_cast<int *>(mStorage) = value;
+		}
+		InOutArgument::InOutArgument(float value) : OutputArgument()
+		{
+			*reinterpret_cast<float *>(mStorage) = value;
+		}
+		InOutArgument::InOutArgument(double value) : OutputArgument()
+		{
+			*reinterpret_cast<float *>(mStorage) = static_cast<float>(value);
+		}
+		InOutArgument::InOutArgument(Entity ^object) : OutputArgument()
+		{
+			*reinterpret_cast<int *>(mStorage) = object->Handle;
+		}
+		InOutArgument::InOutArgument(Ped ^object) : OutputArgument()
+		{
+			*reinterpret_cast<int *>(mStorage) = object->Handle;
+		}
+		InOutArgument::InOutArgument(Player ^object) : OutputArgument()
+		{
+			*reinterpret_cast<int *>(mStorage) = object->Handle;
+		}
+		InOutArgument::InOutArgument(Vehicle ^object) : OutputArgument()
+		{
+			*reinterpret_cast<int *>(mStorage) = object->Handle;
+		}
+		InOutArgument::InOutArgument(Blip ^object) : OutputArgument()
+		{
+			*reinterpret_cast<int *>(mStorage) = object->Handle;
+		}
+		InOutArgument::InOutArgument(Prop ^object) : OutputArgument()
+		{
+			*reinterpret_cast<int *>(mStorage) = object->Handle;
+		}
+		InOutArgument::!InOutArgument()
+		{
+			delete[] this->mStorage;
+		}
+
+
 		Object ^GetResult(Type ^type, PUINT64 value)
 		{
 			if (type == Boolean::typeid)

--- a/source/Native.hpp
+++ b/source/Native.hpp
@@ -123,10 +123,36 @@ namespace GTA
 			generic <typename T>
 			T GetResult();
 
-		private:
+		protected:
 			!OutputArgument();
 
 			unsigned char *mStorage;
+		};
+
+		public ref class InOutArgument : public OutputArgument
+		{
+		public:
+
+			InOutArgument(bool value);
+			InOutArgument(int value);
+			InOutArgument(float value);
+			InOutArgument(double value);
+			InOutArgument(Entity ^object);
+			InOutArgument(Ped ^object);
+			InOutArgument(Player ^object);
+			InOutArgument(Vehicle ^object);
+			InOutArgument(Blip ^object);
+			InOutArgument(Prop ^object);
+
+			~InOutArgument()
+			{
+				this->!InOutArgument();
+			}
+
+		private:
+			!InOutArgument();
+
+
 		};
 
 		public ref class Function abstract sealed


### PR DESCRIPTION
Tested with
                Vehicle vehicle = player.CurrentVehicle;
                Function.Call(Hash.SET_ENTITY_AS_MISSION_ENTITY, vehicle, true, false);
                Function.Call(Hash.DELETE_VEHICLE, new InOutArgument(vehicle));
worked fine, will let VB users use pointer natives(&handle) without unsigned code issues