### PR TITLE
Add Vehicle::ClassType

### DIFF
--- a/source/scripting/Vehicle.cpp
+++ b/source/scripting/Vehicle.cpp
@@ -453,6 +453,10 @@ namespace GTA
 
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + 2212);
 	}
+	VehicleClass Vehicle::ClassType::get()
+	{
+		return static_cast<VehicleClass>(Native::Function::Call<int>(Native::Hash::GET_VEHICLE_CLASS, Handle));
+	}
 
 	int Vehicle::GetMod(VehicleMod modType)
 	{

--- a/source/scripting/Vehicle.hpp
+++ b/source/scripting/Vehicle.hpp
@@ -273,6 +273,31 @@ namespace GTA
 		Hook = 0,
 		Magnet = 1,
 	};
+	public enum class VehicleClass
+	{
+		Compacts = 0,
+		Sedans = 1,
+		SUVs = 2,
+		Coupes = 3,
+		Muscle = 4,
+		SportsClassics = 5,
+		Sports = 6,
+		Super = 7,
+		Motorcycles = 8,
+		OffRoad = 9,
+		Industrial = 10,
+		Utility = 11,
+		Vans = 12,
+		Cycles = 13,
+		Boats = 14,
+		Helicopters = 15,
+		Planes = 16,
+		Service = 17,
+		Emergency = 18,
+		Military = 19,
+		Commercial = 20,
+		Trains = 21,
+	};
 	public ref class Vehicle sealed : public Entity
 	{
 	public:
@@ -547,6 +572,10 @@ namespace GTA
 		property float Steering
 		{
 			float get();
+		}
+		property VehicleClass ClassType
+		{
+			VehicleClass get();
 		}
 
 		int GetMod(VehicleMod modType);


### PR DESCRIPTION
Should be able to get the class type of a vehicle
Like "Boats", "Planes", "Military", "Compacts", "Sports", "Super", etc

inb4 had to use 
```
if (veh.Model.IsBike) { }
else if (veh.Model.IsPlane) { } 
else if (veh.Model.IsBoat) { }
else if (veh.Model.IsCar)
{
 // can't tell the exact class of a car like compacts or sports 
}
```
