### PR TITLE
Some rope extensions

### DIFF
--- a/source/Rope.cpp
+++ b/source/Rope.cpp
@@ -1,5 +1,7 @@
 #include "Rope.hpp"
 #include "Native.hpp"
+#include "Vector3.hpp"
+#include "Entity.hpp"
 
 namespace GTA
 {
@@ -16,5 +18,39 @@ namespace GTA
 	{
 		int handle = this->Handle;
 		Native::Function::Call(Native::Hash::DELETE_ROPE, &handle);
+	}
+	void Rope::ActivatePhysics()
+	{
+		Native::Function::Call(Native::Hash::ACTIVATE_PHYSICS, this->Handle);
+	}
+	void Rope::ResetLength(bool reset)
+	{
+		Native::Function::Call(Native::Hash::ROPE_RESET_LENGTH, this->Handle, reset);
+	}
+	void Rope::ForceLength(float length)
+	{
+		Native::Function::Call(Native::Hash::ROPE_FORCE_LENGTH, this->Handle, length);
+	}
+	void Rope::AttachEntities(Entity ^entityOne, Entity ^entityTwo, float length)
+	{
+		AttachEntities(entityOne, Math::Vector3(), entityTwo, Math::Vector3(), length);
+	}
+	void Rope::AttachEntities(Entity ^entityOne, Math::Vector3 offsetOne, Entity ^entityTwo, Math::Vector3 offsetTwo, float length)
+	{
+		int tmpOne;
+		int tmpTwo;
+		Native::Function::Call(Native::Hash::ATTACH_ENTITIES_TO_ROPE, this->Handle, entityOne, entityTwo, offsetOne.X, offsetOne.Y, offsetOne.Z, offsetTwo.X, offsetTwo.Y, offsetTwo.Z, length, 0, 0, &tmpOne, &tmpTwo);
+	}
+	void Rope::AttachEntity(Entity ^entity)
+	{
+		this->AttachEntity(entity, Math::Vector3());
+	}
+	void Rope::AttachEntity(Entity^ entity, Math::Vector3 offset)
+	{
+		Native::Function::Call(Native::Hash::ATTACH_ROPE_TO_ENTITY, this->Handle, entity, offset.X, offset.Y, offset.Z, 0);
+	}
+	void Rope::DetachEntity(Entity^ entity)
+	{
+		Native::Function::Call(Native::Hash::DETACH_ROPE_FROM_ENTITY, this->Handle, entity);
 	}
 }

--- a/source/Rope.cpp
+++ b/source/Rope.cpp
@@ -33,24 +33,29 @@ namespace GTA
 	}
 	void Rope::AttachEntities(Entity ^entityOne, Entity ^entityTwo, float length)
 	{
-		AttachEntities(entityOne, Math::Vector3(), entityTwo, Math::Vector3(), length);
+		this->AttachEntities(entityOne, Math::Vector3(), entityTwo, Math::Vector3(), length);
 	}
-	void Rope::AttachEntities(Entity ^entityOne, Math::Vector3 offsetOne, Entity ^entityTwo, Math::Vector3 offsetTwo, float length)
+	void Rope::AttachEntities(Entity ^entityOne, Math::Vector3 positionOne, Entity ^entityTwo, Math::Vector3 positionTwo, float length)
 	{
 		int tmpOne;
 		int tmpTwo;
-		Native::Function::Call(Native::Hash::ATTACH_ENTITIES_TO_ROPE, this->Handle, entityOne, entityTwo, offsetOne.X, offsetOne.Y, offsetOne.Z, offsetTwo.X, offsetTwo.Y, offsetTwo.Z, length, 0, 0, &tmpOne, &tmpTwo);
+		Native::Function::Call(Native::Hash::ATTACH_ENTITIES_TO_ROPE, this->Handle, entityOne, entityTwo, positionOne.X, positionOne.Y, positionOne.Z, positionTwo.X, positionTwo.Y, positionTwo.Z, length, 0, 0, &tmpOne, &tmpTwo);
 	}
 	void Rope::AttachEntity(Entity ^entity)
 	{
 		this->AttachEntity(entity, Math::Vector3());
 	}
-	void Rope::AttachEntity(Entity^ entity, Math::Vector3 offset)
+	void Rope::AttachEntity(Entity^ entity, Math::Vector3 position)
 	{
-		Native::Function::Call(Native::Hash::ATTACH_ROPE_TO_ENTITY, this->Handle, entity, offset.X, offset.Y, offset.Z, 0);
+		Native::Function::Call(Native::Hash::ATTACH_ROPE_TO_ENTITY, this->Handle, entity, position.X, position.Y, position.Z, 0);
 	}
 	void Rope::DetachEntity(Entity^ entity)
 	{
 		Native::Function::Call(Native::Hash::DETACH_ROPE_FROM_ENTITY, this->Handle, entity);
+	}
+
+	void Rope::LoadTextures()
+	{
+		Native::Function::Call(Native::Hash::ROPE_LOAD_TEXTURES);
 	}
 }

