### PR TITLE
Add support for global settings file

### DIFF
--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -32,6 +32,7 @@ namespace
 	ref struct ScriptHook
 	{
 		static GTA::ScriptDomain ^Domain = nullptr;
+		static WinForms::Keys ReloadKey = WinForms::Keys::None;
 	};
 
 	bool ManagedInit()
@@ -45,6 +46,7 @@ namespace
 		auto settings = GTA::ScriptSettings::Load(IO::Path::ChangeExtension(location, ".ini"));
 
 		ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(location), settings->GetValue(String::Empty, "ScriptsLocation", "scripts")));
+		ScriptHook::ReloadKey = settings->GetValue<WinForms::Keys>(String::Empty, "ReloadKey", WinForms::Keys::Insert);
 
 		if (Object::ReferenceEquals(ScriptHook::Domain, nullptr))
 		{
@@ -57,7 +59,7 @@ namespace
 	}
 	bool ManagedTick()
 	{
-		if (ScriptHook::Domain->IsKeyPressed(WinForms::Keys::Insert))
+		if (ScriptHook::Domain->IsKeyPressed(ScriptHook::ReloadKey))
 		{
 			return false;
 		}

--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -15,76 +15,73 @@
  */
 
 #include "ScriptDomain.hpp"
-#include "Settings.hpp"
 #include "Native.hpp"
 #include "NativeMemory.hpp"
 #include "Matrix.hpp"
 #include "Quaternion.hpp"
 #include "Vector2.hpp"
 #include "Vector3.hpp"
+#include "Settings.hpp"
 
 using namespace System;
 using namespace System::Reflection;
 namespace WinForms = System::Windows::Forms;
 
-namespace
+ref struct ScriptHook
 {
-	ref struct ScriptHook
+	static GTA::ScriptDomain ^Domain = nullptr;
+	static WinForms::Keys ReloadKey = WinForms::Keys::None;
+};
+
+bool ManagedInit()
+{
+	if (!Object::ReferenceEquals(ScriptHook::Domain, nullptr))
 	{
-		static GTA::ScriptDomain ^Domain = nullptr;
-		static WinForms::Keys ReloadKey = WinForms::Keys::None;
-	};
-
-	bool ManagedInit()
-	{
-		if (!Object::ReferenceEquals(ScriptHook::Domain, nullptr))
-		{
-			GTA::ScriptDomain::Unload(ScriptHook::Domain);
-		}
-
-		String ^scriptsLocation = "scripts";
-		WinForms::Keys reloadKey = WinForms::Keys::Insert;
-		auto location = Assembly::GetExecutingAssembly()->Location;
-		auto settings = GTA::ScriptSettings::Load(IO::Path::ChangeExtension(location, ".ini"));
-
-		if (!Object::ReferenceEquals(settings, nullptr))
-		{
-			scriptsLocation = settings->GetValue(String::Empty, "ScriptsLocation", scriptsLocation);
-			reloadKey = settings->GetValue<WinForms::Keys>(String::Empty, "ReloadKey", reloadKey);
-		}
-
-		ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(location), scriptsLocation));
-		ScriptHook::ReloadKey = reloadKey;
-
-		if (Object::ReferenceEquals(ScriptHook::Domain, nullptr))
-		{
-			return false;
-		}
-
-		ScriptHook::Domain->Start();
-
-		return true;
+		GTA::ScriptDomain::Unload(ScriptHook::Domain);
 	}
-	bool ManagedTick()
+
+	String ^scriptsLocation = "scripts";
+	String ^assemblyLocation = Assembly::GetExecutingAssembly()->Location;
+	WinForms::Keys reloadKey = WinForms::Keys::Insert;
+	auto settings = GTA::ScriptSettings::Load(IO::Path::ChangeExtension(assemblyLocation, ".ini"));
+
+	if (!Object::ReferenceEquals(settings, nullptr))
 	{
-		if (ScriptHook::Domain->IsKeyPressed(ScriptHook::ReloadKey))
-		{
-			return false;
-		}
-
-		ScriptHook::Domain->DoTick();
-
-		return true;
+		reloadKey = settings->GetValue<WinForms::Keys>(String::Empty, "ReloadKey", reloadKey);
+		scriptsLocation = settings->GetValue(String::Empty, "ScriptsLocation", scriptsLocation);
 	}
