### PR TITLE
Add Checkpoint class

### DIFF
--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -85,6 +85,7 @@
     <ClCompile Include="source\scripting\Audio.cpp" />
     <ClCompile Include="source\scripting\Blip.cpp" />
     <ClCompile Include="source\scripting\Camera.cpp" />
+    <ClCompile Include="source\scripting\Checkpoint.cpp" />
     <ClCompile Include="source\scripting\Entity.cpp" />
     <ClCompile Include="source\scripting\Euphoria.cpp" />
     <ClCompile Include="source\scripting\EuphoriaBase.cpp" />
@@ -111,8 +112,9 @@
   <ItemGroup>
     <ClInclude Include="source\scripting\Audio.hpp" />
     <ClInclude Include="source\scripting\Blip.hpp" />
-    <ClInclude Include="source\scripting\Controls.hpp" />
     <ClInclude Include="source\scripting\Camera.hpp" />
+    <ClInclude Include="source\scripting\Checkpoint.hpp" />
+    <ClInclude Include="source\scripting\Controls.hpp" />
     <ClInclude Include="source\scripting\Entity.hpp" />
     <ClInclude Include="source\scripting\Euphoria.hpp" />
     <ClInclude Include="source\scripting\EuphoriaBase.hpp" />

--- a/ScriptHookVDotNet.vcxproj.filters
+++ b/ScriptHookVDotNet.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClCompile Include="source\scripting\WeaponAsset.cpp">
       <Filter>scripting\World</Filter>
     </ClCompile>
+    <ClCompile Include="source\scripting\Checkpoint.cpp">
+      <Filter>scripting\World</Filter>
+    </ClCompile>
     <ClCompile Include="source\AssemblyInfo.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -232,6 +235,9 @@
       <Filter>scripting</Filter>
     </ClInclude>
     <ClInclude Include="source\scripting\WeaponAsset.hpp">
+      <Filter>scripting\World</Filter>
+    </ClInclude>
+    <ClInclude Include="source\scripting\Checkpoint.hpp">
       <Filter>scripting\World</Filter>
     </ClInclude>
   </ItemGroup>

--- a/source/scripting/Checkpoint.cpp
+++ b/source/scripting/Checkpoint.cpp
@@ -1,0 +1,88 @@
+#include "Checkpoint.hpp"
+#include "Native.hpp"
+
+namespace GTA
+{
+    using namespace Math;
+    using namespace System;
+
+    Checkpoint::Checkpoint(CheckpointIcon icon, Math::Vector3 position, Math::Vector3 pointTo, float radius, System::Drawing::Color color)
+        : Checkpoint(icon, position, pointTo, radius, color, 0)
+    {
+    }
+    Checkpoint::Checkpoint(CheckpointIcon icon, Math::Vector3 position, Math::Vector3 pointTo, float radius, System::Drawing::Color color, int reserved) : _icon(icon), _position(position), _pointTo(pointTo), _radius(radius), _color(color), _reserved(reserved)
+    {
+        _handle = Native::Function::Call<int>(Native::Hash::CREATE_CHECKPOINT, static_cast<int>(icon), position.X, position.Y, position.Z, pointTo.X, pointTo.Y, pointTo.Z, radius, static_cast<int>(color.R), static_cast<int>(color.G), static_cast<int>(color.B), static_cast<int>(color.A), reserved);
+    }
+    Checkpoint::~Checkpoint()
+    {
+        Delete();
+    }
+
+    int Checkpoint::Handle::get()
+    {
+        return _handle;
+    }
+    CheckpointIcon Checkpoint::Icon::get()
+    {
+        return _icon;
+    }
+    Vector3 Checkpoint::Position::get()
+    {
+        return _position;
+    }
+    Vector3 Checkpoint::PointTo::get()
+    {
+        return _pointTo;
+    }
+    float Checkpoint::Radius::get()
+    {
+        return _radius;
+    }
+    System::Drawing::Color Checkpoint::Color::get()
+    {
+        return _color;
+    }
+    void Checkpoint::Color::set(System::Drawing::Color color)
+    {
+        Native::Function::Call(Native::Hash::SET_CHECKPOINT_RGBA, Handle, static_cast<int>(color.R), static_cast<int>(color.G), static_cast<int>(color.B), static_cast<int>(color.A));
+        _color = color;
+    }
+
+    void Checkpoint::SetCylinderHeight(float nearHeight, float farHeight, float radius)
+    {
+        Native::Function::Call(Native::Hash::SET_CHECKPOINT_CYLINDER_HEIGHT, Handle, nearHeight, farHeight, radius);
+        _radius = radius;
+    }
+    void Checkpoint::SetIconColor(System::Drawing::Color color)
+    {
+        Native::Function::Call(Native::Hash::_SET_CHECKPOINT_ICON_RGBA, Handle, static_cast<int>(color.R), static_cast<int>(color.G), static_cast<int>(color.B), static_cast<int>(color.A));
+    }
+
+    void Checkpoint::Delete()
+    {
+        Native::Function::Call(Native::Hash::DELETE_CHECKPOINT, Handle);
+        _handle = -1;
+    }
+
+    bool Checkpoint::Exists()
+    {
+        return (_handle != -1);
+    }
+    bool Checkpoint::Exists(Checkpoint ^checkpoint)
+    {
+        return checkpoint->Exists();
+    }
+
+    bool Checkpoint::Equals(System::Object ^obj)
+    {
+        if (obj == nullptr || obj->GetType() != GetType())
+            return false;
+
+        return Equals(safe_cast<Checkpoint ^>(obj));
+    }
+    bool Checkpoint::Equals(GTA::Checkpoint ^checkpoint)
+    {
+        return !Object::ReferenceEquals(checkpoint, nullptr) && Handle == checkpoint->Handle;
+    }
+}

