### PR TITLE
Added support for Natives/OutputArguments returning Entities

### DIFF
--- a/source/Native.cpp
+++ b/source/Native.cpp
@@ -224,6 +224,20 @@ namespace GTA
 			{
 				return gcnew Prop(*reinterpret_cast<int *>(value));
 			}
+			if (type == Entity::typeid)
+			{
+				int handle = *reinterpret_cast<int *>(value);
+				if (Native::Function::Call<bool>(Native::Hash::DOES_ENTITY_EXIST, handle))
+				{
+					switch (Native::Function::Call<int>(Native::Hash::GET_ENTITY_TYPE, handle))
+					{
+					case 1: return gcnew Ped(handle);
+					case 2: return gcnew Vehicle(handle);
+					case 3: return gcnew Prop(handle);
+					}
+				}
+				return nullptr;
+			}
 
 			throw gcnew InvalidCastException(String::Concat("Unable to cast native value to object of type '", type->FullName, "'"));
 		}

--- a/source/Native.cpp
+++ b/source/Native.cpp
@@ -231,9 +231,12 @@ namespace GTA
 				{
 					switch (Native::Function::Call<int>(Native::Hash::GET_ENTITY_TYPE, handle))
 					{
-					case 1: return gcnew Ped(handle);
-					case 2: return gcnew Vehicle(handle);
-					case 3: return gcnew Prop(handle);
+					case 1: 
+						return gcnew Ped(handle);
+					case 2: 
+						return gcnew Vehicle(handle);
+					case 3: 
+						return gcnew Prop(handle);
 					}
 				}
 				return nullptr;


### PR DESCRIPTION
Example use
Entity entity = _OutArg.GetResult < Entity > ();//for some reason it wouldnt format correctly
Can then use methods like entity is ped etc