-	void ManagedKeyboardMessage(int key, bool status, bool statusCtrl, bool statusShift, bool statusAlt)
+
+	ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(assemblyLocation), scriptsLocation));
+	ScriptHook::ReloadKey = reloadKey;
+
+	if (Object::ReferenceEquals(ScriptHook::Domain, nullptr))
 	{
-		if (Object::ReferenceEquals(ScriptHook::Domain, nullptr))
-		{
-			return;
-		}
-
-		ScriptHook::Domain->DoKeyboardMessage(static_cast<WinForms::Keys>(key), status, statusCtrl, statusShift, statusAlt);
+		return false;
 	}
+
+	ScriptHook::Domain->Start();
+
+	return true;
+}
+bool ManagedTick()
+{
+	if (ScriptHook::Domain->IsKeyPressed(ScriptHook::ReloadKey))
+	{
+		return false;
+	}
+
+	ScriptHook::Domain->DoTick();
+
+	return true;
+}
+void ManagedKeyboardMessage(int key, bool status, bool statusCtrl, bool statusShift, bool statusAlt)
+{
+	if (Object::ReferenceEquals(ScriptHook::Domain, nullptr))
+	{
+		return;
+	}
+
+	ScriptHook::Domain->DoKeyboardMessage(static_cast<WinForms::Keys>(key), status, statusCtrl, statusShift, statusAlt);
 }
 
 #pragma unmanaged
@@ -92,77 +89,71 @@ namespace
 #include <Main.h>
 #include <Windows.h>
 
-namespace
+bool sGameReloaded = false;
+PVOID sMainFib = nullptr, sScriptFib = nullptr;
+
+void ScriptMain()
 {
-	bool sGameReloaded = false;
-	PVOID sMainFib = nullptr, sScriptFib = nullptr;
+	const auto version = getGameVersion();
 
-	void ScriptYield()
+	if (version >= 20)
 	{
-		// Switch back to main script fiber used by Script Hook
-		SwitchToFiber(sMainFib);
+		// Disable mpexecutive and mplowrider2 car removing
+		const auto global2562051 = getGlobalPtr(2562051);
+
+		if (global2562051 != nullptr)
+		{
+			*global2562051 = 1;
+		}
 	}
-	void CALLBACK ScriptMainLoop(LPVOID)
+	else if (version >= 18)
 	{
-		while (ManagedInit())
-		{			
-			sGameReloaded = false;
+		// Disable mplowrider2 car removing
+		const auto global2558120 = getGlobalPtr(2558120);
 
-			// Run main loop
-			while (!sGameReloaded && ManagedTick())
+		if (global2558120 != nullptr)
+		{
+			*global2558120 = 1;
+		}
+	}
+
+	// Set up fibers
+	sGameReloaded = true;
+	sMainFib = GetCurrentFiber();
+
+	if (sScriptFib == nullptr)
+	{
+		const auto callback = [](LPVOID)
+		{
+			while (ManagedInit())
 			{
-				ScriptYield();
+				sGameReloaded = false;
+
+				// Run main loop
+				while (!sGameReloaded && ManagedTick())
+				{
+					// Switch back to main script fiber used by Script Hook
+					SwitchToFiber(sMainFib);
+				}
 			}
-		}
+		};
+
+		// Create our own fiber for the common language runtime once
+		sScriptFib = CreateFiber(0, callback, nullptr);
 	}
-	void ScriptMainSetup()
+
+	while (true)
 	{
-		const auto version = getGameVersion();
+		// Yield execution
+		scriptWait(0);
 
-		if (version >= 20)
-		{
-			// Disable mpexecutive and mplowrider2 car removing
-			const auto global2562051 = getGlobalPtr(2562051);
-
-			if (global2562051 != nullptr)
-			{
-				*global2562051 = 1;
-			}
-		}
-		else if (version >= 18)
-		{
-			// Disable mplowrider2 car removing
-			const auto global2558120 = getGlobalPtr(2558120);
-
-			if (global2558120 != nullptr)
-			{
-				*global2558120 = 1;
-			}
-		}
-
-		// Set up fibers
-		sGameReloaded = true;
-		sMainFib = GetCurrentFiber();
-
-		if (sScriptFib == nullptr)
-		{
-			// Create our own fiber for the common language runtime once
-			sScriptFib = CreateFiber(0, &ScriptMainLoop, nullptr);
-		}
-
-		while (true)
-		{
-			// Yield execution
-			scriptWait(0);
-
-			// Switch to our own fiber and wait for it to switch back
-			SwitchToFiber(sScriptFib);
-		}
+		// Switch to our own fiber and wait for it to switch back
+		SwitchToFiber(sScriptFib);
 	}
-	void ScriptKeyboardMessage(DWORD key, WORD repeats, BYTE scanCode, BOOL isExtended, BOOL isWithAlt, BOOL wasDownBefore, BOOL isUpNow)
-	{
-		ManagedKeyboardMessage(static_cast<int>(key), isUpNow == FALSE, (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0, (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0, isWithAlt != FALSE);
-	}
+}
+void ScriptKeyboardMessage(DWORD key, WORD repeats, BYTE scanCode, BOOL isExtended, BOOL isWithAlt, BOOL wasDownBefore, BOOL isUpNow)
+{
+	ManagedKeyboardMessage(static_cast<int>(key), isUpNow == FALSE, (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0, (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0, isWithAlt != FALSE);
 }
 
 BOOL WINAPI DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpvReserved)
@@ -171,7 +162,7 @@ BOOL WINAPI DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpvReserved)
 	{
 		case DLL_PROCESS_ATTACH:
 			DisableThreadLibraryCalls(hModule);
-			scriptRegister(hModule, &ScriptMainSetup);
+			scriptRegister(hModule, &ScriptMain);
 			keyboardHandlerRegister(&ScriptKeyboardMessage);
 			break;
 		case DLL_PROCESS_DETACH:

--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -40,19 +40,11 @@ bool ManagedInit()
 		GTA::ScriptDomain::Unload(ScriptHook::Domain);
 	}
 
-	String ^scriptsLocation = "scripts";
-	String ^assemblyLocation = Assembly::GetExecutingAssembly()->Location;
-	WinForms::Keys reloadKey = WinForms::Keys::Insert;
-	auto settings = GTA::ScriptSettings::Load(IO::Path::ChangeExtension(assemblyLocation, ".ini"));
+	auto location = Assembly::GetExecutingAssembly()->Location;
+	auto settings = GTA::ScriptSettings::Load(IO::Path::ChangeExtension(location, ".ini"));
 
-	if (!Object::ReferenceEquals(settings, nullptr))
-	{
-		reloadKey = settings->GetValue<WinForms::Keys>(String::Empty, "ReloadKey", reloadKey);
-		scriptsLocation = settings->GetValue(String::Empty, "ScriptsLocation", scriptsLocation);
-	}
-
-	ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(assemblyLocation), scriptsLocation));
-	ScriptHook::ReloadKey = reloadKey;
+	ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(location), settings->GetValue(String::Empty, "ScriptsLocation", "scripts")));
+	ScriptHook::ReloadKey = settings->GetValue<WinForms::Keys>(String::Empty, "ReloadKey", WinForms::Keys::Insert);
 
 	if (Object::ReferenceEquals(ScriptHook::Domain, nullptr))
 	{

--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -42,11 +42,19 @@ namespace
 			GTA::ScriptDomain::Unload(ScriptHook::Domain);
 		}
 