--- a/source/scripting/Checkpoint.cpp
+++ b/source/scripting/Checkpoint.cpp
@@ -12,7 +12,7 @@ namespace GTA
     }
     Checkpoint::Checkpoint(CheckpointIcon icon, Math::Vector3 position, Math::Vector3 pointTo, float radius, System::Drawing::Color color, int reserved) : _icon(icon), _position(position), _pointTo(pointTo), _radius(radius), _color(color), _reserved(reserved)
     {
-        _handle = Native::Function::Call<int>(Native::Hash::CREATE_CHECKPOINT, static_cast<int>(icon), position.X, position.Y, position.Z, pointTo.X, pointTo.Y, pointTo.Z, radius, static_cast<int>(color.R), static_cast<int>(color.G), static_cast<int>(color.B), static_cast<int>(color.A), reserved);
+        _handle = Native::Function::Call<int>(Native::Hash::CREATE_CHECKPOINT, static_cast<int>(icon), position.X, position.Y, position.Z, pointTo.X, pointTo.Y, pointTo.Z, radius, color.R, color.G, color.B, color.A, reserved);
     }
     Checkpoint::~Checkpoint()
     {
@@ -45,7 +45,7 @@ namespace GTA
     }
     void Checkpoint::Color::set(System::Drawing::Color color)
     {
-        Native::Function::Call(Native::Hash::SET_CHECKPOINT_RGBA, Handle, static_cast<int>(color.R), static_cast<int>(color.G), static_cast<int>(color.B), static_cast<int>(color.A));
+        Native::Function::Call(Native::Hash::SET_CHECKPOINT_RGBA, Handle, color.R, color.G, color.B, color.A);
         _color = color;
     }
 
@@ -56,13 +56,16 @@ namespace GTA
     }
     void Checkpoint::SetIconColor(System::Drawing::Color color)
     {
-        Native::Function::Call(Native::Hash::_SET_CHECKPOINT_ICON_RGBA, Handle, static_cast<int>(color.R), static_cast<int>(color.G), static_cast<int>(color.B), static_cast<int>(color.A));
+        Native::Function::Call(Native::Hash::_SET_CHECKPOINT_ICON_RGBA, Handle, color.R, color.G, color.B, color.A);
     }
 
     void Checkpoint::Delete()
     {
-        Native::Function::Call(Native::Hash::DELETE_CHECKPOINT, Handle);
-        _handle = -1;
+        if (Exists())
+        {
+            Native::Function::Call(Native::Hash::DELETE_CHECKPOINT, Handle);
+            _handle = -1;
+        }
     }
 
     bool Checkpoint::Exists()

