### PR TITLE
Added NightVision and Parachute to WeaponHashes

### DIFF
--- a/source/scripting/WeaponHashes.hpp
+++ b/source/scripting/WeaponHashes.hpp
@@ -73,6 +73,8 @@ namespace GTA
 			Flashlight = 0x8BB05FD7,
 			Ball = 0x23C9F95C,
 			Flare = 0x497FACC3,
+			NightVision = 0xA720365C,
+			Parachute = 0xFBAB5776
 		};
 	}
 }


### PR DESCRIPTION
So, the only problem with this: `Parachute` and `NightVision` don't have any Models nor any other properties of `Weapon`.

Another way of implementing this:
Make a new Enum called `GadgetHash`, include both, and make a new function called `Ped.GiveGadget(GadgetHash hash)`. But since there are just those 2 gadgets, I don't know if it's worth the extra stuff.

@crosire 