### PR TITLE
Add counter measure against mplowrider2 car removing

### DIFF
--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -47,7 +47,7 @@ namespace
 	bool DisableMplowrider2CarRemoving()
 	{
 		GTA::Global global2558120 = GTA::Game::Globals[2558120];
-		if (global2558120.Address != System::IntPtr::Zero)
+		if (global2558120.MemoryAddress != System::IntPtr::Zero)
 		{
 			global2558120.SetInt(1);
 			return true;

--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -44,16 +44,6 @@ namespace
 
 		return true;
 	}
-	bool DisableMplowrider2CarRemoving()
-	{
-		GTA::Global global2558120 = GTA::Game::Globals[2558120];
-		if (global2558120.MemoryAddress != System::IntPtr::Zero)
-		{
-			global2558120.SetInt(1);
-			return true;
-		}
-		return false;
-	}
 	bool ManagedTick()
 	{
 		if (ScriptHook::Domain->IsKeyPressed(Keys::Insert))
@@ -88,6 +78,16 @@ namespace
 	PVOID sScriptFib = nullptr;
 	bool sMplowrider2CarRemovingDisabled = false;
 
+	bool DisableMplowrider2CarRemoving()
+	{
+		unsigned long long *global2558120 = getGlobalPtr(2558120);
+		if (global2558120 != 0)
+		{
+			*reinterpret_cast<int *>(global2558120) = 1;
+			return true;
+		}
+		return false;
+	}
 	void ScriptYield()
 	{
 		if (!sMplowrider2CarRemovingDisabled)

--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -90,13 +90,6 @@ namespace
 	}
 	void ScriptYield()
 	{
-		if (!sMplowrider2CarRemovingDisabled)
-		{
-			if (DisableMplowrider2CarRemoving())
-			{
-				sMplowrider2CarRemovingDisabled = true;
-			}
-		}
 		// Switch back to main script fiber used by Script Hook
 		SwitchToFiber(sMainFib);
 	}
@@ -115,6 +108,13 @@ namespace
 			// Run main loop
 			while (!sGameReloaded && ManagedTick())
 			{
+				if (!sMplowrider2CarRemovingDisabled)
+				{
+					if (DisableMplowrider2CarRemoving())
+					{
+						sMplowrider2CarRemovingDisabled = true;
+					}
+				}
 				ScriptYield();
 			}
 		}

--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -44,6 +44,16 @@ namespace
 
 		return true;
 	}
