### PR TITLE
Add shortcuts to move cursor using Ctrl and another key

### DIFF
--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -526,10 +526,30 @@ namespace GTA
 				case Keys.Down:
 					GoDownCommandList();
 					break;
+				case Keys.A:
+					if (e.Control)
+					{
+						MoveCursorToStartOfLine();
+					}
+					else
+					{
+						AddToInput(GetCharsFromKeys(e.KeyCode, e.Shift, e.Alt));
+					}
+					break;
 				case Keys.B:
 					if (e.Control)
 					{
 						MoveCursorLeft();
+					}
+					else
+					{
+						AddToInput(GetCharsFromKeys(e.KeyCode, e.Shift, e.Alt));
+					}
+					break;
+				case Keys.E:
+					if (e.Control)
+					{
+						MoveCursorToEndOfLine();
 					}
 					else
 					{
@@ -678,6 +698,14 @@ namespace GTA
 		{
 			if (_cursorPos > 0)
 				_cursorPos--;
+		}
+		private void MoveCursorToStartOfLine()
+		{
+			_cursorPos = _input.Length;
+		}
+		private void MoveCursorToEndOfLine()
+		{
+			_cursorPos = 0;
 		}
 		private void RemoveCharLeft()
 		{

--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -526,6 +526,26 @@ namespace GTA
 				case Keys.Down:
 					GoDownCommandList();
 					break;
+				case Keys.B:
+					if (e.Control)
+					{
+						MoveCursorLeft();
+					}
+					else
+					{
+						AddToInput(GetCharsFromKeys(e.KeyCode, e.Shift, e.Alt));
+					}
+					break;
+				case Keys.F:
+					if (e.Control)
+					{
+						MoveCursorRight();
+					}
+					else
+					{
+						AddToInput(GetCharsFromKeys(e.KeyCode, e.Shift, e.Alt));
+					}
+					break;
 				case Keys.V:
 					if (e.Control)
 					{


### PR DESCRIPTION
I realized bash and zsh have Emacs mode after the I made the second commit. The shortcuts are from the shortcuts available in Emacs mode in them. I recently realized these shortcuts were really useful.