### PR TITLE
Add saving support to Settings file

### DIFF
--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -4,7 +4,8 @@
 
 namespace GTA
 {
-	Menu::Menu(System::String ^headerCaption, array<IMenuItem ^> ^items)
+	Menu::Menu(System::String ^headerCaption, array<IMenuItem ^> ^items) : Menu(headerCaption, items, 10){}
+	Menu::Menu(System::String ^headerCaption, array<IMenuItem ^> ^items, int MaxItemsToDraw)
 	{
 		//Put the items in the item stack
 		//The menu itself will be initialized when it gets added to the viewport
@@ -14,6 +15,7 @@ namespace GTA
 			item->Parent = this;
 		}
 
+		MaxDrawLimit = MaxItemsToDraw;
 		//Set defaults for the properties
 		HeaderColor = System::Drawing::Color::FromArgb(200, 255, 20, 147);
 		HeaderTextColor = System::Drawing::Color::White;
@@ -199,6 +201,20 @@ namespace GTA
 	{
 		if (mSelectedIndex < 0 || mSelectedIndex >= mItems->Count) return;
 		mItems[mSelectedIndex]->Change(right);
+	}
+	void Menu::OnChangeDrawLimit()
+	{
+		if (scrollOffset > mMaxScrollOffset)
+		{
+			mScrollOffset = mMaxScrollOffset;
+		}
+		if (SelectedIndex < scrollOffset)
+			scrollOffset = SelectedIndex - 3;
+		else if (SelectedIndex >scrollOffset + mItemDrawCount)
+			scrollOffset = SelectedIndex + 3 - mItemDrawCount;
+		UpdateItemPositions();
+		if (SelectedIndex >= 0 && SelectedIndex < mItems->Count)
+			mItems[SelectedIndex]->Select();
 	}
 
 	MessageBox::MessageBox(System::String ^caption)

--- a/source/Menu.hpp
+++ b/source/Menu.hpp
@@ -83,6 +83,7 @@ namespace GTA
 	{
 	public:
 		Menu(System::String ^headerCaption, array<IMenuItem ^> ^items);
+		Menu(System::String ^headerCaption, array<IMenuItem ^> ^items, int MaxItemsToDraw);
 
 	public:
 		virtual void Draw() override;
@@ -117,11 +118,23 @@ namespace GTA
 				OnChangeSelection(newIndex);
 			}
 		}
+		property int MaxDrawLimit
+		{
+			int get(){ return mMaxDrawLimit; }
+			void set(int limit)
+			{
+				if (limit < 6 || limit > 20)
+					throw gcnew System::ArgumentOutOfRangeException("MaxDrawLimit", "MaxDrawLimit must be between 6 and 20");
+				mMaxDrawLimit = limit;
+				OnChangeDrawLimit();
+			}
+		}
 
 	public:
 		event System::EventHandler<SelectedIndexChangedArgs^> ^SelectedIndexChanged;
 
 	private:
+		void OnChangeDrawLimit();
 		void UpdateItemPositions();
 		void DrawScrollArrows(bool up, bool down, System::Drawing::Size offset);
 		property int mMaxScrollOffset