+		String ^scriptsLocation = "scripts";
+		WinForms::Keys reloadKey = WinForms::Keys::Insert;
 		auto location = Assembly::GetExecutingAssembly()->Location;
 		auto settings = GTA::ScriptSettings::Load(IO::Path::ChangeExtension(location, ".ini"));
 
-		ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(location), settings->GetValue(String::Empty, "ScriptsLocation", "scripts")));
-		ScriptHook::ReloadKey = settings->GetValue<WinForms::Keys>(String::Empty, "ReloadKey", WinForms::Keys::Insert);
+		if (!Object::ReferenceEquals(settings, nullptr))
+		{
+			scriptsLocation = settings->GetValue(String::Empty, "ScriptsLocation", scriptsLocation);
+			reloadKey = settings->GetValue<WinForms::Keys>(String::Empty, "ReloadKey", reloadKey);
+		}
+
+		ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(location), scriptsLocation));
+		ScriptHook::ReloadKey = reloadKey;
 
 		if (Object::ReferenceEquals(ScriptHook::Domain, nullptr))
 		{

--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "ScriptDomain.hpp"
+#include "Settings.hpp"
 #include "Native.hpp"
 #include "NativeMemory.hpp"
 #include "Matrix.hpp"
@@ -40,7 +41,10 @@ namespace
 			GTA::ScriptDomain::Unload(ScriptHook::Domain);
 		}
 
