### PR TITLE
Fix Game::RadioStation in Blaine County

### DIFF
--- a/source/scripting/Game.cpp
+++ b/source/scripting/Game.cpp
@@ -145,11 +145,26 @@ namespace GTA
 	}
 	GTA::RadioStation Game::RadioStation::get()
 	{
-		return static_cast<GTA::RadioStation>(Native::Function::Call<int>(Native::Hash::GET_PLAYER_RADIO_STATION_INDEX));
+		System::String ^radioName = Native::Function::Call<System::String ^>(Native::Hash::GET_PLAYER_RADIO_STATION_NAME);
+		if (System::String::Equals(radioName, ""))
+		{
+			return GTA::RadioStation::RadioOff;
+		}
+		else
+		{
+			return static_cast<GTA::RadioStation>(System::Array::IndexOf(Game::_radioNames, radioName));
+		}
 	}
 	void Game::RadioStation::set(GTA::RadioStation value)
 	{
-		Native::Function::Call(Native::Hash::SET_RADIO_TO_STATION_INDEX, static_cast<int>(value));
+		if (System::Enum::IsDefined(value.GetType(), value) && value != GTA::RadioStation::RadioOff)
+		{
+			Native::Function::Call(Native::Hash::SET_RADIO_TO_STATION_NAME, _radioNames[static_cast<int>(value)]);
+		}
+		else
+		{
+			Native::Function::Call(Native::Hash::SET_RADIO_TO_STATION_NAME, "");
+		}
 	}
 	System::Drawing::Size Game::ScreenResolution::get()
 	{

--- a/source/scripting/Game.hpp
+++ b/source/scripting/Game.hpp
@@ -44,24 +44,25 @@ namespace GTA
 	};
 	public enum class RadioStation
 	{
-		LosSantosRockRadio,
-		NonStopPopFM,
-		RadioLosSantos,
-		ChannelX,
-		WestCoastTalkRadio,
-		RebelRadio,
-		SoulwaxFM,
-		EastLosFM,
-		WestCoastClassics,
-		TheBlueArk,
-		WorldWideFM,
-		FlyloFM,
-		TheLowdown,
-		TheLab,
-		RadioMirrorPark,
-		Space,
-		VinewoodBoulevardRadio,
-		SelfRadio,
+		LosSantosRockRadio = 0,
+		NonStopPopFM = 1,
+		RadioLosSantos = 2,
+		ChannelX = 3,
+		WestCoastTalkRadio = 4,
+		RebelRadio = 5,
+		SoulwaxFM = 6,
+		EastLosFM = 7,
+		WestCoastClassics = 8,
+		BlaineCountyRadio = 9,
+		TheBlueArk = 10,
+		WorldWideFM = 11,
+		FlyloFM = 12,
+		TheLowdown = 13,
+		RadioMirrorPark = 14,
+		Space = 15,
+		VinewoodBoulevardRadio = 16,
+		SelfRadio = 17,
+		TheLab = 18,
 		RadioOff = 255,
 	};
 	public enum class WindowTitle
@@ -238,6 +239,9 @@ namespace GTA
 		static System::String ^GetUserInput(WindowTitle windowTitle, int maxLength);
 		static System::String ^GetUserInput(System::String^ defaultText, int maxLength);
 		static System::String ^GetUserInput(WindowTitle windowTitle, System::String^ defaultText, int maxLength);
+
+	internal:
+		static initonly array<System::String ^> ^_radioNames = { "RADIO_01_CLASS_ROCK", "RADIO_02_POP", "RADIO_03_HIPHOP_NEW", "RADIO_04_PUNK", "RADIO_05_TALK_01", "RADIO_06_COUNTRY", "RADIO_07_DANCE_01", "RADIO_08_MEXICAN", "RADIO_09_HIPHOP_OLD", "RADIO_11_TALK_02", "RADIO_12_REGGAE", "RADIO_13_JAZZ", "RADIO_14_DANCE_02", "RADIO_15_MOTOWN", "RADIO_16_SILVERLAKE", "RADIO_17_FUNK", "RADIO_18_90S_ROCK", "RADIO_19_USER", "RADIO_20_THELAB", "RADIO_OFF" };
 
 	private:
 		static GameVersion _gameVersion = GameVersion::Unknown;


### PR DESCRIPTION
Also added GTA::RadioStation::BlaineCountyRadio
*West Coast Talk Radio* can only be tuned to inside and around the city, while *Blaine County Radio* can only be tuned to in Blaine County.

Unfortunately ```GET_PLAYER_RADIO_STATION_INDEX``` returns the index of the selected radio station on the radio wheel, therefore when a station is missing, casting the index int to GTA::RadioStation will cause the result to be off.
Same thing with ```SET_RADIO_TO_STATION_INDEX```.

EDIT: Setting RadioOff never worked and still doesn't. Neither ```SET_RADIO_TO_STATION_NAME("RADIO_OFF")```  nor ```SET_RADIO_TO_STATION_NAME("")``` turns it off

EDIT2: This was discovered while I was writing a [web remote control plugin](https://github.com/LibertyLocked/VStats/blob/master/VStats-plugin/WorldHelper.cs#L16). I found that all the radio stations are off in Blaine County while it works perfectly in the city.