### PR TITLE
Update ScriptDomain class

### DIFF
--- a/source/core/ScriptDomain.cpp
+++ b/source/core/ScriptDomain.cpp
@@ -17,6 +17,7 @@
 #include "ScriptDomain.hpp"
 
 using namespace System;
+using namespace System::IO;
 using namespace System::Threading;
 using namespace System::Reflection;
 using namespace System::Windows::Forms;
@@ -40,15 +41,13 @@ namespace GTA
 {
 	void Log(String ^logLevel, ... array<String ^> ^message)
 	{
-		DateTime now = DateTime::Now;
-		String ^logpath = IO::Path::ChangeExtension(Assembly::GetExecutingAssembly()->Location, ".log");
-
-		logpath = logpath->Insert(logpath->IndexOf(".log"), "-" + now.ToString("yyyy-MM-dd"));
+		auto now = DateTime::Now;
+		auto logPath = String::Format("{0}-{1}.log", Assembly::GetExecutingAssembly()->Location, now.ToString("yyyy-MM-dd"));
 
 		try
 		{
-			auto fs = gcnew IO::FileStream(logpath, IO::FileMode::Append, IO::FileAccess::Write, IO::FileShare::Read);
-			auto sw = gcnew IO::StreamWriter(fs);
+			auto fs = gcnew FileStream(logPath, FileMode::Append, FileAccess::Write, FileShare::Read);
+			auto sw = gcnew StreamWriter(fs);
 
 			try
 			{
@@ -72,9 +71,13 @@ namespace GTA
 			return;
 		}
 	}
+	void Logf(String ^logLevel, String ^format, ... array<Object ^> ^args)
+	{
+		Log(logLevel, String::Format(format, args));
+	}
 	Assembly ^HandleResolve(Object ^sender, ResolveEventArgs ^args)
 	{
-		auto assembly = GTA::Script::typeid->Assembly;
+		auto assembly = Script::typeid->Assembly;
 		auto assemblyName = gcnew AssemblyName(args->Name);
 
 		if (assemblyName->Name->StartsWith("ScriptHookVDotNet", StringComparison::CurrentCultureIgnoreCase) &&
@@ -96,69 +99,74 @@ namespace GTA
 			Log("[ERROR]", "Caught fatal unhandled exception:", Environment::NewLine, args->ExceptionObject->ToString());
 		}
 	}
-
-	ScriptDomain::ScriptDomain() : _appdomain(System::AppDomain::CurrentDomain), _executingThreadId(Thread::CurrentThread->ManagedThreadId), _runningScripts(gcnew List<Script ^>()), _taskQueue(gcnew Queue<IScriptTask ^>()), _pinnedStrings(gcnew List<IntPtr>()), _scriptTypes(gcnew List<Tuple<String ^, Type ^> ^>()), _recordKeyboardEvents(true), _keyboardState(gcnew array<bool>(256))
+	ScriptDomain::ScriptDomain() :
+		_appDomain(System::AppDomain::CurrentDomain),
+		_executingThreadId(Thread::CurrentThread->ManagedThreadId)
 	{
 		sCurrentDomain = this;
 
-		_appdomain->AssemblyResolve += gcnew ResolveEventHandler(&HandleResolve);
-		_appdomain->UnhandledException += gcnew UnhandledExceptionEventHandler(&HandleUnhandledException);
+		_appDomain->AssemblyResolve += gcnew ResolveEventHandler(&HandleResolve);
+		_appDomain->UnhandledException += gcnew UnhandledExceptionEventHandler(&HandleUnhandledException);
 
-		Log("[DEBUG]", "Created script domain '", _appdomain->FriendlyName, "' with v", ScriptDomain::typeid->Assembly->GetName()->Version->ToString(3), ".");
+		Logf("[DEBUG]", "Created script domain '{0}' with v{1}.", _appDomain->FriendlyName,
+			ScriptDomain::typeid->Assembly->GetName()->Version->ToString(3));
 	}
 	ScriptDomain::~ScriptDomain()
 	{
 		CleanupStrings();
 
-		Log("[DEBUG]", "Deleted script domain '", _appdomain->FriendlyName, "'.");
+		Logf("[DEBUG]", "Deleted script domain '{0}'.", _appDomain->FriendlyName);
 	}
 
 	ScriptDomain ^ScriptDomain::Load(String ^path)
 	{
-		path = IO::Path::GetFullPath(path);
+		path = Path::GetFullPath(path);
 
-		AppDomainSetup ^setup = gcnew AppDomainSetup();
+		auto setup = gcnew AppDomainSetup();
 		setup->ApplicationBase = path;
 		setup->ShadowCopyFiles = "true";
 		setup->ShadowCopyDirectories = path;
-		Security::PermissionSet ^permissions = gcnew Security::PermissionSet(Security::Permissions::PermissionState::Unrestricted);
 
-		System::AppDomain ^appdomain = System::AppDomain::CreateDomain("ScriptDomain_" + (path->GetHashCode() * Environment::TickCount).ToString("X"), nullptr, setup, permissions);
-		appdomain->InitializeLifetimeService();
+		auto permissions = gcnew Security::PermissionSet(Security::Permissions::PermissionState::Unrestricted);
+
+		auto appDomainName = String::Format("ScriptDomain_{0:X}", (path->GetHashCode() * Environment::TickCount));
+		auto appDomain = System::AppDomain::CreateDomain(appDomainName, nullptr, setup, permissions);
+
+		appDomain->InitializeLifetimeService();
 
 		ScriptDomain ^scriptdomain = nullptr;
 
 		try
 		{
-			scriptdomain = static_cast<ScriptDomain ^>(appdomain->CreateInstanceFromAndUnwrap(ScriptDomain::typeid->Assembly->Location, ScriptDomain::typeid->FullName));
+			scriptdomain = static_cast<ScriptDomain ^>(appDomain->CreateInstanceFromAndUnwrap(ScriptDomain::typeid->Assembly->Location, ScriptDomain::typeid->FullName));
 		}
 		catch (Exception ^ex)
 		{
-			Log("[ERROR]", "Failed to create script domain '", appdomain->FriendlyName, "':", Environment::NewLine, ex->ToString());
+			Logf("[ERROR]", "Failed to create script domain '{0}':{1}{2}", appDomainName, Environment::NewLine, ex);
 
-			System::AppDomain::Unload(appdomain);
+			System::AppDomain::Unload(appDomain);
 
 			return nullptr;
 		}
 
-		Log("[DEBUG]", "Loading scripts from '", path, "' into script domain '", appdomain->FriendlyName, "' ...");
+		Logf("[DEBUG]", "Loading scripts from '{0}' into script domain '{1}' ...", path, appDomainName);
 
-		if (IO::Directory::Exists(path))
+		if (Directory::Exists(path))
 		{
-			List<String ^> ^filenameScripts = gcnew List<String ^>();
-			List<String ^> ^filenameAssemblies = gcnew List<String ^>();
+			auto filenameScripts = gcnew List<String ^>();
+			auto filenameAssemblies = gcnew List<String ^>();
 
 			try
 			{
-				filenameScripts->AddRange(IO::Directory::GetFiles(path, "*.vb", IO::SearchOption::AllDirectories));
-				filenameScripts->AddRange(IO::Directory::GetFiles(path, "*.cs", IO::SearchOption::AllDirectories));
-				filenameAssemblies->AddRange(IO::Directory::GetFiles(path, "*.dll", IO::SearchOption::AllDirectories));
+				filenameScripts->AddRange(Directory::GetFiles(path, "*.vb", SearchOption::AllDirectories));
+				filenameScripts->AddRange(Directory::GetFiles(path, "*.cs", SearchOption::AllDirectories));
+				filenameAssemblies->AddRange(Directory::GetFiles(path, "*.dll", SearchOption::AllDirectories));
 			}
 			catch (Exception ^ex)
 			{
 				Log("[ERROR]", "Failed to reload scripts:", Environment::NewLine, ex->ToString());
 
-				System::AppDomain::Unload(appdomain);
+				System::AppDomain::Unload(appDomain);
 
 				return nullptr;
 			}
@@ -174,27 +182,28 @@ namespace GTA
 		}
 		else
 		{
-			Log("[ERROR]", "Failed to reload scripts because directory is missing.");
+			Log("[ERROR]", "Failed to reload scripts because the directory is missing.");
 		}
 
 		return scriptdomain;
 	}
 	bool ScriptDomain::LoadScript(String ^filename)
 	{
-		CodeDom::Compiler::CodeDomProvider ^compiler = nullptr;
-		CodeDom::Compiler::CompilerParameters ^compilerOptions = gcnew CodeDom::Compiler::CompilerParameters();
+		auto compilerOptions = gcnew CodeDom::Compiler::CompilerParameters();
 		compilerOptions->CompilerOptions = "/optimize";
 		compilerOptions->GenerateInMemory = true;
 		compilerOptions->IncludeDebugInformation = true;
-		compilerOptions->ReferencedAssemblies->Add("System.dll");
-		compilerOptions->ReferencedAssemblies->Add("System.Core.dll");
-		compilerOptions->ReferencedAssemblies->Add("System.Drawing.dll");
-		compilerOptions->ReferencedAssemblies->Add("System.Windows.Forms.dll");
-		compilerOptions->ReferencedAssemblies->Add("System.XML.dll");
-		compilerOptions->ReferencedAssemblies->Add("System.XML.Linq.dll");
-		compilerOptions->ReferencedAssemblies->Add(GTA::Script::typeid->Assembly->Location);
 
-		String ^extension = IO::Path::GetExtension(filename);
+		for each (auto assembly in _referenceAssemblies)
+		{
+			compilerOptions->ReferencedAssemblies->Add(assembly);
+		}
+
+		compilerOptions->ReferencedAssemblies->Add(Script::typeid->Assembly->Location);
+
+		CodeDom::Compiler::CodeDomProvider ^compiler = nullptr;
+
+		auto extension = Path::GetExtension(filename);
 
 		if (extension->Equals(".cs", StringComparison::InvariantCultureIgnoreCase))
 		{
@@ -207,69 +216,59 @@ namespace GTA
 		}
 		else
 		{
+			Logf("[DEBUG]", "Could not load script file '{0}': Unknown file extension '{1}'.", filename, extension);
+
 			return false;
 		}
 
-		CodeDom::Compiler::CompilerResults ^compilerResult = compiler->CompileAssemblyFromFile(compilerOptions, filename);
+		auto compilerResult = compiler->CompileAssemblyFromFile(compilerOptions, filename);
 
 		if (!compilerResult->Errors->HasErrors)
 		{
-			Log("[DEBUG]", "Successfully compiled '", IO::Path::GetFileName(filename), "'.");
+			Logf("[DEBUG]", "Successfully compiled '{0}'.", Path::GetFileName(filename));
 
 			return LoadAssembly(filename, compilerResult->CompiledAssembly);
 		}
 		else
 		{
-			Text::StringBuilder ^errors = gcnew Text::StringBuilder();
+			auto errors = gcnew Text::StringBuilder();
 
-			for (int i = 0; i < compilerResult->Errors->Count; ++i)
+			errors->AppendFormat("Failed to compile '{0}' with {1} error(s):", Path::GetFileName(filename), compilerResult->Errors->Count);
+			errors->AppendLine();
+
+			for each (CodeDom::Compiler::CompilerError ^err in compilerResult->Errors)
 			{
-				errors->Append("   at line ");
-				errors->Append(compilerResult->Errors->default[i]->Line);
-				errors->Append(": ");
-				errors->Append(compilerResult->Errors->default[i]->ErrorText);
-
-				if (i < compilerResult->Errors->Count - 1)
-				{
-					errors->AppendLine();
-				}
+				errors->AppendFormat("   at line {0}: {1}", err->Line, err->ErrorText);
+				errors->AppendLine();
 			}
 
-			Log("[ERROR]", "Failed to compile '", IO::Path::GetFileName(filename), "' with ", compilerResult->Errors->Count.ToString(), " error(s):", Environment::NewLine, errors->ToString());
+			Log("[ERROR]", errors->ToString());
 
 			return false;
 		}
 	}
-	bool ScriptDomain::LoadAssembly(String ^filename)
-	{
-		if (IO::Path::GetFileNameWithoutExtension(filename)->StartsWith("ScriptHookVDotNet", StringComparison::CurrentCultureIgnoreCase))
-		{
-			Log("[ERROR]", "Skipped assembly '", IO::Path::GetFileName(filename), "'. Please remove it from the 'scripts' directory.");
-
-			return false;
-		}
-
-		Assembly ^assembly = nullptr;
-
-		try
-		{
-			assembly = Assembly::LoadFrom(filename);
-		}
-		catch (Exception ^ex)
-		{
-			Log("[ERROR]", "Failed to load assembly '", IO::Path::GetFileName(filename), "':", Environment::NewLine, ex->ToString());
-
-			return false;
-		}
-
-		return LoadAssembly(filename, assembly);
-	}
+    bool ScriptDomain::LoadAssembly(String ^filename)
+    {
+        return LoadAssembly(filename, nullptr);
+    }
 	bool ScriptDomain::LoadAssembly(String ^filename, Assembly ^assembly)
 	{
-		unsigned int count = 0;
+		if (Path::GetFileNameWithoutExtension(filename)->StartsWith("ScriptHookVDotNet", StringComparison::CurrentCultureIgnoreCase))
+		{
+			Logf("[ERROR]", "Skipped assembly '{0}'. Please remove it from the 'scripts' directory.", Path::GetFileName(filename));
+
+			return false;
+		}
+
+		auto count = 0u;
 
 		try
 		{
+			if (Object::ReferenceEquals(assembly, nullptr))
+			{
+				assembly = Assembly::LoadFrom(filename);
+			}
+
 			for each (auto type in assembly->GetTypes())
 			{
 				if (!type->IsSubclassOf(Script::typeid))
@@ -281,20 +280,20 @@ namespace GTA
 				_scriptTypes->Add(gcnew Tuple<String ^, Type ^>(filename, type));
 			}
 		}
-		catch (ReflectionTypeLoadException ^ex)
+		catch (Exception ^ex)
 		{
-			Log("[ERROR]", "Failed to load assembly '", IO::Path::GetFileName(filename), "':", Environment::NewLine, ex->ToString());
+			Logf("[ERROR]", "Failed to load assembly '{0}':{1}{2}", Path::GetFileName(filename), Environment::NewLine, ex);
 
 			return false;
 		}
 
-		Log("[DEBUG]", "Found ", count.ToString(), " script(s) in '", IO::Path::GetFileName(filename), "'.");
+		Logf("[DEBUG]", "Found {0} script(s) in '{1}'.", count.ToString(), Path::GetFileName(filename));
 
 		return count != 0;
 	}
 	void ScriptDomain::Unload(ScriptDomain ^%domain)
 	{
-		Log("[DEBUG]", "Unloading script domain '", domain->Name, "' ...");
+		Logf("[DEBUG]", "Unloading script domain '{0}' ...", domain->Name);
 
 		domain->Abort();
 
@@ -322,7 +321,7 @@ namespace GTA
 			return nullptr;
 		}
 
-		Log("[DEBUG]", "Instantiating script '", scripttype->FullName, "' in script domain '", Name, "' ...");
+		Logf("[DEBUG]", "Instantiating script '{0}' in script domain '{1}' ....", scripttype->FullName, Name);
 
 		try
 		{
@@ -330,15 +329,15 @@ namespace GTA
 		}
 		catch (MissingMethodException ^)
 		{
-			Log("[ERROR]", "Failed to instantiate script '", scripttype->FullName, "' because no public default constructor was found.");
+			Logf("[ERROR]", "Failed to instantiate script '{0}' because no public default constructor was found.", scripttype->FullName);
 		}
 		catch (TargetInvocationException ^ex)
 		{
-			Log("[ERROR]", "Failed to instantiate script '", scripttype->FullName, "' because constructor threw an exception:", Environment::NewLine, ex->InnerException->ToString());
+			Logf("[ERROR]", "Failed to instantiate script '{0}' because constructor threw an exception:{1}{2}", scripttype->FullName, Environment::NewLine, ex->InnerException);
 		}
 		catch (Exception ^ex)
 		{
-			Log("[ERROR]", "Failed to instantiate script '", scripttype->FullName, "':", Environment::NewLine, ex->ToString());
+			Logf("[ERROR]", "Failed to instantiate script '{0}':{1}{2}", scripttype->FullName, Environment::NewLine, ex);
 		}
 
 		return nullptr;
@@ -401,10 +400,10 @@ namespace GTA
 			return;
 		}
 
-		String ^assemblyPath = Assembly::GetExecutingAssembly()->Location;
-		String ^assemblyFilename = IO::Path::GetFileNameWithoutExtension(assemblyPath);
+		auto assemblyPath = Assembly::GetExecutingAssembly()->Location;
+		auto assemblyFilename = Path::GetFileNameWithoutExtension(assemblyPath);
 
-		for each (String ^path in IO::Directory::GetFiles(IO::Path::GetDirectoryName(assemblyPath), "*.log"))
+		for each (auto path in Directory::GetFiles(Path::GetDirectoryName(assemblyPath), "*.log"))
 		{
 			if (!path->StartsWith(assemblyFilename))
 			{
@@ -413,12 +412,12 @@ namespace GTA
 
 			try
 			{
-				TimeSpan logAge = DateTime::Now - DateTime::Parse(IO::Path::GetFileNameWithoutExtension(path)->Substring(path->IndexOf('-') + 1));
+				auto logAge = DateTime::Now - DateTime::Parse(Path::GetFileNameWithoutExtension(path)->Substring(path->IndexOf('-') + 1));
 
 				// Delete logs older than 5 days
 				if (logAge.Days >= 5)
 				{
-					IO::File::Delete(path);
+					File::Delete(path);
 				}
 			}
 			catch (...)
@@ -427,16 +426,16 @@ namespace GTA
 			}
 		}
 
-		Log("[DEBUG]", "Starting ", _scriptTypes->Count.ToString(), " script(s) ...");
+		Logf("[DEBUG]", "Starting {0} script(s) ...", _scriptTypes->Count);
 
 		if (!SortScripts(_scriptTypes))
 		{
 			return;
 		}
 
-		for each (Tuple<String ^, Type ^> ^scripttype in _scriptTypes)
+		for each (auto scripttype in _scriptTypes)
 		{
-			Script ^script = InstantiateScript(scripttype->Item2);
+			auto script = InstantiateScript(scripttype->Item2);
 
 			if (Object::ReferenceEquals(script, nullptr))
 			{
@@ -450,14 +449,14 @@ namespace GTA
 
 			script->_thread->Start();
 
-			Log("[DEBUG]", "Started script '", script->Name, "'.");
+			Logf("[DEBUG]", "Started script '{0}'.", script->Name);
 
 			_runningScripts->Add(script);
 		}
 	}
 	void ScriptDomain::Abort()
 	{
-		Log("[DEBUG]", "Stopping ", _runningScripts->Count.ToString(), " script(s) ...");
+		Logf("[DEBUG]", "Stopping {0} script(s) ...", _runningScripts->Count);
 
 		for each (Script ^script in _runningScripts)
 		{
@@ -483,7 +482,7 @@ namespace GTA
 		script->_thread->Abort();
 		script->_thread = nullptr;
 
-		Log("[DEBUG]", "Aborted script '", script->Name, "'.");
+		Logf("[DEBUG]", "Aborted script '{0}'.", script->Name);
 	}
 	void ScriptDomain::DoTick()
 	{
@@ -506,7 +505,7 @@ namespace GTA
 
 			if (!script->_running)
 			{
-				Log("[ERROR]", "Script '", script->Name, "' is not responding! Aborting ...");
+				Logf("[ERROR]", "Script '{0}' is not responding! Aborting ...", script->Name);
 
 				AbortScript(script);
 				continue;
@@ -522,15 +521,24 @@ namespace GTA
 
 		if (keycode < 0 || keycode >= 256)
 		{
-			return;
+            return;
 		}
 
 		_keyboardState[keycode] = status;
 
 		if (_recordKeyboardEvents)
 		{
-			KeyEventArgs ^args = gcnew KeyEventArgs(key | (statusCtrl ? Keys::Control : Keys::None) | (statusShift ? Keys::Shift : Keys::None) | (statusAlt ? Keys::Alt : Keys::None));
-			Tuple<bool, KeyEventArgs ^> ^eventinfo = gcnew Tuple<bool, KeyEventArgs ^>(status, args);
+			auto keyData = key;
+			
+			if (statusCtrl)
+				keyData = (keyData |Keys::Control);
+			if (statusShift)
+				keyData = (keyData | Keys::Shift);
+			if (statusAlt)
+				keyData = (keyData | Keys::Alt);
+
+			auto args = gcnew KeyEventArgs(key);
+			auto eventinfo = gcnew Tuple<bool, KeyEventArgs ^>(status, args);
 
 			for each (Script ^script in _runningScripts)
 			{
@@ -558,10 +566,12 @@ namespace GTA
 	}
 	IntPtr ScriptDomain::PinString(String ^string)
 	{
-		const int size = Text::Encoding::UTF8->GetByteCount(string);
+		auto bytes = Text::Encoding::UTF8->GetBytes(string);
+		auto size = bytes->Length;
+
 		IntPtr handle(new unsigned char[size + 1]());
 
-		Runtime::InteropServices::Marshal::Copy(Text::Encoding::UTF8->GetBytes(string), 0, handle, size);
+		Runtime::InteropServices::Marshal::Copy(bytes, 0, handle, size);
 
 		_pinnedStrings->Add(handle);
 
@@ -578,7 +588,7 @@ namespace GTA
 	}
 	String ^ScriptDomain::LookupScriptFilename(Type ^type)
 	{
-		for each (Tuple<String ^, Type ^> ^scripttype in _scriptTypes)
+		for each (auto scripttype in _scriptTypes)
 		{
 			if (scripttype->Item2 == type)
 			{

--- a/source/core/ScriptDomain.hpp
+++ b/source/core/ScriptDomain.hpp
@@ -18,14 +18,20 @@
 
 #include "Script.hpp"
 
+using namespace System;
+using namespace System::Threading;
+using namespace System::Reflection;
+using namespace System::Windows::Forms;
+using namespace System::Collections::Generic;
+
 namespace GTA
 {
 	private interface class IScriptTask
 	{
 		void Run();
 	};
-
-	private ref class ScriptDomain sealed : public System::MarshalByRefObject
+    
+	private ref class ScriptDomain sealed : public MarshalByRefObject
 	{
 	public:
 		ScriptDomain();
@@ -35,7 +41,7 @@ namespace GTA
 		{
 			Script ^get()
 			{
-				if (System::Object::ReferenceEquals(sCurrentDomain, nullptr))
+				if (Object::ReferenceEquals(sCurrentDomain, nullptr))
 				{
 					return nullptr;
 				}
@@ -51,21 +57,21 @@ namespace GTA
 			}
 		}
 
-		static ScriptDomain ^Load(System::String ^path);
+		static ScriptDomain ^Load(String ^path);
 		static void Unload(ScriptDomain ^%domain);
 
 		property System::String ^Name
 		{
 			inline System::String ^get()
 			{
-				return _appdomain->FriendlyName;
+				return _appDomain->FriendlyName;
 			}
 		}
 		property System::AppDomain ^AppDomain
 		{
 			inline System::AppDomain ^get()
 			{
-				return _appdomain;
+				return _appDomain;
 			}
 		}
 
@@ -73,12 +79,12 @@ namespace GTA
 		void Abort();
 		static void AbortScript(Script ^script);
 		void DoTick();
-		void DoKeyboardMessage(System::Windows::Forms::Keys key, bool status, bool statusCtrl, bool statusShift, bool statusAlt);
+		void DoKeyboardMessage(Keys key, bool status, bool statusCtrl, bool statusShift, bool statusAlt);
 
 		void PauseKeyboardEvents(bool pause);
 		void ExecuteTask(IScriptTask ^task);
-		System::IntPtr PinString(System::String ^string);
-		inline bool IsKeyPressed(System::Windows::Forms::Keys key)
+		IntPtr PinString(String ^string);
+		inline bool IsKeyPressed(Keys key)
 		{
 			return _keyboardState[static_cast<int>(key)];
 		}
@@ -86,25 +92,36 @@ namespace GTA
 		{
 			return LookupScriptFilename(script->GetType());
 		}
-		System::String ^LookupScriptFilename(System::Type ^scripttype);
-		System::Object ^InitializeLifetimeService() override;
+		String ^LookupScriptFilename(Type ^scripttype);
+		Object ^InitializeLifetimeService() override;
 
 	private:
-		bool LoadScript(System::String ^filename);
-		bool LoadAssembly(System::String ^filename);
-		bool LoadAssembly(System::String ^filename, System::Reflection::Assembly ^assembly);
-		Script ^InstantiateScript(System::Type ^scripttype);
+		bool LoadScript(String ^filename);
+        bool LoadAssembly(String ^filename);
+		bool LoadAssembly(String ^filename, Assembly ^assembly);
+		Script ^InstantiateScript(Type ^scripttype);
 		void CleanupStrings();
 
 		static ScriptDomain ^sCurrentDomain;
-		System::AppDomain ^_appdomain;
+
+		System::AppDomain ^_appDomain;
 		int _executingThreadId;
 		Script ^_executingScript;
-		System::Collections::Generic::List<Script ^> ^_runningScripts;
-		System::Collections::Generic::Queue<IScriptTask ^> ^_taskQueue;
-		System::Collections::Generic::List<System::IntPtr> ^_pinnedStrings;
-		System::Collections::Generic::List<System::Tuple<System::String ^, System::Type ^> ^> ^_scriptTypes;
-		bool _recordKeyboardEvents;
-		array<bool> ^_keyboardState;
+
+		List<Script ^> ^_runningScripts = gcnew List<Script ^>();
+        System::Collections::Generic::Queue<IScriptTask ^> ^_taskQueue = gcnew System::Collections::Generic::Queue<IScriptTask ^>();
+		List<IntPtr> ^_pinnedStrings = gcnew List<IntPtr>();
+		List<Tuple<String ^, Type ^> ^> ^_scriptTypes = gcnew List<Tuple<String ^, Type ^> ^>();
+		bool _recordKeyboardEvents = true;
+		array<bool> ^_keyboardState = gcnew array<bool>(256);
+
+		static initonly array<String ^> ^_referenceAssemblies = gcnew array<String ^> {
+			"System.dll",
+			"System.Core.dll",
+			"System.Drawing.dll",
+			"System.Windows.Forms.dll",
+			"System.XML.dll",
+			"System.XML.Linq.dll",
+		};
 	};
 }


### PR DESCRIPTION
I've made the following changes to the ScriptDomain class:

* Added `Logf` function for adding formatted strings to the log file.
* Moved reference assembly names to an array.
* Changed behavior of `LoadAssembly(String)`:
  - Moved code to `LoadAssembly(String, Assembly)`:
    - Will now load the assembly from the file if assembly parameter is null
* Cleaned up overall code formatting:
  - Use of `auto` keyword in places where applicable.
  - Use of `String.Format` in places where appropriate.
  - Moved initialization of some private variables to class declaration.
  - Created local variables for things referenced more than once.
  - Converted all spaces to tabs.