### PR TITLE
SelectedIndexChanged event for Menu and List Menu

### DIFF
--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -220,6 +220,7 @@ namespace GTA
 			EntryTuple->Item2->Color = TextColor;
 			i++;
 		}
+		this->SelectedIndexChanged(this, gcnew SelectedIndexChangedArgs(this->mSelectedIndex));
 	}
 
 	void ListMenu::Draw()

--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -130,6 +130,7 @@ namespace GTA
 			FooterTextColor,
 			FooterFont,
 			FooterCentered);
+		this->SelectedIndexChanged(this, gcnew SelectedIndexChangedArgs(this->mSelectedIndex));
 	}
 
 	void Menu::OnChangeItem(bool right)

--- a/source/Menu.hpp
+++ b/source/Menu.hpp
@@ -10,6 +10,23 @@ namespace GTA
 	interface class MenuItem;
 	ref class Viewport;
 
+	public ref class SelectedIndexChangedArgs :System::EventArgs
+	{
+	private:
+		int mSelectedIndex;
+
+	public:
+		SelectedIndexChangedArgs(int selectedIndex)
+		{
+			this->mSelectedIndex = selectedIndex;
+		}
+
+		property int SelectedIndex
+		{
+			int get(){ return this->mSelectedIndex; }
+		}
+	};
+
 	public ref class MenuBase
 	{
 	public:
@@ -132,6 +149,15 @@ namespace GTA
 		void Remove(int Index);
 		void Remove(System::String ^Caption);
 
+		property System::Tuple<System::String ^, System::String ^> ^default[int]
+		{
+			System::Tuple<System::String ^, System::String ^> ^get(int index) { return mItems[index]; }
+			void set(int index, System::Tuple<System::String ^, System::String ^> ^item)
+			{
+				mItems[index] = item;
+				this->UpdateEntries();
+			}
+		}
 		property int SelectedIndex
 		{
 			int get() { return mSelectedIndex; }
@@ -152,6 +178,9 @@ namespace GTA
 		property int FooterHeight;
 		property int ItemHeight;
 		property bool HasFooter;
+
+	public:
+		event System::EventHandler<SelectedIndexChangedArgs^> ^SelectedIndexChanged;
 
 	private:
 		System::Action<ListMenu ^> ^mActivateAction;

--- a/source/Menu.hpp
+++ b/source/Menu.hpp
@@ -101,6 +101,7 @@ namespace GTA
 		property int FooterHeight;
 		property int ItemHeight;
 		property bool HasFooter;
+
 		property System::Collections::Generic::List<MenuItem ^> ^Items
 		{
 			System::Collections::Generic::List<MenuItem ^> ^get() { return mItems; }
@@ -116,6 +117,9 @@ namespace GTA
 				OnChangeSelection(newIndex);
 			}
 		}
+
+	public:
+		event System::EventHandler<SelectedIndexChangedArgs^> ^SelectedIndexChanged;
 
 	private:
 		UIRectangle ^mHeaderRect = nullptr, ^mFooterRect = nullptr;


### PR DESCRIPTION
Also added setter/getter for List menu.
```c#
var listMenu = new ListMenu( "lol" );
listMenu.Add( "el1" );
listMenu.Add( "el2" );
listMenu.Add( "el3" );
listMenu.SelectedIndexChanged += ( o, changed ) =>
{
	int index = changed.SelectedIndex;
	var menu = ( o as ListMenu );
	if ( menu == null )
	{
		return;
	}
	string s = "Caption = " + menu.Caption + ", Selected Item Caption: " + menu[ index ].Item1;
	UI.ShowSubtitle( s, 2000 );
};
this.View.AddMenu( listMenu );
...
var gtaMenu = new Menu( "TestMenu", new MenuItem[]
{
	new MenuButton( "Btn", () => { } ),
	new MenuButton( "Btn2", () => { } ),
	new MenuButton( "Btn3", () => { } ),
} );
gtaMenu.SelectedIndexChanged += ( o, args ) =>
{
	int index = args.SelectedIndex;
	var menu = ( o as Menu );
	if ( menu == null )
	{
		return;
	}
	string s = "Caption = " + menu.Caption + ", Selected Item Caption: " + menu.Items[ index ].Caption;
	UI.ShowSubtitle( s, 2000 );
};
this.View.AddMenu( gtaMenu );
```