### PR TITLE
Fix Entity.Health

### DIFF
--- a/source/scripting/Entity.cpp
+++ b/source/scripting/Entity.cpp
@@ -51,7 +51,7 @@ namespace GTA
 	}
 	int Entity::Health::get()
 	{
-		return Native::Function::Call<int>(Native::Hash::GET_ENTITY_HEALTH, Handle) / 2;
+		return Native::Function::Call<int>(Native::Hash::GET_ENTITY_HEALTH, Handle) - 100;
 	}
 	void Entity::Health::set(int value)
 	{


### PR DESCRIPTION
Apparently someone changed -100 to /2 which caused it to show a value between 50 and 100 instead of 0 and 100......

So this should make health what it used to be. Should fix #383
