### PR TITLE
Added Exception Handling for Loading Assmblies

### DIFF
--- a/source/core/ScriptDomain.cpp
+++ b/source/core/ScriptDomain.cpp
@@ -236,22 +236,27 @@ namespace GTA
 			for (int i = 0; i < filenameAssemblies->Count; i++)
 			{
 				auto filename = filenameAssemblies[i];
-				auto assemblyName = AssemblyName::GetAssemblyName(filename);
+				try {
+					auto assemblyName = AssemblyName::GetAssemblyName(filename);
 
-				if (assemblyName->Name->StartsWith("ScriptHookVDotNet", StringComparison::OrdinalIgnoreCase))
-				{
-					Log("[WARNING]", "Removing assembly file '", IO::Path::GetFileName(filename), "'.");
-
-					filenameAssemblies->RemoveAt(i--);
-
-					try
+					if(assemblyName->Name->StartsWith("ScriptHookVDotNet", StringComparison::OrdinalIgnoreCase))
 					{
-						IO::File::Delete(filename);
+						Log("[WARNING]", "Removing assembly file '", IO::Path::GetFileName(filename), "'.");
+
+						filenameAssemblies->RemoveAt(i--);
+
+						try
+						{
+							IO::File::Delete(filename);
+						}
+						catch(Exception ^ex)
+						{
+							Log("[ERROR]", "Failed to delete assembly file:", Environment::NewLine, ex->ToString());
+						}
 					}
-					catch (Exception ^ex)
-					{
-						Log("[ERROR]", "Failed to delete assembly file:", Environment::NewLine, ex->ToString());
-					}
+				}
+				catch(Exception ^ex) {
+					Log("[ERROR]", "Failed to load " + filename + ", possibly a non .Net assembly, skipping.", Environment::NewLine, ex->ToString());
 				}
 			}
 


### PR DESCRIPTION
Adjusted loading of scripts to skip over files which fail to load. Ran into this issue when writing a mod that referenced a native dll that had to be in the scripts directory to work. ScriptHookVDotNet would try to load the native DLL and read the assembly, which would throw an unhandled exception.  This would also protect against failed loads of corrupted dll's, malformed .cs or .vb scripts, etc, allowing other scripts to be loaded and prevent GTAV from crashing on the unhandled exception.