--- a/source/scripting/Checkpoint.hpp
+++ b/source/scripting/Checkpoint.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "Vector3.hpp"
+#include "Interface.hpp"
+
+namespace GTA
+{
+    public enum class CheckpointIcon
+    {
+        Traditional = 0,
+        SmallArrow = 5,
+        DoubleArrow = 6,
+        TripleArrow = 7,
+        CycleArrow = 8,
+        ArrowInCircle = 10,
+        DoubleArrowInCircle = 11,
+        TripleArrowInCircle = 12,
+        CycleArrowInCircle = 13,
+        CheckerInCircle = 14,
+        Arrow = 15
+    };
+
+    public ref class Checkpoint sealed : System::IEquatable<Checkpoint ^>, IHandleable
+    {
+    public:
+        virtual property int Handle
+        {
+            int get();
+        }
+        /// <summary>
+        /// The icon type of the <see cref="Checkpoint />.
+        /// </summary>
+        property CheckpointIcon Icon
+        {
+            CheckpointIcon get();
+        }
+        /// <summary>
+        /// The position of the <see cref="Checkpoint />.
+        /// </summary>
+        property Math::Vector3 Position
+        {
+            Math::Vector3 get();
+        }
+        /// <summary>
+        /// The position of the next <see cref="Checkpoint /> the arrow points to.
+        /// </summary>
+        property Math::Vector3 PointTo
+        {
+            Math::Vector3 get();
+        }
+        /// <summary>
+        /// The radius of the <see cref="Checkpoint />.
+        /// </summary>
+        property float Radius
+        {
+            float get();
+        }
+        /// <summary>
+        /// The color of the <see cref="Checkpoint />.
+        /// </summary>
+        property System::Drawing::Color Color
+        {
+            System::Drawing::Color get();
+            void set(System::Drawing::Color value);
+        }
+
+        void SetCylinderHeight(float nearHeight, float farHeight, float radius);
+        void SetIconColor(System::Drawing::Color color);
+
+        void Delete();
+
+        virtual bool Exists();
+        static bool Exists(Checkpoint ^checkpoint);
+
+        virtual bool Equals(System::Object ^obj) override;
+        virtual bool Equals(Checkpoint ^checkpoint);
+
+        virtual inline int GetHashCode() override
+        {
+            return Handle;
+        }
+
+        static inline bool operator==(Checkpoint ^left, Checkpoint ^right)
+        {
+            if (ReferenceEquals(left, nullptr))
+            {
+                return ReferenceEquals(right, nullptr);
+            }
+
+            return left->Equals(right);
+        }
+        static inline bool operator!=(Checkpoint ^left, Checkpoint ^right)
+        {
+            return !operator==(left, right);
+        }
+
+        Checkpoint(CheckpointIcon icon, Math::Vector3 position, Math::Vector3 pointTo, float radius, System::Drawing::Color color);
+        ~Checkpoint();
+    internal:
+        Checkpoint(CheckpointIcon icon, Math::Vector3 position, Math::Vector3 pointTo, float radius, System::Drawing::Color color, int reserved);
+    private:
+        int _handle = -1;
+        CheckpointIcon _icon;
+        Math::Vector3 _position;
+        Math::Vector3 _pointTo;
+        float _radius;
+        System::Drawing::Color _color;
+        int _reserved;
+    };
+}


### PR DESCRIPTION
As discussed in #155, I've created a `Checkpoint` class for creating checkpoints. In the future, some static methods could possibly be added for more advanced checkpoint creation. For now, the last parameter is hidden to users since it's not fully documented. This could easily be added in the future without breaking backwards compatibility.