### PR TITLE
Add custom implict conversions to InputArgument/OutputArgument

### DIFF
--- a/source/core/Native.hpp
+++ b/source/core/Native.hpp
@@ -97,6 +97,22 @@ namespace GTA
 			{
 				return gcnew InputArgument(System::IntPtr(value));
 			}
+			static inline operator InputArgument ^ (char value)
+			{
+				return gcnew InputArgument(static_cast<int>(value));
+			}
+			static inline operator InputArgument ^ (unsigned char value)
+			{
+				return gcnew InputArgument(static_cast<int>(value));
+			}
+			static inline operator InputArgument ^ (short value)
+			{
+				return gcnew InputArgument(static_cast<int>(value));
+			}
+			static inline operator InputArgument ^ (unsigned short value)
+			{
+				return gcnew InputArgument(static_cast<int>(value));
+			}
 			static inline operator InputArgument ^ (int value)
 			{
 				return gcnew InputArgument(value);
@@ -188,6 +204,18 @@ namespace GTA
 			OutputArgument();
 			OutputArgument(System::Object ^initvalue);
 			inline OutputArgument(bool initvalue) : OutputArgument(static_cast<System::Object ^>(initvalue))
+			{
+			}
+			inline OutputArgument(char initvalue) : OutputArgument(static_cast<System::Object ^>(static_cast<int>(initvalue)))
+			{
+			}
+			inline OutputArgument(unsigned char initvalue) : OutputArgument(static_cast<System::Object ^>(static_cast<int>(initvalue)))
+			{
+			}
+			inline OutputArgument(short initvalue) : OutputArgument(static_cast<System::Object ^>(static_cast<int>(initvalue)))
+			{
+			}
+			inline OutputArgument(unsigned short initvalue) : OutputArgument(static_cast<System::Object ^>(static_cast<int>(initvalue)))
 			{
 			}
 			inline OutputArgument(int initvalue) : OutputArgument(static_cast<System::Object ^>(initvalue))

--- a/source/scripting/Vehicle.cpp
+++ b/source/scripting/Vehicle.cpp
@@ -171,10 +171,6 @@ namespace GTA
 			Native::Function::Call(Native::Hash::SET_VEHICLE_FORWARD_SPEED, Handle, value);
 		}
 	}
-	float Vehicle::MaxSpeed::get()
-	{
-		return Native::Function::Call<float>(Native::Hash::_GET_VEHICLE_MAX_SPEED, Model.Hash);
-	}
 	float Vehicle::MaxTraction::get()
 	{
 		return Native::Function::Call<float>(Native::Hash::GET_VEHICLE_MAX_TRACTION, Handle);

--- a/source/scripting/Vehicle.hpp
+++ b/source/scripting/Vehicle.hpp
@@ -448,10 +448,6 @@ namespace GTA
 			float get();
 			void set(float value);
 		}
-		property float MaxSpeed
-		{
-			float get();
-		}
 		property float MaxTraction
 		{
 			float get();


### PR DESCRIPTION
And removed `Vehicle.MaxSpeed`, to avoid compile error. And `_GET_VEHICLE_MAX_SPEED` doesn't return the vehicle's current max physical speed.