### PR TITLE
Refactor Code

### DIFF
--- a/source/core/Native.cpp
+++ b/source/core/Native.cpp
@@ -97,17 +97,17 @@ namespace GTA
 					return ScriptDomain::CurrentDomain->PinString(static_cast<String ^>(value)).ToInt64();
 				}
 
-                // Scripting types
-                if (INativeValue::typeid->IsAssignableFrom(type))
-                {
-                    return safe_cast<INativeValue ^>(value)->NativeValue;
-                }
-                if (IHandleable::typeid->IsAssignableFrom(type))
-                {
-                    return safe_cast<IHandleable ^>(value)->Handle;
-                }
+				// Scripting types
+				if (INativeValue::typeid->IsAssignableFrom(type))
+				{
+					return safe_cast<INativeValue ^>(value)->NativeValue;
+				}
+				if (IHandleable::typeid->IsAssignableFrom(type))
+				{
+					return safe_cast<IHandleable ^>(value)->Handle;
+				}
 
-                /*
+				/*
 				if (type == Model::typeid)
 				{
 					return static_cast<Model>(value).Hash;
@@ -149,7 +149,7 @@ namespace GTA
 				{
 					return static_cast<Vehicle ^>(value)->Handle;
 				}
-                */
+				*/
 
 				throw gcnew InvalidCastException(String::Concat("Unable to cast object of type '", type->FullName, "' to native value"));
 			}
@@ -208,12 +208,12 @@ namespace GTA
 				// Math types
 				if (type == Math::Vector2::typeid)
 				{
-                    NativeVector3 *vec = reinterpret_cast<NativeVector3 *>(value);
+					NativeVector3 *vec = reinterpret_cast<NativeVector3 *>(value);
 					return gcnew Math::Vector2(vec->x, vec->y);
 				}
 				if (type == Math::Vector3::typeid)
 				{
-                    NativeVector3 *vec = reinterpret_cast<NativeVector3 *>(value);
+					NativeVector3 *vec = reinterpret_cast<NativeVector3 *>(value);
 					return gcnew Math::Vector3(vec->x, vec->y, vec->z);
 				}
 

--- a/source/core/Native.cpp
+++ b/source/core/Native.cpp
@@ -97,7 +97,17 @@ namespace GTA
 					return ScriptDomain::CurrentDomain->PinString(static_cast<String ^>(value)).ToInt64();
 				}
 
-				// Scripting types
+                // Scripting types
+                if (INativeValue::typeid->IsAssignableFrom(type))
+                {
+                    return safe_cast<INativeValue ^>(value)->NativeValue;
+                }
+                if (IHandleable::typeid->IsAssignableFrom(type))
+                {
+                    return safe_cast<IHandleable ^>(value)->Handle;
+                }
+
+                /*
 				if (type == Model::typeid)
 				{
 					return static_cast<Model>(value).Hash;
@@ -139,6 +149,7 @@ namespace GTA
 				{
 					return static_cast<Vehicle ^>(value)->Handle;
 				}
+                */
 
 				throw gcnew InvalidCastException(String::Concat("Unable to cast object of type '", type->FullName, "' to native value"));
 			}
@@ -197,11 +208,13 @@ namespace GTA
 				// Math types
 				if (type == Math::Vector2::typeid)
 				{
-					return gcnew Math::Vector2(reinterpret_cast<NativeVector3 *>(value)->x, reinterpret_cast<NativeVector3 *>(value)->y);
+                    NativeVector3 *vec = reinterpret_cast<NativeVector3 *>(value);
+					return gcnew Math::Vector2(vec->x, vec->y);
 				}
 				if (type == Math::Vector3::typeid)
 				{
-					return gcnew Math::Vector3(reinterpret_cast<NativeVector3 *>(value)->x, reinterpret_cast<NativeVector3 *>(value)->y, reinterpret_cast<NativeVector3 *>(value)->z);
+                    NativeVector3 *vec = reinterpret_cast<NativeVector3 *>(value);
+					return gcnew Math::Vector3(vec->x, vec->y, vec->z);
 				}
 
 				const int handle = *reinterpret_cast<int *>(value);

--- a/source/core/Native.cpp
+++ b/source/core/Native.cpp
@@ -98,21 +98,16 @@ namespace GTA
 				}
 
 				// Scripting types
-				if (INativeValue::typeid->IsAssignableFrom(type))
-				{
-					return safe_cast<INativeValue ^>(value)->NativeValue;
-				}
 				if (IHandleable::typeid->IsAssignableFrom(type))
 				{
 					return safe_cast<IHandleable ^>(value)->Handle;
 				}
