### PR TITLE
Advanced MSBuild project settings

### DIFF
--- a/ScriptHookVDotNet.sln
+++ b/ScriptHookVDotNet.sln
@@ -1,8 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2013 or higher
+MinimumVisualStudioVersion = 12.0.40629.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ScriptHookVDotNet", "ScriptHookVDotNet.vcxproj", "{019193A7-50C0-444A-84CA-777595E702CD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptHookVDotNetExamples", "ScriptHookVDotNetExamples.csproj", "{A717AD5D-C5B5-4769-BD40-F14C09F269BB}"

--- a/ScriptHookVDotNet.sln
+++ b/ScriptHookVDotNet.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013 or higher
+# Visual Studio 2013
 MinimumVisualStudioVersion = 12.0.40629.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ScriptHookVDotNet", "ScriptHookVDotNet.vcxproj", "{019193A7-50C0-444A-84CA-777595E702CD}"
 EndProject

--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
@@ -13,39 +13,49 @@
     <RootNamespace>GTA</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+  <!-- Global configuration settings -->
+  <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <!-- Support for VS2013 and VS2015 -->
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <CLRSupport>true</CLRSupport>
+    <OutDir>bin\</OutDir>
+    <IntDir>obj\</IntDir>
+  </PropertyGroup>
+  <!-- Release configuration settings -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup>
-    <OutDir>bin\</OutDir>
-    <IntDir>obj\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+  <!-- Global compilation settings -->
+  <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOSOUND;NOMINMAX;NDEBUG;%(PreprocessorDefinitions);NOSOUND;NOMINMAX</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>source\core;source\scripting;sdk\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <GenerateXMLDocumentationFiles>true</GenerateXMLDocumentationFiles>
     </ClCompile>
     <Link>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
       <AdditionalLibraryDirectories>sdk\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>ScriptHookV.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy "$(TargetPath)" "$(TargetDir)$(TargetName).asi"</Command>
     </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <!-- Release compilation settings -->
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;NOSOUND;NOMINMAX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -124,4 +134,18 @@
     <ClInclude Include="source\scripting\Weapon.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <!-- Verify SDK files exist before generating anything -->
+  <Target Name="VerifySDKFiles" BeforeTargets="BeforeBuildGenerateSources">
+    <ItemGroup>
+      <!-- look for the header files and the library -->
+      <SDKFiles Include="sdk\inc\*.h" />
+      <SDKLib Include="sdk\lib\*.lib" />
+    </ItemGroup>
+    <PropertyGroup>
+      <!-- make sure all necessary files are present -->
+      <SDKFilesMissing>false</SDKFilesMissing>
+      <SDKFilesMissing Condition="'@(SDKFiles)' == '' or '@(SDKLib)' == ''">true</SDKFilesMissing>
+    </PropertyGroup>
+    <Error Text="ScriptHookV SDK files not found. Please copy the SDK files into the 'sdk' folder and try again." Condition="$(SDKFilesMissing)" />
+  </Target>
 </Project>

--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -62,6 +62,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
+  <!-- Core source files -->
   <ItemGroup>
     <ClCompile Include="source\core\Main.cpp" />
     <ClCompile Include="source\core\Native.cpp" />
@@ -69,12 +70,23 @@
     <ClCompile Include="source\core\Script.cpp" />
     <ClCompile Include="source\core\ScriptDomain.cpp" />
     <ClCompile Include="source\core\Settings.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="source\core\Native.hpp" />
+    <ClInclude Include="source\core\NativeHashes.hpp" />
+    <ClInclude Include="source\core\NativeMemory.hpp" />
+    <ClInclude Include="source\core\Script.hpp" />
+    <ClInclude Include="source\core\ScriptDomain.hpp" />
+    <ClInclude Include="source\core\Settings.hpp" />
+  </ItemGroup>
+  <!-- Additional source files -->
+  <ItemGroup>
     <ClCompile Include="source\scripting\Audio.cpp" />
     <ClCompile Include="source\scripting\Blip.cpp" />
     <ClCompile Include="source\scripting\Camera.cpp" />
     <ClCompile Include="source\scripting\Entity.cpp" />
-    <ClCompile Include="source\scripting\EuphoriaBase.cpp" />
     <ClCompile Include="source\scripting\Euphoria.cpp" />
+    <ClCompile Include="source\scripting\EuphoriaBase.cpp" />
     <ClCompile Include="source\scripting\Game.cpp" />
     <ClCompile Include="source\scripting\Matrix.cpp" />
     <ClCompile Include="source\scripting\Model.cpp" />
@@ -95,19 +107,13 @@
     <ClCompile Include="source\scripting\Weapon.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="source\core\Native.hpp" />
-    <ClInclude Include="source\core\NativeHashes.hpp" />
-    <ClInclude Include="source\core\NativeMemory.hpp" />
-    <ClInclude Include="source\core\Script.hpp" />
-    <ClInclude Include="source\core\ScriptDomain.hpp" />
-    <ClInclude Include="source\core\Settings.hpp" />
     <ClInclude Include="source\scripting\Audio.hpp" />
-    <ClInclude Include="source\scripting\Controls.hpp" />
     <ClInclude Include="source\scripting\Blip.hpp" />
+    <ClInclude Include="source\scripting\Controls.hpp" />
     <ClInclude Include="source\scripting\Camera.hpp" />
     <ClInclude Include="source\scripting\Entity.hpp" />
-    <ClInclude Include="source\scripting\EuphoriaBase.hpp" />
     <ClInclude Include="source\scripting\Euphoria.hpp" />
+    <ClInclude Include="source\scripting\EuphoriaBase.hpp" />
     <ClInclude Include="source\scripting\EuphoriaHelpers.hpp" />
     <ClInclude Include="source\scripting\Game.hpp" />
     <ClInclude Include="source\scripting\Interface.hpp" />

--- a/ScriptHookVDotNetExamples.csproj
+++ b/ScriptHookVDotNetExamples.csproj
@@ -10,14 +10,18 @@
     <AssemblyName>examples</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  <!-- Global compilation settings -->
+  <PropertyGroup>
+    <PlatformTarget>x64</PlatformTarget>
     <OutputPath>bin\scripts\</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <!-- Release compilation settings -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -26,7 +30,6 @@
     <ProjectReference Include="ScriptHookVDotNet.vcxproj">
       <Project>{019193a7-50c0-444a-84ca-777595e702cd}</Project>
       <Name>ScriptHookVDotNet</Name>
-      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I've modified the project/solution settings to behave more dynamically and allow the use of either Visual Studio 2013 or 2015 without the need of updating the solution/project files. If you're using VS2015, it'll compile with the v140 platform toolset -- otherwise it'll use v120. I made Visual Studio 2013 the minimum version required to open the solution, so hopefully there's no need to put in place a "fallback" value for this. If you feel this should be handled differently, let me know.

I've also added an MSBuild Target that checks to make sure the user has installed all necessary SDK files before trying to generate any code (very useful and prevents a huge chain of compiler errors). This can be located at the end of the .vcxproj file.

I'm fairly experienced with MSBuild stuff so if you have any questions/comments/concerns, feel free to let me know!