--- a/source/Rope.cpp
+++ b/source/Rope.cpp
@@ -13,6 +13,14 @@ namespace GTA
 	{
 		return this->mHandle;
 	}
+	float Rope::Length::get()
+	{
+		return Native::Function::Call<float>(Native::Hash::_0x73040398DFF9A4A6, this->mHandle);
+	}
+	void Rope::Length::set(float value)
+	{
+		Native::Function::Call(Native::Hash::ROPE_FORCE_LENGTH, this->mHandle, value);
+	}
 
 	void Rope::Delete()
 	{
@@ -26,10 +34,6 @@ namespace GTA
 	void Rope::ResetLength(bool reset)
 	{
 		Native::Function::Call(Native::Hash::ROPE_RESET_LENGTH, this->Handle, reset);
-	}
-	void Rope::ForceLength(float length)
-	{
-		Native::Function::Call(Native::Hash::ROPE_FORCE_LENGTH, this->Handle, length);
 	}
 	void Rope::AttachEntities(Entity ^entityOne, Entity ^entityTwo, float length)
 	{

--- a/source/Rope.hpp
+++ b/source/Rope.hpp
@@ -15,11 +15,15 @@ namespace GTA
 		{
 			int get();
 		}
+		property float Length
+		{
+			float get();
+			void set(float value);
+		}
 
 		void Delete();
 		void ActivatePhysics();
 		void ResetLength(bool reset);
-		void ForceLength(float length);
 		void AttachEntities(Entity ^entityOne, Entity ^entityTwo, float length);
 		void AttachEntities(Entity ^entityOne, Math::Vector3 positionOne, Entity ^entityTwo, Math::Vector3 positionTwo, float length);
 		void AttachEntity(Entity ^entity);

--- a/source/Rope.hpp
+++ b/source/Rope.hpp
@@ -21,10 +21,12 @@ namespace GTA
 		void ResetLength(bool reset);
 		void ForceLength(float length);
 		void AttachEntities(Entity ^entityOne, Entity ^entityTwo, float length);
-		void AttachEntities(Entity ^entityOne, Math::Vector3 offsetOne, Entity ^entityTwo, Math::Vector3 offsetTwo, float length);
+		void AttachEntities(Entity ^entityOne, Math::Vector3 positionOne, Entity ^entityTwo, Math::Vector3 positionTwo, float length);
 		void AttachEntity(Entity ^entity);
-		void AttachEntity(Entity ^entity, Math::Vector3 offset);
+		void AttachEntity(Entity ^entity, Math::Vector3 position);
 		void DetachEntity(Entity ^entity);
+
+		static void LoadTextures();
 
 	private:
 		int mHandle;

--- a/source/Rope.hpp
+++ b/source/Rope.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "Vector3.hpp"
+
 namespace GTA
 {
+	ref class Entity;
+
 	public ref class Rope sealed
 	{
 	public:
@@ -13,6 +17,14 @@ namespace GTA
 		}
 
 		void Delete();
+		void ActivatePhysics();
+		void ResetLength(bool reset);
+		void ForceLength(float length);
+		void AttachEntities(Entity ^entityOne, Entity ^entityTwo, float length);
+		void AttachEntities(Entity ^entityOne, Math::Vector3 offsetOne, Entity ^entityTwo, Math::Vector3 offsetTwo, float length);
+		void AttachEntity(Entity ^entity);
+		void AttachEntity(Entity ^entity, Math::Vector3 offset);
+		void DetachEntity(Entity ^entity);
 
 	private:
 		int mHandle;

--- a/source/World.cpp
+++ b/source/World.cpp
@@ -243,6 +243,7 @@ namespace GTA
 			type = 1;
 		}
 
+		Rope::LoadTextures();
 		int tmp;
 
 		const int handle = Native::Function::Call<int>(Native::Hash::ADD_ROPE, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, lenght, type, maxLenght, minLenght, p10, p11, p12, p13, p14, breakable, &tmp);


### PR DESCRIPTION
Example script:

````c#
Entity one;
Entity two;

//Somewhere in OnKeyDown under your desired key
if (one == null)
{
    one = Game.Player.GetTargetedEntity();
    UI.Notify("First entity set");
    return;
}
if (two == null)
{
    two = Game.Player.GetTargetedEntity();
    UI.Notify("Second entity set");
    return;
}

//Somewhere else in OnKeyDown :P
Rope.LoadTextures();
float distance = World.GetDistance(one.Position, two.Position);

rope = World.AddRope(Game.Player.Character.Position, new Vector3(), distance, 4, distance, 0, 10.0, true, true, true, 10.0, true);
rope.ActivatePhysics();

rope.AttachEntities(one, two, distance);
UI.Notify("Attached"); 
````

Maybe you can have a quick look at it @crosire 