-		ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(Assembly::GetExecutingAssembly()->Location), "scripts"));
+		auto location = Assembly::GetExecutingAssembly()->Location;
+		auto settings = GTA::ScriptSettings::Load(IO::Path::ChangeExtension(location, ".ini"));
+
+		ScriptHook::Domain = GTA::ScriptDomain::Load(IO::Path::Combine(IO::Path::GetDirectoryName(location), settings->GetValue(String::Empty, "ScriptsLocation", "scripts")));
 
 		if (Object::ReferenceEquals(ScriptHook::Domain, nullptr))
 		{

--- a/source/core/Script.cpp
+++ b/source/core/Script.cpp
@@ -36,14 +36,7 @@ namespace GTA
 		{
 			String ^path = IO::Path::ChangeExtension(_filename, ".ini");
 
-			if (IO::File::Exists(path))
-			{
-				_settings = ScriptSettings::Load(path);
-			}
-			else
-			{
-				_settings = gcnew ScriptSettings(path);
-			}
+			_settings = ScriptSettings::Load(path);
 		}
 
 		return _settings;

--- a/source/core/ScriptDomain.cpp
+++ b/source/core/ScriptDomain.cpp
@@ -77,9 +77,13 @@ namespace GTA
 		auto assembly = Script::typeid->Assembly;
 		auto assemblyName = gcnew AssemblyName(args->Name);
 
-		if (assemblyName->Name->StartsWith("ScriptHookVDotNet", StringComparison::CurrentCultureIgnoreCase) &&
-			assemblyName->Version->Major == assembly->GetName()->Version->Major)
+		if (assemblyName->Name->StartsWith("ScriptHookVDotNet", StringComparison::CurrentCultureIgnoreCase))
 		{
+			if (assemblyName->Version->Major != assembly->GetName()->Version->Major)
+			{
+				Log("[WARNING]", "A script references v", assemblyName->Version->ToString(3), " which may not be compatible with the current v" + assembly->GetName()->Version->ToString(3), ".");
+			}
+
 			return assembly;
 		}
 
@@ -239,7 +243,7 @@ namespace GTA
 	{
 		if (IO::Path::GetFileNameWithoutExtension(filename)->StartsWith("ScriptHookVDotNet", StringComparison::CurrentCultureIgnoreCase))
 		{
-			Log("[ERROR]", "Skipped assembly '", IO::Path::GetFileName(filename), "'. Please remove it from the directory.");
+			Log("[WARNING]", "Skipped assembly '", IO::Path::GetFileName(filename), "'. Please remove it from the directory.");
 
 			return false;
 		}

--- a/source/core/Settings.cpp
+++ b/source/core/Settings.cpp
@@ -33,7 +33,7 @@ namespace GTA
 		}
 
 		String ^line = nullptr;
-		String ^section = "";
+		String ^section = String::Empty;
 		IO::StreamReader ^reader = nullptr;
 		
 		try
@@ -138,7 +138,7 @@ namespace GTA
 			{
 				writer->WriteLine("[" + section.Key + "]");
 
-				for each (Tuple<String ^, String ^> ^value in section.Value)
+				for each (auto value in section.Value)
 				{
 					writer->WriteLine(value->Item1 + " = " + value->Item2);
 				}

--- a/source/core/Settings.cpp
+++ b/source/core/Settings.cpp
@@ -27,9 +27,11 @@ namespace GTA
 
 	ScriptSettings ^ScriptSettings::Load(String ^filename)
 	{
+		auto result = gcnew ScriptSettings(filename);
+
 		if (!IO::File::Exists(filename))
 		{
-			return nullptr;
+			return result;
 		}
 
 		String ^line = nullptr;
@@ -42,10 +44,8 @@ namespace GTA
 		}
 		catch (IO::IOException ^)
 		{
-			return nullptr;
+			return result;
 		}
-
-		auto result = gcnew ScriptSettings(filename);
 
 		try
 		{

--- a/source/core/Settings.hpp
+++ b/source/core/Settings.hpp
@@ -33,7 +33,7 @@ namespace GTA
 		void SetValue(System::String ^section, System::String ^name, T value);
 		void SetValue(System::String ^section, System::String ^name, System::String ^value);
 
-	internal:
+	private:
 		ScriptSettings(System::String ^filename);
 
 		System::String ^_filename;

--- a/source/core/Settings.hpp
+++ b/source/core/Settings.hpp
@@ -35,8 +35,7 @@ namespace GTA
 
 	internal:
 		ScriptSettings(System::String ^filename);
-		
-	private:
+
 		System::String ^_filename;
 		System::Collections::Generic::Dictionary<System::String ^, System::String ^> ^_values = gcnew System::Collections::Generic::Dictionary<System::String ^, System::String ^>();
 	};


### PR DESCRIPTION
This pull request modifies the initialization routine of ScriptHookVDotNet to load a global INI file (same name as the ASI, but with INI extension) which can be used to change various settings. Currently it adds support to change both the reload key and location to load scripts from. I also replaced the version check when resolving the ScriptHookVDotNet assembly with a warning log message, because multiple versions can be used together now by changing the scripts location for each of them.

Example settings file with the default values (note the lack of a section tag):
```
ReloadKey=Insert
ScriptsLocation=scripts
```