### PR TITLE
Fixed an issue where UI::DrawTexture distorts the texture

### DIFF
--- a/source/UI.cpp
+++ b/source/UI.cpp
@@ -70,13 +70,12 @@ namespace GTA
 		}
 
 		System::Drawing::Size resolution = Game::ScreenResolution;
-		float screenHeightScaleFactor = static_cast<float>(resolution.Width) / static_cast<float>(resolution.Height);
-
+		
 		const float x = static_cast<float>(pos.X) / UI::WIDTH;
 		const float y = static_cast<float>(pos.Y) / UI::HEIGHT;
 		const float w = static_cast<float>(size.Width) / UI::WIDTH;
 		const float h = static_cast<float>(size.Height) / UI::HEIGHT;
 
-		drawTexture(id, index, level, time, w, h, 0.0f, 0.0f, x, y, rotation, screenHeightScaleFactor, color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+		drawTexture(id, index, level, time, w, h, 0.0f, 0.0f, x, y, rotation, 1.0f, color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
 	}
 }


### PR DESCRIPTION
UI::DrawTexture uses scale factor incorrectly that the texture being drawn is distorted

Edit: Scale factor is used to scale the height of the texture. It should be 1.0 because UI::DrawTexture already calculated the proportion of the screen space the texture takes for current screen resolution, therefore height does not need to be scaled. If it is set to anything more than 1, the texture will be stretched in height.