### PR TITLE
Update offsets for v1_0_877_1, fix versions

### DIFF
--- a/source/scripting/Vehicle.cpp
+++ b/source/scripting/Vehicle.cpp
@@ -519,7 +519,8 @@ namespace GTA
 	{
 		System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		const int offset = (static_cast<int>(Game::Version) > 4 ? 0x844 : 0x834);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x844 : 0x834);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x864 : offset);
 
 		return address == 0 ? false : (*reinterpret_cast<int *>(address + offset) & (1 << 2)) != 0;
 	}
@@ -547,7 +548,8 @@ namespace GTA
 	{
 		System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		const int offset = (static_cast<int>(Game::Version) > 4 ? 0x844 : 0x834);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x844 : 0x834);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x864 : offset);
 
 		return address == 0 ? false : (*reinterpret_cast<int *>(address + offset) & (1 << 1)) != 0;
 	}
@@ -676,7 +678,8 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x7A0: 0x790);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x7A0: 0x790);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x7C0 : offset);
 
 		return address == 0 ? 0 : static_cast<int>(*reinterpret_cast<const unsigned char *>(address + offset));
 	}
@@ -684,7 +687,8 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x7A6 : 0x796);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x7A6 : 0x796);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x7C6 : offset);
 
 		return address == 0 ? 0 : static_cast<int>(*reinterpret_cast<const unsigned char *>(address + offset));
 	}
@@ -702,7 +706,8 @@ namespace GTA
 			return;
 		}
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x7A6 : 0x796);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x7A6 : 0x796);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x7C6 : offset);
 
 		*reinterpret_cast<unsigned char *>(address + offset) = static_cast<unsigned char>(value);
 	}
@@ -710,7 +715,8 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x768: 0x758);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x768: 0x758);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x788 : offset);
 
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
@@ -723,7 +729,8 @@ namespace GTA
 			return;
 		}
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x768 : 0x758);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x768 : 0x758);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x788 : offset);
 
 		*reinterpret_cast<float *>(address + offset) = value;
 	}
@@ -731,7 +738,8 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 2004 : 1988);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x7D4 : 0x7C4);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x7F4 : offset);
 
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
@@ -739,7 +747,8 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 2004 : 1988);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x7D4 : 0x7C4);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x7F4 : offset);
 
 		*reinterpret_cast<float *>(address + offset) = value;
 	}
@@ -747,7 +756,8 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x7E4 : 0x7D4);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x7E4 : 0x7D4);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x804 : offset);
 
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
@@ -755,7 +765,9 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 		//old game version hasnt been tested, just following the patterns above for old game ver
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x9A4 : 0x994);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x9A4 : 0x994);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x9C4 : offset);
+
 
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
@@ -763,7 +775,8 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x8AC : 0x89C);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x8AC : 0x89C);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x8CC : offset);
 
 		if (!address == 0)
 		{
@@ -779,7 +792,8 @@ namespace GTA
 	{
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x8A4 : 0x894);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x8A4 : 0x894);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x8C4 : offset);
 
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
@@ -792,7 +806,8 @@ namespace GTA
 			return;
 		}
 
-		int offset = (static_cast<int>(Game::Version) > 4 ? 0x8A4 : 0x894);
+		int offset = (static_cast<int>(Game::Version) > 3 ? 0x8A4 : 0x894);
+		offset = (static_cast<int>(Game::Version) > 25 ? 0x8C4 : offset);
 
 		*reinterpret_cast<float *>(address + offset) = value;
 	}


### PR DESCRIPTION
dev_v2 branch

Fix Steam versions taken as base to non-steam versions. (0, 1 are same,
2, 3 are same, 4, 5 are same. Previously script changed on 5, which is
wrong for NoSteam version.