-
-				/*
 				if (type == Model::typeid)
 				{
 					return static_cast<Model>(value).Hash;
 				}
 
+                /*
 				if (type == Blip::typeid)
 				{
 					return static_cast<Blip ^>(value)->Handle;

--- a/source/scripting/Blip.cpp
+++ b/source/scripting/Blip.cpp
@@ -110,16 +110,13 @@ namespace GTA
 	}
 	bool Blip::Equals(Object ^value)
 	{
-		if (value == nullptr)
-			return false;
-
-		if (value->GetType() != GetType())
+		if (value == nullptr || value->GetType() != GetType())
 			return false;
 
 		return Equals(safe_cast<Blip ^>(value));
 	}
 	bool Blip::Equals(Blip ^blip)
 	{
-		return !System::Object::ReferenceEquals(blip, nullptr) && Handle == blip->Handle;
+		return !Object::ReferenceEquals(blip, nullptr) && Handle == blip->Handle;
 	}
 }

--- a/source/scripting/Blip.hpp
+++ b/source/scripting/Blip.hpp
@@ -295,9 +295,11 @@ namespace GTA
 		void HideNumber();
 		void ShowNumber(int number);
 
+        void Remove();
+
 		virtual bool Exists();
 		static bool Exists(Blip ^blip);
-		void Remove();
+		
 		virtual bool Equals(System::Object ^obj) override;
 		virtual bool Equals(Blip ^blip);
 
@@ -305,6 +307,7 @@ namespace GTA
 		{
 			return Handle;
 		}
+
 		static inline bool operator==(Blip ^left, Blip ^right)
 		{
 			if (ReferenceEquals(left, nullptr))

--- a/source/scripting/Blip.hpp
+++ b/source/scripting/Blip.hpp
@@ -295,7 +295,7 @@ namespace GTA
 		void HideNumber();
 		void ShowNumber(int number);
 
-        void Remove();
+		void Remove();
 
 		virtual bool Exists();
 		static bool Exists(Blip ^blip);

--- a/source/scripting/Camera.cpp
+++ b/source/scripting/Camera.cpp
@@ -234,32 +234,30 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::STOP_CAM_POINTING, Handle);
 	}
+    void Camera::Destroy()
+    {
+        Native::Function::Call(Native::Hash::DESTROY_CAM, Handle, 0);
+    }
 
 	bool Camera::Exists()
 	{
-		return Exists(this);
+        return Native::Function::Call<bool>(Native::Hash::DOES_CAM_EXIST, Handle);
 	}
 	bool Camera::Exists(Camera ^camera)
 	{
-		return !Object::ReferenceEquals(camera, nullptr) && Native::Function::Call<bool>(Native::Hash::DOES_CAM_EXIST, camera->Handle);
+        return !Object::ReferenceEquals(camera, nullptr) && camera->Exists();
 	}
-	void Camera::Destroy()
-	{
-		Native::Function::Call(Native::Hash::DESTROY_CAM, Handle, 0);
-	}
+	
 	bool Camera::Equals(Object ^value)
 	{
-		if (value == nullptr)
-			return false;
-
-		if (value->GetType() != GetType())
+		if (value == nullptr || value->GetType() != GetType())
 			return false;
 
 		return Equals(safe_cast<Camera ^>(value));
 	}
 	bool Camera::Equals(Camera ^camera)
 	{
-		return !System::Object::ReferenceEquals(camera, nullptr) && Handle == camera->Handle;
+		return !Object::ReferenceEquals(camera, nullptr) && Handle == camera->Handle;
 	}
 
 	void GameplayCamera::ClampYaw(float min, float max)

--- a/source/scripting/Camera.cpp
+++ b/source/scripting/Camera.cpp
@@ -234,18 +234,18 @@ namespace GTA
 	{
 		Native::Function::Call(Native::Hash::STOP_CAM_POINTING, Handle);
 	}
-    void Camera::Destroy()
-    {
-        Native::Function::Call(Native::Hash::DESTROY_CAM, Handle, 0);
-    }
+	void Camera::Destroy()
+	{
+		Native::Function::Call(Native::Hash::DESTROY_CAM, Handle, 0);
+	}
 
 	bool Camera::Exists()
 	{
-        return Native::Function::Call<bool>(Native::Hash::DOES_CAM_EXIST, Handle);
+		return Native::Function::Call<bool>(Native::Hash::DOES_CAM_EXIST, Handle);
 	}
 	bool Camera::Exists(Camera ^camera)
 	{
-        return !Object::ReferenceEquals(camera, nullptr) && camera->Exists();
+		return !Object::ReferenceEquals(camera, nullptr) && camera->Exists();
 	}
 	
 	bool Camera::Equals(Object ^value)

--- a/source/scripting/Camera.hpp
+++ b/source/scripting/Camera.hpp
@@ -115,9 +115,11 @@ namespace GTA
 		void PointAt(Ped ^target, int boneIndex, Math::Vector3 offset);
 		void StopPointing();
 
+        void Destroy();
+
 		virtual bool Exists();
 		static bool Exists(Camera ^camera);
-		void Destroy();
+
 		virtual bool Equals(System::Object ^obj) override;
 		virtual bool Equals(Camera ^camera);
 
@@ -125,6 +127,7 @@ namespace GTA
 		{
 			return Handle;
 		}
+
 		static inline bool operator==(Camera ^left, Camera ^right)
 		{
 			if (ReferenceEquals(left, nullptr))
@@ -140,11 +143,24 @@ namespace GTA
 		}
 
 	internal:
-		static initonly array<System::String ^> ^_shakeNames = { "HAND_SHAKE", "SMALL_EXPLOSION_SHAKE", "MEDIUM_EXPLOSION_SHAKE", "LARGE_EXPLOSION_SHAKE", "JOLT_SHAKE", "VIBRATE_SHAKE", "ROAD_VIBRATION_SHAKE", "DRUNK_SHAKE", "SKY_DIVING_SHAKE", "FAMILY5_DRUG_TRIP_SHAKE", "DEATH_FAIL_IN_EFFECT_SHAKE" };
+		static initonly array<System::String ^> ^_shakeNames = {
+            "HAND_SHAKE",
+            "SMALL_EXPLOSION_SHAKE",
+            "MEDIUM_EXPLOSION_SHAKE",
+            "LARGE_EXPLOSION_SHAKE",
+            "JOLT_SHAKE",
+            "VIBRATE_SHAKE",
+            "ROAD_VIBRATION_SHAKE",
+            "DRUNK_SHAKE",
+            "SKY_DIVING_SHAKE",
+            "FAMILY5_DRUG_TRIP_SHAKE",
+            "DEATH_FAIL_IN_EFFECT_SHAKE"
+        };
 
 	private:
 		int _handle;
 	};
+
 	public ref class GameplayCamera sealed abstract
 	{
 	public:

--- a/source/scripting/Camera.hpp
+++ b/source/scripting/Camera.hpp
@@ -115,7 +115,7 @@ namespace GTA
 		void PointAt(Ped ^target, int boneIndex, Math::Vector3 offset);
 		void StopPointing();
 
-        void Destroy();
+		void Destroy();
 
 		virtual bool Exists();
 		static bool Exists(Camera ^camera);
@@ -144,18 +144,18 @@ namespace GTA
 
 	internal:
 		static initonly array<System::String ^> ^_shakeNames = {
-            "HAND_SHAKE",
-            "SMALL_EXPLOSION_SHAKE",
-            "MEDIUM_EXPLOSION_SHAKE",
-            "LARGE_EXPLOSION_SHAKE",
-            "JOLT_SHAKE",
-            "VIBRATE_SHAKE",
-            "ROAD_VIBRATION_SHAKE",
-            "DRUNK_SHAKE",
-            "SKY_DIVING_SHAKE",
-            "FAMILY5_DRUG_TRIP_SHAKE",
-            "DEATH_FAIL_IN_EFFECT_SHAKE"
-        };
+			"HAND_SHAKE",
+			"SMALL_EXPLOSION_SHAKE",
+			"MEDIUM_EXPLOSION_SHAKE",
+			"LARGE_EXPLOSION_SHAKE",
+			"JOLT_SHAKE",
+			"VIBRATE_SHAKE",
+			"ROAD_VIBRATION_SHAKE",
+			"DRUNK_SHAKE",
+			"SKY_DIVING_SHAKE",
+			"FAMILY5_DRUG_TRIP_SHAKE",
+			"DEATH_FAIL_IN_EFFECT_SHAKE"
+		};
 
 	private:
 		int _handle;

--- a/source/scripting/Entity.cpp
+++ b/source/scripting/Entity.cpp
@@ -463,31 +463,30 @@ namespace GTA
 		Native::Function::Call(Native::Hash::SET_ENTITY_AS_MISSION_ENTITY, handle, true, false);
 		Native::Function::Call(Native::Hash::DELETE_ENTITY, &handle);
 	}
+    void Entity::MarkAsNoLongerNeeded()
+    {
+        int handle = Handle;
+        Native::Function::Call(Native::Hash::SET_ENTITY_AS_NO_LONGER_NEEDED, &handle);
+    }
+
 	bool Entity::Exists()
 	{
-		return Exists(this);
+        return Native::Function::Call<bool>(Native::Hash::DOES_ENTITY_EXIST, Handle);
 	}
-	bool Entity::Exists(Entity ^entity)
-	{
-		return !Object::ReferenceEquals(entity, nullptr) && Native::Function::Call<bool>(Native::Hash::DOES_ENTITY_EXIST, entity->Handle);
-	}
-	void Entity::MarkAsNoLongerNeeded()
-	{
-		int handle = Handle;
-		Native::Function::Call(Native::Hash::SET_ENTITY_AS_NO_LONGER_NEEDED, &handle);
-	}
-	bool Entity::Equals(Object ^value)
-	{
-		if (value == nullptr)
-			return false;
+    bool Entity::Exists(Entity ^entity)
+    {
+        return !Object::ReferenceEquals(entity, nullptr) && entity->Exists();
+    }
 
-		if (value->GetType() != GetType())
-			return false;
+    bool Entity::Equals(Object ^value)
+    {
+        if (value == nullptr || value->GetType() != GetType())
+            return false;
 
-		return Equals(safe_cast<Entity ^>(value));
-	}
+        return Equals(safe_cast<Entity ^>(value));
+    }
 	bool Entity::Equals(Entity ^entity)
 	{
-		return !System::Object::ReferenceEquals(entity, nullptr) && Handle == entity->Handle;
+		return !Object::ReferenceEquals(entity, nullptr) && Handle == entity->Handle;
 	}
 }

--- a/source/scripting/Entity.cpp
+++ b/source/scripting/Entity.cpp
@@ -463,28 +463,28 @@ namespace GTA
 		Native::Function::Call(Native::Hash::SET_ENTITY_AS_MISSION_ENTITY, handle, true, false);
 		Native::Function::Call(Native::Hash::DELETE_ENTITY, &handle);
 	}
-    void Entity::MarkAsNoLongerNeeded()
-    {
-        int handle = Handle;
-        Native::Function::Call(Native::Hash::SET_ENTITY_AS_NO_LONGER_NEEDED, &handle);
-    }
+	void Entity::MarkAsNoLongerNeeded()
+	{
+		int handle = Handle;
+		Native::Function::Call(Native::Hash::SET_ENTITY_AS_NO_LONGER_NEEDED, &handle);
+	}
 
 	bool Entity::Exists()
 	{
-        return Native::Function::Call<bool>(Native::Hash::DOES_ENTITY_EXIST, Handle);
+		return Native::Function::Call<bool>(Native::Hash::DOES_ENTITY_EXIST, Handle);
 	}
-    bool Entity::Exists(Entity ^entity)
-    {
-        return !Object::ReferenceEquals(entity, nullptr) && entity->Exists();
-    }
+	bool Entity::Exists(Entity ^entity)
+	{
+		return !Object::ReferenceEquals(entity, nullptr) && entity->Exists();
+	}
 
-    bool Entity::Equals(Object ^value)
-    {
-        if (value == nullptr || value->GetType() != GetType())
-            return false;
+	bool Entity::Equals(Object ^value)
+	{
+		if (value == nullptr || value->GetType() != GetType())
+			return false;
 
-        return Equals(safe_cast<Entity ^>(value));
-    }
+		return Equals(safe_cast<Entity ^>(value));
+	}
 	bool Entity::Equals(Entity ^entity)
 	{
 		return !Object::ReferenceEquals(entity, nullptr) && Handle == entity->Handle;

--- a/source/scripting/Entity.hpp
+++ b/source/scripting/Entity.hpp
@@ -232,7 +232,7 @@ namespace GTA
 		bool HasBone(System::String ^boneName);
 
 		void Delete();
-        void MarkAsNoLongerNeeded();
+		void MarkAsNoLongerNeeded();
 
 		virtual bool Exists();
 		static bool Exists(Entity ^entity);

--- a/source/scripting/Entity.hpp
+++ b/source/scripting/Entity.hpp
@@ -232,9 +232,11 @@ namespace GTA
 		bool HasBone(System::String ^boneName);
 
 		void Delete();
+        void MarkAsNoLongerNeeded();
+
 		virtual bool Exists();
 		static bool Exists(Entity ^entity);
-		void MarkAsNoLongerNeeded();
+
 		virtual bool Equals(System::Object ^obj) override;
 		virtual bool Equals(Entity ^entity);
 
@@ -242,6 +244,7 @@ namespace GTA
 		{
 			return Handle;
 		}
+
 		static inline bool operator==(Entity ^left, Entity ^right)
 		{
 			if (ReferenceEquals(left, nullptr))

--- a/source/scripting/Game.cpp
+++ b/source/scripting/Game.cpp
@@ -39,9 +39,11 @@ namespace GTA
 	}
 	void Global::SetVector3(Math::Vector3 value)
 	{
-		*(reinterpret_cast<float *>(this->mAddress) + 0) = value.X;
-		*(reinterpret_cast<float *>(this->mAddress) + 1) = value.Y;
-		*(reinterpret_cast<float *>(this->mAddress) + 2) = value.Z;
+		float *vec = reinterpret_cast<float *>(this->mAddress);
+
+		*(vec + 0) = value.X;
+		*(vec + 1) = value.Y;
+		*(vec + 2) = value.Z;
 	}
 	int Global::GetInt()
 	{
@@ -57,7 +59,9 @@ namespace GTA
 	}
 	Math::Vector3 Global::GetVector3()
 	{
-		return Math::Vector3(*(reinterpret_cast<float *>(this->mAddress) + 0), *(reinterpret_cast<float *>(this->mAddress) + 1), *(reinterpret_cast<float *>(this->mAddress) + 2));
+		float *vec = reinterpret_cast<float *>(this->mAddress);
+
+		return Math::Vector3(*(vec + 0), *(vec + 1), *(vec + 2));
 	}
 
 	Global GlobalCollection::default::get(int index)

--- a/source/scripting/Interface.hpp
+++ b/source/scripting/Interface.hpp
@@ -2,6 +2,14 @@
 
 namespace GTA
 {
+    public interface class INativeValue
+    {
+        property int NativeValue
+        {
+            int get();
+        }
+    };
+
 	public interface class IHandleable
 	{
 		property int Handle

--- a/source/scripting/Interface.hpp
+++ b/source/scripting/Interface.hpp
@@ -2,13 +2,13 @@
 
 namespace GTA
 {
-    public interface class INativeValue
-    {
-        property int NativeValue
-        {
-            int get();
-        }
-    };
+	public interface class INativeValue
+	{
+		property int NativeValue
+		{
+			int get();
+		}
+	};
 
 	public interface class IHandleable
 	{

--- a/source/scripting/Interface.hpp
+++ b/source/scripting/Interface.hpp
@@ -2,14 +2,6 @@
 
 namespace GTA
 {
-	public interface class INativeValue
-	{
-		property int NativeValue
-		{
-			int get();
-		}
-	};
-
 	public interface class IHandleable
 	{
 		property int Handle

--- a/source/scripting/Matrix.cpp
+++ b/source/scripting/Matrix.cpp
@@ -828,10 +828,7 @@ namespace GTA
 		}
 		bool Matrix::Equals(Object ^value)
 		{
-			if (value == nullptr)
-				return false;
-
-			if (value->GetType() != GetType())
+			if (value == nullptr || value->GetType() != GetType())
 				return false;
 
 			return Equals(safe_cast<Matrix>(value));

--- a/source/scripting/Model.cpp
+++ b/source/scripting/Model.cpp
@@ -24,10 +24,6 @@ namespace GTA
 	{
 		return _hash;
 	}
-	int Model::NativeValue::get()
-	{
-		return Hash;
-	}
 	bool Model::IsValid::get()
 	{
 		return Native::Function::Call<bool>(Native::Hash::IS_MODEL_VALID, Hash);

--- a/source/scripting/Model.cpp
+++ b/source/scripting/Model.cpp
@@ -24,10 +24,10 @@ namespace GTA
 	{
 		return _hash;
 	}
-    int Model::NativeValue::get()
-    {
-        return Hash;
-    }
+	int Model::NativeValue::get()
+	{
+		return Hash;
+	}
 	bool Model::IsValid::get()
 	{
 		return Native::Function::Call<bool>(Native::Hash::IS_MODEL_VALID, Hash);
@@ -86,15 +86,15 @@ namespace GTA
 	}
 	bool Model::IsCargobob::get()
 	{
-        switch (static_cast<Native::VehicleHash>(Hash))
-        {
-            case Native::VehicleHash::Cargobob:
-            case Native::VehicleHash::Cargobob2:
-            case Native::VehicleHash::Cargobob3:
-            case Native::VehicleHash::Cargobob4:
-                return true;
-        }
-        return false;
+		switch (static_cast<Native::VehicleHash>(Hash))
+		{
+			case Native::VehicleHash::Cargobob:
+			case Native::VehicleHash::Cargobob2:
+			case Native::VehicleHash::Cargobob3:
+			case Native::VehicleHash::Cargobob4:
+				return true;
+		}
+		return false;
 	}
 
 	void Model::GetDimensions([System::Runtime::InteropServices::OutAttribute] Math::Vector3 %minimum, [System::Runtime::InteropServices::OutAttribute] Math::Vector3 %maximum)

--- a/source/scripting/Model.cpp
+++ b/source/scripting/Model.cpp
@@ -24,6 +24,10 @@ namespace GTA
 	{
 		return _hash;
 	}
+    int Model::NativeValue::get()
+    {
+        return Hash;
+    }
 	bool Model::IsValid::get()
 	{
 		return Native::Function::Call<bool>(Native::Hash::IS_MODEL_VALID, Hash);
@@ -82,7 +86,15 @@ namespace GTA
 	}
 	bool Model::IsCargobob::get()
 	{
-		return Hash == static_cast<int>(Native::VehicleHash::Cargobob) || Hash == static_cast<int>(Native::VehicleHash::Cargobob2) || Hash == static_cast<int>(Native::VehicleHash::Cargobob3) || Hash == static_cast<int>(Native::VehicleHash::Cargobob4);
+        switch (static_cast<Native::VehicleHash>(Hash))
+        {
+            case Native::VehicleHash::Cargobob:
+            case Native::VehicleHash::Cargobob2:
+            case Native::VehicleHash::Cargobob3:
+            case Native::VehicleHash::Cargobob4:
+                return true;
+        }
+        return false;
 	}
 
 	void Model::GetDimensions([System::Runtime::InteropServices::OutAttribute] Math::Vector3 %minimum, [System::Runtime::InteropServices::OutAttribute] Math::Vector3 %maximum)

--- a/source/scripting/Model.hpp
+++ b/source/scripting/Model.hpp
@@ -9,7 +9,7 @@
 
 namespace GTA
 {
-	public value class Model : System::IEquatable<Model>, INativeValue
+	public value class Model : System::IEquatable<Model>
 	{
 	public:
 		Model(int hash);
@@ -129,11 +129,6 @@ namespace GTA
 		static inline bool operator!=(Model left, Model right)
 		{
 			return !operator==(left, right);
-		}
-	protected:
-		virtual property int NativeValue
-		{
-			int get() = INativeValue::NativeValue::get;
 		}
 	private:
 		int _hash;

--- a/source/scripting/Model.hpp
+++ b/source/scripting/Model.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
 #include "Vector3.hpp"
+#include "Interface.hpp"
+
 #include "PedHashes.hpp"
 #include "VehicleHashes.hpp"
 #include "WeaponHashes.hpp"
 
 namespace GTA
 {
-	public value class Model
+    public value class Model : System::IEquatable<Model>, INativeValue
 	{
 	public:
 		Model(int hash);
@@ -87,7 +89,8 @@ namespace GTA
 		void Request();
 		bool Request(int timeout);
 		void MarkAsNoLongerNeeded();
-		virtual bool Equals(Model model);
+
+        virtual bool Equals(Model model);
 
 		virtual inline int GetHashCode() override
 		{
@@ -97,35 +100,41 @@ namespace GTA
 		{
 			return "0x" + Hash.ToString("X");
 		}
-		static inline operator Model(int source)
-		{
-			return Model(source);
-		}
-		static inline operator Model(System::String ^source)
-		{
-			return Model(source);
-		}
-		static inline operator Model(Native::PedHash source)
-		{
-			return Model(source);
-		}
-		static inline operator Model(Native::VehicleHash source)
-		{
-			return Model(source);
-		}
-		static inline operator Model(Native::WeaponHash source)
-		{
-			return Model(source);
-		}
-		static inline bool operator==(Model left, Model right)
-		{
-			return left.Equals(right);
-		}
-		static inline bool operator!=(Model left, Model right)
-		{
-			return !operator==(left, right);
-		}
 
+        static inline operator Model(int source)
+        {
+            return Model(source);
+        }
+        static inline operator Model(System::String ^source)
+        {
+            return Model(source);
+        }
+        static inline operator Model(Native::PedHash source)
+        {
+            return Model(source);
+        }
+        static inline operator Model(Native::VehicleHash source)
+        {
+            return Model(source);
+        }
+        static inline operator Model(Native::WeaponHash source)
+        {
+            return Model(source);
+        }
+
+        static inline bool operator==(Model left, Model right)
+        {
+            return left.Equals(right);
+        }
+        static inline bool operator!=(Model left, Model right)
+        {
+            return !operator==(left, right);
+        }
+    protected:
+        virtual property int NativeValue
+        {
+            int get() = INativeValue::NativeValue::get;
+        }
 	private:
 		int _hash;
 	};

--- a/source/scripting/Model.hpp
+++ b/source/scripting/Model.hpp
@@ -9,7 +9,7 @@
 
 namespace GTA
 {
-    public value class Model : System::IEquatable<Model>, INativeValue
+	public value class Model : System::IEquatable<Model>, INativeValue
 	{
 	public:
 		Model(int hash);
@@ -90,7 +90,7 @@ namespace GTA
 		bool Request(int timeout);
 		void MarkAsNoLongerNeeded();
 
-        virtual bool Equals(Model model);
+		virtual bool Equals(Model model);
 
 		virtual inline int GetHashCode() override
 		{
@@ -101,40 +101,40 @@ namespace GTA
 			return "0x" + Hash.ToString("X");
 		}
 
-        static inline operator Model(int source)
-        {
-            return Model(source);
-        }
-        static inline operator Model(System::String ^source)
-        {
-            return Model(source);
-        }
-        static inline operator Model(Native::PedHash source)
-        {
-            return Model(source);
-        }
-        static inline operator Model(Native::VehicleHash source)
-        {
-            return Model(source);
-        }
-        static inline operator Model(Native::WeaponHash source)
-        {
-            return Model(source);
-        }
+		static inline operator Model(int source)
+		{
+			return Model(source);
+		}
+		static inline operator Model(System::String ^source)
+		{
+			return Model(source);
+		}
+		static inline operator Model(Native::PedHash source)
+		{
+			return Model(source);
+		}
+		static inline operator Model(Native::VehicleHash source)
+		{
+			return Model(source);
+		}
+		static inline operator Model(Native::WeaponHash source)
+		{
+			return Model(source);
+		}
 
-        static inline bool operator==(Model left, Model right)
-        {
-            return left.Equals(right);
-        }
-        static inline bool operator!=(Model left, Model right)
-        {
-            return !operator==(left, right);
-        }
-    protected:
-        virtual property int NativeValue
-        {
-            int get() = INativeValue::NativeValue::get;
-        }
+		static inline bool operator==(Model left, Model right)
+		{
+			return left.Equals(right);
+		}
+		static inline bool operator!=(Model left, Model right)
+		{
+			return !operator==(left, right);
+		}
+	protected:
+		virtual property int NativeValue
+		{
+			int get() = INativeValue::NativeValue::get;
+		}
 	private:
 		int _hash;
 	};

--- a/source/scripting/Ped.cpp
+++ b/source/scripting/Ped.cpp
@@ -721,24 +721,24 @@ namespace GTA
 		return list;
 	}
 
-    bool PedGroup::Exists()
-    {
-        return Native::Function::Call<bool>(Native::Hash::DOES_GROUP_EXIST, Handle);
-    }
-    bool PedGroup::Exists(PedGroup ^pedGroup)
-    {
-        return !Object::ReferenceEquals(pedGroup, nullptr) && pedGroup->Exists();
-    }
+	bool PedGroup::Exists()
+	{
+		return Native::Function::Call<bool>(Native::Hash::DOES_GROUP_EXIST, Handle);
+	}
+	bool PedGroup::Exists(PedGroup ^pedGroup)
+	{
+		return !Object::ReferenceEquals(pedGroup, nullptr) && pedGroup->Exists();
+	}
 
-    bool PedGroup::Equals(Object ^value)
-    {
-        if (value == nullptr || value->GetType() != GetType())
-            return false;
+	bool PedGroup::Equals(Object ^value)
+	{
+		if (value == nullptr || value->GetType() != GetType())
+			return false;
 
-        return Equals(safe_cast<PedGroup ^>(value));
-    }
-    bool PedGroup::Equals(PedGroup ^pedGroup)
-    {
-        return !Object::ReferenceEquals(pedGroup, nullptr) && Handle == pedGroup->Handle;
-    }
+		return Equals(safe_cast<PedGroup ^>(value));
+	}
+	bool PedGroup::Equals(PedGroup ^pedGroup)
+	{
+		return !Object::ReferenceEquals(pedGroup, nullptr) && Handle == pedGroup->Handle;
+	}
 }

--- a/source/scripting/Ped.cpp
+++ b/source/scripting/Ped.cpp
@@ -659,33 +659,11 @@ namespace GTA
 	{
 		return Native::Function::Call<Ped ^>(Native::Hash::GET_PED_AS_GROUP_MEMBER, Handle, index);
 	}
-	bool PedGroup::Exists()
-	{
-		return Exists(this);
-	}
-	bool PedGroup::Exists(PedGroup ^pedGroup)
-	{
-		return !ReferenceEquals(pedGroup, nullptr) && Native::Function::Call<bool>(Native::Hash::DOES_GROUP_EXIST, pedGroup->Handle);
-	}
 	bool PedGroup::Contains(Ped ^ped)
 	{
 		return Native::Function::Call<bool>(Native::Hash::IS_PED_GROUP_MEMBER, ped->Handle, Handle);
 	}
-	bool PedGroup::Equals(Object ^value)
-	{
-		if (value == nullptr)
-			return false;
-
-		if (value->GetType() != GetType())
-			return false;
-
-		return Equals(safe_cast<PedGroup ^>(value));
-	}
-	bool PedGroup::Equals(PedGroup ^pedGroup)
-	{
-		return !System::Object::ReferenceEquals(pedGroup, nullptr) && Handle == pedGroup->Handle;
-	}
-
+	
 	array<Ped ^> ^PedGroup::ToArray(bool includingLeader)
 	{
 		const int arraySize = includingLeader ? MemberCount + 1 : MemberCount;
@@ -742,4 +720,25 @@ namespace GTA
 
 		return list;
 	}
+
+    bool PedGroup::Exists()
+    {
+        return Native::Function::Call<bool>(Native::Hash::DOES_GROUP_EXIST, Handle);
+    }
+    bool PedGroup::Exists(PedGroup ^pedGroup)
+    {
+        return !Object::ReferenceEquals(pedGroup, nullptr) && pedGroup->Exists();
+    }
+
+    bool PedGroup::Equals(Object ^value)
+    {
+        if (value == nullptr || value->GetType() != GetType())
+            return false;
+
+        return Equals(safe_cast<PedGroup ^>(value));
+    }
+    bool PedGroup::Equals(PedGroup ^pedGroup)
+    {
+        return !Object::ReferenceEquals(pedGroup, nullptr) && Handle == pedGroup->Handle;
+    }
 }

--- a/source/scripting/Ped.hpp
+++ b/source/scripting/Ped.hpp
@@ -641,19 +641,22 @@ namespace GTA
 		void Add(Ped ^ped, bool leader);
 		void Remove(Ped ^ped);
 		Ped ^GetMember(int index);
-		virtual bool Exists();
-		static bool Exists(PedGroup ^pedGroup);
 		bool Contains(Ped ^ped);
-		virtual bool Equals(System::Object ^obj) override;
-		virtual bool Equals(PedGroup ^pedGroup);
-
+		
 		array<Ped ^> ^ToArray(bool includingLeader);
 		Generic::List<Ped ^> ^ToList(bool includingLeader);
+
+        virtual bool Exists();
+        static bool Exists(PedGroup ^pedGroup);
+
+        virtual bool Equals(System::Object ^obj) override;
+        virtual bool Equals(PedGroup ^pedGroup);
 
 		virtual inline int GetHashCode() override
 		{
 			return Handle;
 		}
+
 		static inline bool operator==(PedGroup ^left, PedGroup ^right)
 		{
 			if (ReferenceEquals(left, nullptr))

--- a/source/scripting/Ped.hpp
+++ b/source/scripting/Ped.hpp
@@ -646,11 +646,11 @@ namespace GTA
 		array<Ped ^> ^ToArray(bool includingLeader);
 		Generic::List<Ped ^> ^ToList(bool includingLeader);
 
-        virtual bool Exists();
-        static bool Exists(PedGroup ^pedGroup);
+		virtual bool Exists();
+		static bool Exists(PedGroup ^pedGroup);
 
-        virtual bool Equals(System::Object ^obj) override;
-        virtual bool Equals(PedGroup ^pedGroup);
+		virtual bool Equals(System::Object ^obj) override;
+		virtual bool Equals(PedGroup ^pedGroup);
 
 		virtual inline int GetHashCode() override
 		{

--- a/source/scripting/Pickup.cpp
+++ b/source/scripting/Pickup.cpp
@@ -19,35 +19,33 @@ namespace GTA
 	{
 		return Native::Function::Call<Math::Vector3>(Native::Hash::GET_PICKUP_COORDS, Handle);
 	}
+    void Pickup::Delete()
+    {
+        return Native::Function::Call(Native::Hash::REMOVE_PICKUP, Handle);
+    }
+    bool Pickup::ObjectExists()
+    {
+        return Native::Function::Call<bool>(Native::Hash::DOES_PICKUP_OBJECT_EXIST, Handle);
+    }
 
 	bool Pickup::Exists()
 	{
-		return Exists(this);
+        return Native::Function::Call<bool>(Native::Hash::DOES_PICKUP_EXIST, Handle);
 	}
 	bool Pickup::Exists(Pickup ^pickup)
 	{
-		return !Object::ReferenceEquals(pickup, nullptr) && Native::Function::Call<bool>(Native::Hash::DOES_PICKUP_EXIST, pickup->Handle);
+        return !Object::ReferenceEquals(pickup, nullptr) && pickup->Exists();
 	}
-	bool Pickup::ObjectExists()
-	{
-		return Native::Function::Call<bool>(Native::Hash::DOES_PICKUP_OBJECT_EXIST, Handle);
-	}
-	void Pickup::Delete()
-	{
-		return Native::Function::Call(Native::Hash::REMOVE_PICKUP, Handle);
-	}
+    
 	bool Pickup::Equals(Object ^value)
 	{
-		if (value == nullptr)
-			return false;
-
-		if (value->GetType() != GetType())
+		if (value == nullptr || value->GetType() != GetType())
 			return false;
 
 		return Equals(safe_cast<Pickup ^>(value));
 	}
 	bool Pickup::Equals(Pickup ^pickup)
 	{
-		return !System::Object::ReferenceEquals(pickup, nullptr) && Handle == pickup->Handle;
+		return !Object::ReferenceEquals(pickup, nullptr) && Handle == pickup->Handle;
 	}
 }

--- a/source/scripting/Pickup.cpp
+++ b/source/scripting/Pickup.cpp
@@ -19,24 +19,24 @@ namespace GTA
 	{
 		return Native::Function::Call<Math::Vector3>(Native::Hash::GET_PICKUP_COORDS, Handle);
 	}
-    void Pickup::Delete()
-    {
-        return Native::Function::Call(Native::Hash::REMOVE_PICKUP, Handle);
-    }
-    bool Pickup::ObjectExists()
-    {
-        return Native::Function::Call<bool>(Native::Hash::DOES_PICKUP_OBJECT_EXIST, Handle);
-    }
+	void Pickup::Delete()
+	{
+		return Native::Function::Call(Native::Hash::REMOVE_PICKUP, Handle);
+	}
+	bool Pickup::ObjectExists()
+	{
+		return Native::Function::Call<bool>(Native::Hash::DOES_PICKUP_OBJECT_EXIST, Handle);
+	}
 
 	bool Pickup::Exists()
 	{
-        return Native::Function::Call<bool>(Native::Hash::DOES_PICKUP_EXIST, Handle);
+		return Native::Function::Call<bool>(Native::Hash::DOES_PICKUP_EXIST, Handle);
 	}
 	bool Pickup::Exists(Pickup ^pickup)
 	{
-        return !Object::ReferenceEquals(pickup, nullptr) && pickup->Exists();
+		return !Object::ReferenceEquals(pickup, nullptr) && pickup->Exists();
 	}
-    
+	
 	bool Pickup::Equals(Object ^value)
 	{
 		if (value == nullptr || value->GetType() != GetType())

--- a/source/scripting/Pickup.hpp
+++ b/source/scripting/Pickup.hpp
@@ -23,7 +23,7 @@ namespace GTA
 			Math::Vector3 get();
 		}
 
-        void Delete();
+		void Delete();
 		bool ObjectExists();
 
 		virtual bool Exists();

--- a/source/scripting/Pickup.hpp
+++ b/source/scripting/Pickup.hpp
@@ -23,10 +23,12 @@ namespace GTA
 			Math::Vector3 get();
 		}
 
+        void Delete();
+		bool ObjectExists();
+
 		virtual bool Exists();
 		static bool Exists(Pickup ^pickup);
-		bool ObjectExists();
-		void Delete();
+
 		virtual bool Equals(System::Object ^obj) override;
 		virtual bool Equals(Pickup ^pickup);
 
@@ -34,6 +36,7 @@ namespace GTA
 		{
 			return Handle;
 		}
+
 		static inline bool operator==(Pickup ^left, Pickup ^right)
 		{
 			if (ReferenceEquals(left, nullptr))

--- a/source/scripting/Player.cpp
+++ b/source/scripting/Player.cpp
@@ -215,8 +215,15 @@ namespace GTA
 		Native::Function::Call(Native::Hash::SET_PLAYER_MAY_NOT_ENTER_ANY_VEHICLE, Handle);
 	}
 
+    bool Player::Equals(Object ^value)
+    {
+        if (value == nullptr || value->GetType() != GetType())
+            return false;
+
+        return Equals(safe_cast<Entity ^>(value));
+    }
 	bool Player::Equals(Player ^player)
 	{
-		return !ReferenceEquals(player, nullptr) && Handle == player->Handle;
+		return !Object::ReferenceEquals(player, nullptr) && Handle == player->Handle;
 	}
 }

--- a/source/scripting/Player.cpp
+++ b/source/scripting/Player.cpp
@@ -215,13 +215,13 @@ namespace GTA
 		Native::Function::Call(Native::Hash::SET_PLAYER_MAY_NOT_ENTER_ANY_VEHICLE, Handle);
 	}
 
-    bool Player::Equals(Object ^value)
-    {
-        if (value == nullptr || value->GetType() != GetType())
-            return false;
+	bool Player::Equals(Object ^value)
+	{
+		if (value == nullptr || value->GetType() != GetType())
+			return false;
 
-        return Equals(safe_cast<Entity ^>(value));
-    }
+		return Equals(safe_cast<Entity ^>(value));
+	}
 	bool Player::Equals(Player ^player)
 	{
 		return !Object::ReferenceEquals(player, nullptr) && Handle == player->Handle;

--- a/source/scripting/Player.hpp
+++ b/source/scripting/Player.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "Vector3.hpp"
+#include "Interface.hpp"
+
 namespace GTA
 {
 	#pragma region Forward Declarations
@@ -8,12 +11,12 @@ namespace GTA
 	ref class Entity;
 	#pragma endregion
 
-	public ref class Player sealed
+    public ref class Player sealed : System::IEquatable<Player ^>, IHandleable
 	{
 	public:
 		Player(int handle);
 
-		property int Handle
+		virtual property int Handle
 		{
 			int get();
 		}
@@ -120,12 +123,21 @@ namespace GTA
 		void SetMayOnlyEnterThisVehicleThisFrame(Vehicle ^vehicle);
 		void SetMayNotEnterAnyVehicleThisFrame();
 
-		virtual bool Equals(Player ^player);
+        virtual bool Equals(System::Object ^obj) override;
+        virtual bool Equals(Player ^player);
+
+        virtual inline bool Exists() = IHandleable::Exists
+        {
+            // IHandleable forces us to implement this unfortunately,
+            // so we'll implement it explicitly and return true
+            return true;
+        }
 
 		virtual inline int GetHashCode() override
 		{
 			return Handle;
 		}
+
 		static inline bool operator==(Player ^left, Player ^right)
 		{
 			if (Object::ReferenceEquals(left, nullptr))
@@ -139,7 +151,6 @@ namespace GTA
 		{
 			return !operator==(left, right);
 		}
-
 	private:
 		int _handle;
 		Ped ^_ped;

--- a/source/scripting/Player.hpp
+++ b/source/scripting/Player.hpp
@@ -11,7 +11,7 @@ namespace GTA
 	ref class Entity;
 	#pragma endregion
 
-    public ref class Player sealed : System::IEquatable<Player ^>, IHandleable
+	public ref class Player sealed : System::IEquatable<Player ^>, IHandleable
 	{
 	public:
 		Player(int handle);
@@ -123,15 +123,15 @@ namespace GTA
 		void SetMayOnlyEnterThisVehicleThisFrame(Vehicle ^vehicle);
 		void SetMayNotEnterAnyVehicleThisFrame();
 
-        virtual bool Equals(System::Object ^obj) override;
-        virtual bool Equals(Player ^player);
+		virtual bool Equals(System::Object ^obj) override;
+		virtual bool Equals(Player ^player);
 
-        virtual inline bool Exists() = IHandleable::Exists
-        {
-            // IHandleable forces us to implement this unfortunately,
-            // so we'll implement it explicitly and return true
-            return true;
-        }
+		virtual inline bool Exists() = IHandleable::Exists
+		{
+			// IHandleable forces us to implement this unfortunately,
+			// so we'll implement it explicitly and return true
+			return true;
+		}
 
 		virtual inline int GetHashCode() override
 		{

--- a/source/scripting/Quaternion.cpp
+++ b/source/scripting/Quaternion.cpp
@@ -536,10 +536,7 @@ namespace GTA
 		}
 		bool Quaternion::Equals(Object^ value)
 		{
-			if (value == nullptr)
-				return false;
-
-			if (value->GetType() != GetType())
+			if (value == nullptr || value->GetType() != GetType())
 				return false;
 
 			return Equals(safe_cast<Quaternion>(value));
@@ -548,7 +545,7 @@ namespace GTA
 		{
 			return (X == value.X && Y == value.Y && Z == value.Z && W == value.W);
 		}
-		bool Quaternion::Equals(Quaternion% value1, Quaternion% value2)
+		bool Quaternion::Equals(Quaternion %value1, Quaternion %value2)
 		{
 			return (value1.X == value2.X && value1.Y == value2.Y && value1.Z == value2.Z && value1.W == value2.W);
 		}

--- a/source/scripting/Rope.cpp
+++ b/source/scripting/Rope.cpp
@@ -68,20 +68,20 @@ namespace GTA
 		return Native::Function::Call<Math::Vector3>(Native::Hash::GET_ROPE_VERTEX_COORD, Handle, vertex);
 	}
 
-    void Rope::Delete()
-    {
-        int handle = Handle;
-        Native::Function::Call(Native::Hash::DELETE_ROPE, &handle);
-    }
+	void Rope::Delete()
+	{
+		int handle = Handle;
+		Native::Function::Call(Native::Hash::DELETE_ROPE, &handle);
+	}
 
 	bool Rope::Exists()
 	{
-        int handle = Handle;
-        return Native::Function::Call<bool>(Native::Hash::DOES_ROPE_EXIST, &handle);
+		int handle = Handle;
+		return Native::Function::Call<bool>(Native::Hash::DOES_ROPE_EXIST, &handle);
 	}
 	bool Rope::Exists(Rope ^rope)
 	{
-        return !Object::ReferenceEquals(rope, nullptr) && rope->Exists();
+		return !Object::ReferenceEquals(rope, nullptr) && rope->Exists();
 	}
 
 	bool Rope::Equals(Object ^value)

--- a/source/scripting/Rope.cpp
+++ b/source/scripting/Rope.cpp
@@ -68,39 +68,31 @@ namespace GTA
 		return Native::Function::Call<Math::Vector3>(Native::Hash::GET_ROPE_VERTEX_COORD, Handle, vertex);
 	}
 
+    void Rope::Delete()
+    {
+        int handle = Handle;
+        Native::Function::Call(Native::Hash::DELETE_ROPE, &handle);
+    }
+
 	bool Rope::Exists()
 	{
-		return Exists(this);
+        int handle = Handle;
+        return Native::Function::Call<bool>(Native::Hash::DOES_ROPE_EXIST, &handle);
 	}
 	bool Rope::Exists(Rope ^rope)
 	{
-		if (!Object::ReferenceEquals(rope, nullptr))
-		{
-			int handle = rope->Handle;
-			return Native::Function::Call<bool>(Native::Hash::DOES_ROPE_EXIST, &handle);
-		}
-		else
-		{
-			return false;
-		}
+        return !Object::ReferenceEquals(rope, nullptr) && rope->Exists();
 	}
+
 	bool Rope::Equals(Object ^value)
 	{
-		if (value == nullptr)
-			return false;
-
-		if (value->GetType() != GetType())
+		if (value == nullptr || value->GetType() != GetType())
 			return false;
 
 		return Equals(safe_cast<Rope ^>(value));
 	}
 	bool Rope::Equals(Rope ^rope)
 	{
-		return !System::Object::ReferenceEquals(rope, nullptr) && Handle == rope->Handle;
-	}
-	void Rope::Delete()
-	{
-		int handle = Handle;
-		Native::Function::Call(Native::Hash::DELETE_ROPE, &handle);
+		return !Object::ReferenceEquals(rope, nullptr) && Handle == rope->Handle;
 	}
 }

--- a/source/scripting/Rope.hpp
+++ b/source/scripting/Rope.hpp
@@ -39,7 +39,7 @@ namespace GTA
 		void UnpinVertex(int vertex);
 		Math::Vector3 GetVertexCoord(int vertex);
 
-        void Delete();
+		void Delete();
 
 		virtual bool Exists();
 		static bool Exists(Rope ^rope);

--- a/source/scripting/Rope.hpp
+++ b/source/scripting/Rope.hpp
@@ -39,9 +39,11 @@ namespace GTA
 		void UnpinVertex(int vertex);
 		Math::Vector3 GetVertexCoord(int vertex);
 
+        void Delete();
+
 		virtual bool Exists();
 		static bool Exists(Rope ^rope);
-		void Delete();
+		
 		virtual bool Equals(System::Object ^obj) override;
 		virtual bool Equals(Rope ^rope);
 
@@ -49,6 +51,7 @@ namespace GTA
 		{
 			return Handle;
 		}
+
 		static inline bool operator==(Rope ^left, Rope ^right)
 		{
 			if (ReferenceEquals(left, nullptr))

--- a/source/scripting/Vector2.cpp
+++ b/source/scripting/Vector2.cpp
@@ -249,10 +249,7 @@ namespace GTA
 		}
 		bool Vector2::Equals(Object ^value)
 		{
-			if (value == nullptr)
-				return false;
-
-			if (value->GetType() != GetType())
+			if (value == nullptr || value->GetType() != GetType())
 				return false;
 
 			return Equals(safe_cast<Vector2>(value));

--- a/source/scripting/Vector3.cpp
+++ b/source/scripting/Vector3.cpp
@@ -335,10 +335,7 @@ namespace GTA
 		}
 		bool Vector3::Equals(Object ^value)
 		{
-			if (value == nullptr)
-				return false;
-
-			if (value->GetType() != GetType())
+			if (value == nullptr || value->GetType() != GetType())
 				return false;
 
 			return Equals(safe_cast<Vector3>(value));


### PR DESCRIPTION
**EDIT:** _The `INativeValue` interface has been removed -- this is now mainly a code refactoring pull request._

--
I've implemented the proposed interface as disccused in issue #438. `Native::ObjectToNative` will now check if the object implements the `INativeValue` or `IHandleable` interface to retrieve the appropriate value.

I've also updated a couple of classes to inherit from some common interfaces (e.g. `System::IEquatable<T>`, `IHandleable`, etc). I figured I'd do some code cleanup while I was at it, so there's quite a few updates as well. Everything should still be 100% backwards compatible.