--- a/source/Script.cpp
+++ b/source/Script.cpp
@@ -48,9 +48,11 @@ namespace GTA
 	}
 	ScriptSettings ^Script::Settings::get()
 	{
+		if (this->mFilename == nullptr)
+			return nullptr;
 		if (Object::ReferenceEquals(this->mSettings, nullptr))
 		{
-			String ^path = IO::Path::ChangeExtension(this->mFilename, "ini");
+			String ^path = IO::Path::ChangeExtension(this->mFilename, ".ini");
 
 			if (IO::File::Exists(path))
 			{
@@ -58,7 +60,7 @@ namespace GTA
 			}
 			else
 			{
-				this->mSettings = gcnew ScriptSettings();
+				this->mSettings = gcnew ScriptSettings(path);
 			}
 		}
 

--- a/source/Script.cpp
+++ b/source/Script.cpp
@@ -48,12 +48,9 @@ namespace GTA
 	}
 	ScriptSettings ^Script::Settings::get()
 	{
-		if (this->mFilename == nullptr)
-			return nullptr;
 		if (Object::ReferenceEquals(this->mSettings, nullptr))
 		{
-			String ^path = IO::Path::ChangeExtension(this->mFilename, ".ini");
-
+			String ^path = System::IO::Path::Combine(System::IO::Path::GetDirectoryName(System::Reflection::Assembly::GetExecutingAssembly()->Location), "scripts", this->GetType()->Assembly->GetName()->Name + ".ini");
 			if (IO::File::Exists(path))
 			{
 				this->mSettings = ScriptSettings::Load(path);

--- a/source/Script.hpp
+++ b/source/Script.hpp
@@ -48,6 +48,8 @@ namespace GTA
 		System::Windows::Forms::Keys UpKey = System::Windows::Forms::Keys::NumPad8;
 		System::Windows::Forms::Keys DownKey = System::Windows::Forms::Keys::NumPad2;
 
+		virtual void OnLoaded(){}
+
 		property System::String ^Name
 		{
 			System::String ^get()

--- a/source/Script.hpp
+++ b/source/Script.hpp
@@ -48,8 +48,6 @@ namespace GTA
 		System::Windows::Forms::Keys UpKey = System::Windows::Forms::Keys::NumPad8;
 		System::Windows::Forms::Keys DownKey = System::Windows::Forms::Keys::NumPad2;
 
-		virtual void OnLoaded(){}
-
 		property System::String ^Name
 		{
 			System::String ^get()

--- a/source/ScriptDomain.cpp
+++ b/source/ScriptDomain.cpp
@@ -190,6 +190,7 @@ namespace GTA
 		}
 
 		CodeDom::Compiler::CompilerParameters ^compilerOptions = gcnew CodeDom::Compiler::CompilerParameters();
+		compilerOptions->OutputAssembly = IO::Path::Combine(IO::Path::GetTempPath(), IO::Path::GetFileNameWithoutExtension(filename) + ".dll");
 		compilerOptions->CompilerOptions = "/optimize" + csharp ? " /unsafe" : "";
 		compilerOptions->GenerateInMemory = true;
 		compilerOptions->IncludeDebugInformation = true;
@@ -197,9 +198,7 @@ namespace GTA
 		compilerOptions->ReferencedAssemblies->Add("System.Drawing.dll");
 		compilerOptions->ReferencedAssemblies->Add("System.Windows.Forms.dll");
 		compilerOptions->ReferencedAssemblies->Add(GTA::Script::typeid->Assembly->Location);
-
 		CodeDom::Compiler::CompilerResults ^compilerResult = compiler->CompileAssemblyFromFile(compilerOptions, filename);
-
 		if (!compilerResult->Errors->HasErrors)
 		{
 			Log("[DEBUG]", "Successfully compiled '", IO::Path::GetFileName(filename), "'.");
@@ -373,7 +372,7 @@ namespace GTA
 			script->mFilename = scripttype->Item1;
 			script->mScriptDomain = this;
 			script->mThread = gcnew Thread(gcnew ThreadStart(script, &Script::MainLoop));
-			script->OnLoaded();
+
 			script->mThread->Start();
 
 			Log("[DEBUG]", "Started script '", script->Name, "'.");

--- a/source/ScriptDomain.cpp
+++ b/source/ScriptDomain.cpp
@@ -373,7 +373,7 @@ namespace GTA
 			script->mFilename = scripttype->Item1;
 			script->mScriptDomain = this;
 			script->mThread = gcnew Thread(gcnew ThreadStart(script, &Script::MainLoop));
-
+			script->OnLoaded();
 			script->mThread->Start();
 
 			Log("[DEBUG]", "Started script '", script->Name, "'.");

--- a/source/Settings.cpp
+++ b/source/Settings.cpp
@@ -42,7 +42,7 @@ namespace GTA
 			return nullptr;
 		}
 
-		ScriptSettings ^result = gcnew ScriptSettings();
+		ScriptSettings ^result = gcnew ScriptSettings(filename);
 
 		try
 		{
@@ -93,7 +93,6 @@ namespace GTA
 		{
 			reader->Close();
 		}
-
 		return result;
 	}
 
@@ -198,5 +197,60 @@ namespace GTA
 		String ^lookup = String::Format("[{0}]{1}", section, key)->ToUpper();
 
 		this->mValues->default[lookup] = value;
+		if (!this->mValues->ContainsKey(lookup))
+			this->mValues->Add(lookup, value);
+		else
+			this->mValues->default[lookup] = value;
+	}
+	void ScriptSettings::Save()
+	{
+		if (mFileName == nullptr)
+			throw gcnew Exception("The file name is still fucking null when saving");
+		Dictionary<String ^, List<Tuple<String ^, String ^> ^> ^> ^IniData = gcnew	Dictionary<String ^, List<Tuple<String ^, String ^> ^> ^>();
+
+		for each(KeyValuePair<String ^, String ^> IniLine in mValues)
+		{
+			String ^Section = IniLine.Key->Remove(IniLine.Key->IndexOf("]"))->Substring(1);
+			String ^Key = IniLine.Key->Substring(IniLine.Key->IndexOf("]") + 1);
+			String ^Value = IniLine.Value;
+			if (!IniData->ContainsKey(Section))
+			{
+				List < Tuple<String ^, String ^> ^> ^Item = gcnew List < Tuple<String ^, String ^>^>();
+				Item->Add(gcnew Tuple<String ^, String ^>(Key, Value));
+				IniData->Add(Section, Item);
+			}
+			else
+			{
+				IniData[Section]->Add(gcnew Tuple<String ^, String ^>(Key, Value));
+			}
+		}
+		try
+		{
+			IO::StreamWriter ^Writer = IO::File::CreateText(this->mFileName);
+			for each (KeyValuePair<String ^, List<Tuple<String ^, String ^> ^> ^> IniLine in IniData)
+			{
+				Writer->WriteLine("[" + IniLine.Key + "]");
+				for each (Tuple<String ^, String ^> ^IniValue in IniLine.Value)
+				{
+					Writer->WriteLine(IniValue->Item1 + "=" + IniValue->Item2);
+				}
+				Writer->WriteLine();
+			}
+			Writer->Close();
+		}
+		catch (IO::IOException ^EX)
+		{
+			if (this->mFileName == nullptr)
+			{
+				throw gcnew IO::IOException("Error saving file, file name fucked up", EX);
+			}
+			else
+			throw gcnew IO::IOException("Error saving file", EX);
+		}
+		catch (Exception ^Ex)
+		{
+			throw Ex;
+		}
+		
 	}
 }

--- a/source/Settings.cpp
+++ b/source/Settings.cpp
@@ -202,8 +202,6 @@ namespace GTA
 	}
 	void ScriptSettings::Save()
 	{
-		if (mFileName == nullptr)
-			throw gcnew Exception("The file name is still fucking null when saving");
 		Dictionary<String ^, List<Tuple<String ^, String ^> ^> ^> ^IniData = gcnew	Dictionary<String ^, List<Tuple<String ^, String ^> ^> ^>();
 
 		for each(KeyValuePair<String ^, String ^> IniLine in mValues)

--- a/source/Settings.cpp
+++ b/source/Settings.cpp
@@ -195,8 +195,6 @@ namespace GTA
 	void ScriptSettings::SetValue(String ^section, String ^key, String ^value)
 	{
 		String ^lookup = String::Format("[{0}]{1}", section, key)->ToUpper();
-
-		this->mValues->default[lookup] = value;
 		if (!this->mValues->ContainsKey(lookup))
 			this->mValues->Add(lookup, value);
 		else

--- a/source/Settings.hpp
+++ b/source/Settings.hpp
@@ -31,7 +31,15 @@ namespace GTA
 		generic <typename T>
 		void SetValue(System::String ^section, System::String ^name, T value);
 		void SetValue(System::String ^section, System::String ^name, System::String ^value);
-
+		void Save();
+		
+	internal:
+		ScriptSettings(System::String ^FileName)
+		{
+			mFileName = FileName;
+		}
+		System::String ^mFileName;
+		
 	private:
 		System::Collections::Generic::Dictionary<System::String ^, System::String ^> ^mValues = gcnew System::Collections::Generic::Dictionary<System::String ^, System::String ^>();
 	};


### PR DESCRIPTION
Also Add method called after constructor has finished that can be overridden called OnLoaded, This means you can access ScriptSettings before the main script starts without getting errors that you would get by putting it in the constructor
fixes these issues
https://github.com/crosire/scripthookvdotnet/issues/249
https://github.com/crosire/scripthookvdotnet/issues/248