+	bool DisableMplowrider2CarRemoving()
+	{
+		GTA::Global global2558120 = GTA::Game::Globals[2558120];
+		if (global2558120.Address != System::IntPtr::Zero)
+		{
+			global2558120.SetInt(1);
+			return true;
+		}
+		return false;
+	}
 	bool ManagedTick()
 	{
 		if (ScriptHook::Domain->IsKeyPressed(Keys::Insert))
@@ -76,16 +86,30 @@ namespace
 	bool sGameReloaded = false;
 	PVOID sMainFib = nullptr;
 	PVOID sScriptFib = nullptr;
+	bool sMplowrider2CarRemovingDisabled = false;
 
 	void ScriptYield()
 	{
+		if (!sMplowrider2CarRemovingDisabled)
+		{
+			if (DisableMplowrider2CarRemoving())
+			{
+				sMplowrider2CarRemovingDisabled = true;
+			}
+		}
 		// Switch back to main script fiber used by Script Hook
 		SwitchToFiber(sMainFib);
 	}
 	void CALLBACK ScriptMainLoop()
 	{
 		while (ManagedInit())
-		{
+		{			
+			// Disables mplowrider2 car removing when starting a new game or loading a save game
+			if (sGameReloaded)
+			{
+				sMplowrider2CarRemovingDisabled = false;
+				DisableMplowrider2CarRemoving();
+			}
 			sGameReloaded = false;
 
 			// Run main loop

--- a/source/core/Native.cpp
+++ b/source/core/Native.cpp
@@ -72,9 +72,13 @@ namespace GTA
 				{
 					return static_cast<bool>(value) ? 1 : 0;
 				}
-				if (type == Int32::typeid || type == UInt32::typeid)
+				if (type == Int32::typeid)
 				{
 					return static_cast<int>(value);
+				}
+				if (type == UInt32::typeid)
+				{
+					return static_cast<unsigned int>(value);
 				}
 				if (type == Single::typeid)
 				{
@@ -145,9 +149,13 @@ namespace GTA
 				{
 					return *reinterpret_cast<int *>(value) != 0;
 				}
-				if (type == Int32::typeid || type == UInt32::typeid)
+				if (type == Int32::typeid)
 				{
 					return *reinterpret_cast<int *>(value);
+				}
+				if (type == UInt32::typeid)
+				{
+					return *reinterpret_cast<unsigned int *>(value);
 				}
 				if (type == Single::typeid)
 				{

--- a/source/core/Native.hpp
+++ b/source/core/Native.hpp
@@ -93,6 +93,10 @@ namespace GTA
 			{
 				return gcnew InputArgument(value);
 			}
+			static inline operator InputArgument ^ (bool *value)
+			{
+				return gcnew InputArgument(System::IntPtr(value));
+			}
 			static inline operator InputArgument ^ (int value)
 			{
 				return gcnew InputArgument(value);

--- a/source/scripting/Game.cpp
+++ b/source/scripting/Game.cpp
@@ -16,6 +16,11 @@ namespace GTA
 	{
 	}
 
+	System::IntPtr Global::Address::get()
+	{
+		return System::IntPtr(mAddress);
+	}
+
 	void Global::SetInt(int value)
 	{
 		*reinterpret_cast<int *>(this->mAddress) = value;

--- a/source/scripting/Game.cpp
+++ b/source/scripting/Game.cpp
@@ -16,7 +16,7 @@ namespace GTA
 	{
 	}
 
-	System::IntPtr Global::Address::get()
+	System::IntPtr Global::MemoryAddress::get()
 	{
 		return System::IntPtr(mAddress);
 	}

--- a/source/scripting/Game.cpp
+++ b/source/scripting/Game.cpp
@@ -16,9 +16,9 @@ namespace GTA
 	{
 	}
 
-	System::IntPtr Global::MemoryAddress::get()
+	unsigned long long *Global::MemoryAddress::get()
 	{
-		return System::IntPtr(mAddress);
+		return reinterpret_cast<unsigned long long *>(this->mAddress);
 	}
 
 	void Global::SetInt(int value)

--- a/source/scripting/Game.cpp
+++ b/source/scripting/Game.cpp
@@ -89,6 +89,10 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::SET_PAUSE_MENU_ACTIVE, value);
 	}
+	bool Game::IsLoading::get()
+	{
+		return Native::Function::Call<bool>(Native::Hash::GET_IS_LOADING_SCREEN_ACTIVE);
+	}
 	bool Game::IsWaypointActive::get()
 	{
 		return Native::Function::Call<bool>(Native::Hash::IS_WAYPOINT_ACTIVE);

--- a/source/scripting/Game.hpp
+++ b/source/scripting/Game.hpp
@@ -105,6 +105,11 @@ namespace GTA
 	public value class Global
 	{
 	public:
+		property System::IntPtr Address
+		{
+			System::IntPtr get();
+		}
+
 		void SetInt(int value);
 		void SetFloat(float value);
 		void SetString(System::String ^value);

--- a/source/scripting/Game.hpp
+++ b/source/scripting/Game.hpp
@@ -105,9 +105,9 @@ namespace GTA
 	public value class Global
 	{
 	public:
-		property System::IntPtr MemoryAddress
+		property unsigned long long *MemoryAddress
 		{
-			System::IntPtr get();
+			unsigned long long *get();
 		}
 
 		void SetInt(int value);

--- a/source/scripting/Game.hpp
+++ b/source/scripting/Game.hpp
@@ -105,7 +105,7 @@ namespace GTA
 	public value class Global
 	{
 	public:
-		property System::IntPtr Address
+		property System::IntPtr MemoryAddress
 		{
 			System::IntPtr get();
 		}

--- a/source/scripting/Game.hpp
+++ b/source/scripting/Game.hpp
@@ -156,6 +156,10 @@ namespace GTA
 			bool get();
 			void set(bool value);
 		}
+		static property bool IsLoading
+		{
+			bool get();
+		}
 		static property bool IsWaypointActive
 		{
 			bool get();


### PR DESCRIPTION
If we declare a property/method which returns a unsafe pointer, we can't use it from VB.NET scripts, so I declared ```Global.MemoryAddress``` as a property which returns a IntPtr value. There are no properties/methods which returns a unsafe pointer in RAGE Plugin Hook.