### PR TITLE
Add ReloadAllScripts & AbortAllScripts

### DIFF
--- a/source/core/Console.cpp
+++ b/source/core/Console.cpp
@@ -706,6 +706,11 @@ namespace GTA
 		Abort(filename);
 		Load(filename);
 	}
+	void DefaultConsoleCommands::ReloadAllScripts()
+	{
+		AbortAllScripts();
+		ScriptDomain::CurrentDomain->StartAllScripts();
+	}
 	void DefaultConsoleCommands::List()
 	{
 		auto scripts = gcnew Collections::Generic::List<Script ^>(ScriptDomain::CurrentDomain->RunningScripts);
@@ -746,6 +751,10 @@ namespace GTA
 		}
 
 		ScriptDomain::CurrentDomain->AbortScript(filename);
+	}
+	void DefaultConsoleCommands::AbortAllScripts()
+	{
+		ScriptDomain::CurrentDomain->AbortAllScriptsExceptConsole();
 	}
 	void DefaultConsoleCommands::Clear()
 	{

--- a/source/core/Console.hpp
+++ b/source/core/Console.hpp
@@ -220,11 +220,17 @@ namespace GTA
 		[ConsoleCommand("Reloads scripts from a file")]
 		static void Reload(System::String ^filename);
 
+		[ConsoleCommand("Reloads all scripts found in the script folder")]
+		static void ReloadAllScripts();
+
 		[ConsoleCommand("List all loaded scripts")]
 		static void List();
 
 		[ConsoleCommand("Aborts all scripts from the specified file")]
 		static void Abort(System::String ^filename);
+
+		[ConsoleCommand("Aborts all scripts found in the script folder")]
+		static void AbortAllScripts();
 
 		[ConsoleCommand("Clears the console output")]
 		static void Clear();

--- a/source/core/ScriptDomain.hpp
+++ b/source/core/ScriptDomain.hpp
@@ -86,8 +86,10 @@ namespace GTA
 
 		void Start();
 		void StartScript(System::String ^filename);
+		void StartAllScripts();
 		void Abort();
 		void AbortScript(System::String ^filename);
+		void AbortAllScriptsExceptConsole();
 		static void OnStartScript(Script ^script);
 		static void OnAbortScript(Script ^script);
 


### PR DESCRIPTION
I hope the console separate its arguments with spaces as most terminals, not commas, and I hope the console can execute its commands without parenthesis ~~or semicolons~~ as them. 