### PR TITLE
Separate ForwardSpeed and add new getter to Entity.Speed and Vehicle.ForwardSpeed

### DIFF
--- a/source/scripting/Entity.cs
+++ b/source/scripting/Entity.cs
@@ -444,6 +444,19 @@ namespace GTA
 			}
 		}
 		/// <summary>
+		/// Gets this <see cref="Entity"/>s speed.
+		/// </summary>
+		/// <value>
+		/// The speed in m/s.
+		/// </value>
+		public float Speed
+		{
+			get
+			{
+				return Function.Call<float>(Hash.GET_ENTITY_SPEED, Handle);
+			}
+		}
+		/// <summary>
 		/// Sets the maximum speed this <see cref="Entity"/> can move at.
 		/// </summary>
 		public float MaxSpeed

--- a/source/scripting/Entity.cs
+++ b/source/scripting/Entity.cs
@@ -444,7 +444,7 @@ namespace GTA
 			}
 		}
 		/// <summary>
-		/// Gets this <see cref="Entity"/>s speed.
+		/// Gets or sets this <see cref="Entity"/>s speed.
 		/// </summary>
 		/// <value>
 		/// The speed in m/s.
@@ -454,6 +454,10 @@ namespace GTA
 			get
 			{
 				return Function.Call<float>(Hash.GET_ENTITY_SPEED, Handle);
+			}
+			set
+			{
+				Velocity = Velocity.Normalized * value;
 			}
 		}
 		/// <summary>

--- a/source/scripting/Vehicle.cs
+++ b/source/scripting/Vehicle.cs
@@ -677,7 +677,7 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets or sets this <see cref="Vehicle"/>s speed.
+		/// Gets this <see cref="Vehicle"/>s speed.
 		/// </summary>
 		/// <value>
 		/// The speed in m/s.
@@ -688,6 +688,15 @@ namespace GTA
 			{
 				return Function.Call<float>(Hash.GET_ENTITY_SPEED, Handle);
 			}
+		}
+		/// <summary>
+		/// Sets this <see cref="Vehicle"/>s forward speed.
+		/// </summary>
+		/// <value>
+		/// The forward speed in m/s.
+		/// </value>
+		public float ForwardSpeed
+		{
 			set
 			{
 				if (Model.IsTrain)

--- a/source/scripting/Vehicle.cs
+++ b/source/scripting/Vehicle.cs
@@ -677,19 +677,6 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets this <see cref="Vehicle"/>s speed.
-		/// </summary>
-		/// <value>
-		/// The speed in m/s.
-		/// </value>
-		public float Speed
-		{
-			get
-			{
-				return Function.Call<float>(Hash.GET_ENTITY_SPEED, Handle);
-			}
-		}
-		/// <summary>
 		/// Sets this <see cref="Vehicle"/>s forward speed.
 		/// </summary>
 		/// <value>


### PR DESCRIPTION
MulleDK19 was right about one thing, `Vehicle.Speed`. They talked about RPH2 features, and we should separete the absolute speed of entity and the forward speed of them, too.
![snapcrab_noname_2017-9-18_0-25-19_no-00](https://user-images.githubusercontent.com/9353978/30522638-7e96a278-9c0e-11e7-88f2-746d6494f3fd.png)

