### PR TITLE
Added getter and setter for Rim and Pearlescent Colors

### DIFF
--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -155,6 +155,26 @@ namespace GTA
 		Native::Function::Call(Native::Hash::GET_VEHICLE_COLOURS, this->Handle, &color1, &color2);
 		Native::Function::Call(Native::Hash::SET_VEHICLE_COLOURS, this->Handle, color1, static_cast<int>(value));
 	}
+	VehicleColor Vehicle::RimColor::get()
+	{
+		int pearlescentColor, rimColor;
+		Native::Function::Call(Native::Hash::GET_VEHICLE_EXTRA_COLOURS, this->Handle, &pearlescentColor, &rimColor);
+		return static_cast<VehicleColor>(rimColor);
+	}
+	void Vehicle::RimColor::set(VehicleColor value)
+	{
+		Native::Function::Call(Native::Hash::SET_VEHICLE_EXTRA_COLOURS, this->Handle, this->PearlescentColor, static_cast<int>(value));
+	}
+	int Vehicle::PearlescentColor::get()
+	{
+		int pearlescentColor, rimColor;
+		Native::Function::Call(Native::Hash::GET_VEHICLE_EXTRA_COLOURS, this->Handle, &pearlescentColor, &rimColor);
+		return pearlescentColor;
+	}
+	void Vehicle::PearlescentColor::set(int value)
+	{
+		Native::Function::Call(Native::Hash::SET_VEHICLE_EXTRA_COLOURS, this->Handle, value, static_cast<int>(this->RimColor));
+	}
 	VehicleWheelType Vehicle::WheelType::get()
 	{
 		return static_cast<VehicleWheelType>(Native::Function::Call<int>(Native::Hash::GET_VEHICLE_WHEEL_TYPE, this->Handle));

--- a/source/Vehicle.cpp
+++ b/source/Vehicle.cpp
@@ -163,17 +163,27 @@ namespace GTA
 	}
 	void Vehicle::RimColor::set(VehicleColor value)
 	{
-		Native::Function::Call(Native::Hash::SET_VEHICLE_EXTRA_COLOURS, this->Handle, this->PearlescentColor, static_cast<int>(value));
+		Native::Function::Call(
+			Native::Hash::SET_VEHICLE_EXTRA_COLOURS, 
+			this->Handle, 
+			static_cast<int>(this->PearlescentColor),
+			static_cast<int>(value)
+		);
 	}
-	int Vehicle::PearlescentColor::get()
+	VehicleColor Vehicle::PearlescentColor::get()
 	{
 		int pearlescentColor, rimColor;
 		Native::Function::Call(Native::Hash::GET_VEHICLE_EXTRA_COLOURS, this->Handle, &pearlescentColor, &rimColor);
-		return pearlescentColor;
+		return static_cast<VehicleColor>(pearlescentColor);
 	}
-	void Vehicle::PearlescentColor::set(int value)
+	void Vehicle::PearlescentColor::set(VehicleColor value)
 	{
-		Native::Function::Call(Native::Hash::SET_VEHICLE_EXTRA_COLOURS, this->Handle, value, static_cast<int>(this->RimColor));
+		Native::Function::Call(
+			Native::Hash::SET_VEHICLE_EXTRA_COLOURS, 
+			this->Handle, 
+			static_cast<int>(value), 
+			static_cast<int>(this->RimColor)
+		);
 	}
 	VehicleWheelType Vehicle::WheelType::get()
 	{

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -347,10 +347,10 @@ namespace GTA
 			VehicleColor get();
 			void set(VehicleColor value);
 		}
-		property int PearlescentColor
+		property VehicleColor PearlescentColor
 		{
-			int get();
-			void set(int value);
+			VehicleColor get();
+			void set(VehicleColor value);
 		}
 		property VehicleWheelType WheelType
 		{

--- a/source/Vehicle.hpp
+++ b/source/Vehicle.hpp
@@ -342,6 +342,16 @@ namespace GTA
 			VehicleColor get();
 			void set(VehicleColor value);
 		}
+		property VehicleColor RimColor
+		{
+			VehicleColor get();
+			void set(VehicleColor value);
+		}
+		property int PearlescentColor
+		{
+			int get();
+			void set(int value);
+		}
 		property VehicleWheelType WheelType
 		{
 			VehicleWheelType get();


### PR DESCRIPTION
According to native-db comments, Rim colors are the same as Vehicle colors, so I used the VehicleColor enum.

For Pearlescent Color I'm not sure about the color names so its implemented using just int for now.