### PR TITLE
Update GameVersion enum and fix GenerateHash

### DIFF
--- a/source/scripting/Game.cpp
+++ b/source/scripting/Game.cpp
@@ -355,12 +355,16 @@ namespace GTA
 		System::UInt32 hash = 0;
 		array<System::Char>^ chars = input->ToCharArray();
 
-		//converts ascii uppercase to lowercase
+		//converts ascii uppercase to lowercase and replaces backslash with slash
 		for (int i = 0, length = chars->Length; i < length; i++)
 		{
 			if (chars[i] >= 'A' && chars[i] <= 'Z')
 			{
 				chars[i] = chars[i] + 32;
+			}
+			else if (chars[i] == '\\')
+			{
+				chars[i] = '/';
 			}
 		}
 

--- a/source/scripting/Game.hpp
+++ b/source/scripting/Game.hpp
@@ -41,7 +41,9 @@ namespace GTA
 		VER_1_0_944_2_STEAM,
 		VER_1_0_944_2_NOSTEAM,
 		VER_1_0_1011_1_STEAM,
-		VER_1_0_1011_1_NOSTEAM
+		VER_1_0_1011_1_NOSTEAM,
+		VER_1_0_1032_1_STEAM,
+		VER_1_0_1032_1_NOSTEAM
 	};
 	public enum class Language
 	{

--- a/source/scripting/Vehicle.cpp
+++ b/source/scripting/Vehicle.cpp
@@ -704,9 +704,9 @@ namespace GTA
 	}
 	void Vehicle::HighGear::set(int value)
 	{
-		if (value < 0 || value > System::Byte::MaxValue)
+		if (value < 0 || value > 8)
 		{
-			throw gcnew System::ArgumentOutOfRangeException("value", "Values must be between 0 and 255, inclusive.");
+			throw gcnew System::ArgumentOutOfRangeException("value", "Values must be between 0 and 8, inclusive.");
 		}
 
 		const System::UInt64 address = Native::MemoryAccess::GetAddressOfEntity(Handle);


### PR DESCRIPTION
Close #607
I found [this information](http://gtaforums.com/topic/879408-c-string-hasher/) and confirmed backslash `\` is replaced with slash `/` by `GET_HASH_KEY`.