### PR TITLE
Add OnAbort virtual method

### DIFF
--- a/source/Script.cpp
+++ b/source/Script.cpp
@@ -78,8 +78,14 @@ namespace GTA
 		this->mInterval = value;
 	}
 
+	virtual void Script::OnAbort() {
+		
+	}
+	
 	void Script::Abort()
 	{
+		this->OnAbort();
+		
 		this->mWaitEvent->Set();
 
 		this->mScriptDomain->AbortScript(this);

--- a/source/Script.cpp
+++ b/source/Script.cpp
@@ -86,7 +86,7 @@ namespace GTA
 	{
 		try
 		{
-			Tick(this, EventArgs::Empty);
+			this->OnAbort();
 		}
 		catch (Exception ^ex)
 		{

--- a/source/Script.cpp
+++ b/source/Script.cpp
@@ -78,13 +78,20 @@ namespace GTA
 		this->mInterval = value;
 	}
 
-	virtual void Script::OnAbort() {
+	void Script::OnAbort() {
 		
 	}
 	
 	void Script::Abort()
 	{
-		this->OnAbort();
+		try
+		{
+			Tick(this, EventArgs::Empty);
+		}
+		catch (Exception ^ex)
+		{
+			HandleUnhandledException(this, gcnew UnhandledExceptionEventArgs(ex, true));
+		}
 		
 		this->mWaitEvent->Set();
 

--- a/source/Script.cpp
+++ b/source/Script.cpp
@@ -84,15 +84,6 @@ namespace GTA
 	
 	void Script::Abort()
 	{
-		try
-		{
-			this->OnAbort();
-		}
-		catch (Exception ^ex)
-		{
-			HandleUnhandledException(this, gcnew UnhandledExceptionEventArgs(ex, true));
-		}
-		
 		this->mWaitEvent->Set();
 
 		this->mScriptDomain->AbortScript(this);

--- a/source/Script.hpp
+++ b/source/Script.hpp
@@ -71,6 +71,8 @@ namespace GTA
 			ScriptSettings ^get();
 		}
 
+		virtual void OnAbort();
+
 		void Abort();
 
 		virtual System::String ^ToString() override

--- a/source/ScriptDomain.cpp
+++ b/source/ScriptDomain.cpp
@@ -399,6 +399,15 @@ namespace GTA
 	}
 	void ScriptDomain::AbortScript(Script ^script)
 	{
+		try
+		{
+			script->OnAbort();
+		}
+		catch (Exception ^ex)
+		{
+			HandleUnhandledException(script, gcnew UnhandledExceptionEventArgs(ex, true));
+		}
+
 		if (Object::ReferenceEquals(script->mThread, nullptr))
 		{
 			return;


### PR DESCRIPTION
Having an OnAbort virtual method allows scripts to do any shutdown tasks before aborting.

Example use cases:
- Resetting a player's camera
- Remove a screen overlay
- Destroy created entities