### PR TITLE
Added getter and setter methods for extra colors (Pearlescence and Ri…

### DIFF
--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -15,6 +15,32 @@ namespace GTA
 	{
 	}
 
+	VehicleColor Vehicle::RimColor::get() 
+	{
+		int pearlescentColor, rimColor;
+		Native::Function::Call(Native::Hash::GET_VEHICLE_EXTRA_COLOURS,this->Handle, &pearlescentColor, &rimColor);
+		return static_cast<VehicleColor>(rimColor);
+	}
+
+	void Vehicle::RimColor::set(VehicleColor value)
+	{
+		int pearlescentColor = this->PearlescentColor;
+		Native::Function::Call(Native::Hash::SET_VEHICLE_EXTRA_COLOURS, this->Handle, pearlescentColor, static_cast<int>(value));
+	}
+
+	int Vehicle::PearlescentColor::get()
+	{
+		int pearlescentColor, rimColor;
+		Native::Function::Call(Native::Hash::GET_VEHICLE_EXTRA_COLOURS, this->Handle, &pearlescentColor, &rimColor);
+		return pearlescentColor;
+	}
+
+	void Vehicle::PearlescentColor::set(int value) 
+	{
+		VehicleColor rimColor;
+		Native::Function::Call(Native::Hash::SET_VEHICLE_EXTRA_COLOURS, this->Handle, value, static_cast<int>(rimColor));
+	}
+
 	bool Vehicle::HasRoof::get()
 	{
 		return Native::Function::Call<bool>(Native::Hash::DOES_VEHICLE_HAVE_ROOF, this->Handle);

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -263,6 +263,18 @@ namespace GTA
 	public:
 		Vehicle(int handle);
 
+		property VehicleColor RimColor 
+		{
+			VehicleColor get();
+			void set(VehicleColor value);
+		}
+
+		property int PearlescentColor 
+		{
+			int get();
+			void set(int value);
+		}
+
 		property bool HasRoof
 		{
 			bool get();


### PR DESCRIPTION
I have added getter and setter methods to Vehicle class for Vehicle pearlescence and Vehicle rim colors.

According to native-db comments, RimColors are equivalent to VehicleColors, so I'm using the existing VehicleColor enum. 

Pearlescence is an int and we don't have yet any enum for it, so it will return an int on getter and expect an int on setter.