### PR TITLE
Added Reload Scripts When Insert Is Pressed Functionality

### DIFF
--- a/source/core/Main.cpp
+++ b/source/core/Main.cpp
@@ -60,9 +60,14 @@ ref struct ScriptHookVDotNet
 
 	static void KeyboardMessage(WinForms::Keys key, bool status, bool statusCtrl, bool statusShift, bool statusAlt)
 	{
-		if (Domain != nullptr)
-		{
-			Domain->DoKeyboardMessage(key, status, statusCtrl, statusShift, statusAlt);
+		if (key == WinForms::Keys::Insert) {
+			Init();
+		}
+		else {
+			if (Domain != nullptr)
+			{
+				Domain->DoKeyboardMessage(key, status, statusCtrl, statusShift, statusAlt);
+			}
 		}
 	}
 };


### PR DESCRIPTION
Added functionality to reload scripts when the 'insert' button is pressed. This was advertised on the getting started page but not implemented as far as I could see in the code or testing and very much needed for my development.

Built and tested with one of my mods where failure to fully reload the script would be apparent and obvious. Seems to work.