### PR TITLE
Added Requirements to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This is an ASI plugin for Grand Theft Auto V, based on the C++ ScriptHook by Ale
 
 Prebuilt binaries can be found on the [releases](https://github.com/crosire/scripthookvdotnet/releases) page.
 
+## Requirements
+
+* [C++ ScriptHook by Alexander Blade](http://www.dev-c.com/gtav/scripthookv/)
+* .NET Framework ≥4.5
+
 ## Contributing
 
 You'll need Visual Studio to open the project file and the [Script Hook V SDK](http://www.dev-c.com/gtav/scripthookv/), which has to be extracted into "[/sdk](/sdk)" after downloading.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Community Script Hook V .NET
 
 This is an ASI plugin for Grand Theft Auto V, based on the C++ ScriptHook by Alexander Blade, which allows running scripts written in any .NET language ingame.
 
-## Downloads
-
-Prebuilt binaries can be found on the [releases](https://github.com/crosire/scripthookvdotnet/releases) page.
-
 ## Requirements
 
 * [C++ ScriptHook by Alexander Blade](http://www.dev-c.com/gtav/scripthookv/)
-* .NET Framework ≥4.5
+* .NET Framework ≥ 4.5
+
+## Downloads
+
+Prebuilt binaries can be found on the [releases](https://github.com/crosire/scripthookvdotnet/releases) page.
 
 ## Contributing
 


### PR DESCRIPTION
Like @zorg93 wrote to me, it seems like a lot of people ran into problems by having the wrong .NET Version installed. This little addition should make clear which .NET Version needs to be installed (And added a link to the original scripthook)

Maybe you can take a quick look @crosire, you may want to add/change sth.