### PR TITLE
Fixed GET_ENTITY_HEALTH

### DIFF
--- a/source/Entity.cpp
+++ b/source/Entity.cpp
@@ -51,7 +51,7 @@ namespace GTA
 	}
 	int Entity::Health::get()
 	{
-		return Native::Function::Call<int>(Native::Hash::GET_ENTITY_HEALTH, Handle) - 100;
+		return Native::Function::Call<int>(Native::Hash::GET_ENTITY_HEALTH, Handle) / 2;
 	}
 	void Entity::Health::set(int value)
 	{


### PR DESCRIPTION
Changed return Native::Function::Call<int>(Native::Hash::GET_ENTITY_HEALTH, Handle) - 100; to
return Native::Function::Call<int>(Native::Hash::GET_ENTITY_HEALTH, Handle) / 2;

GET_ENTITY_HEALTH - 100 is incorrect, you have to divide the health by 2 for peds. For vehicles it would be 10.