### PR TITLE
Update vehicle memory offsets

### DIFF
--- a/source/scripting/Game/GameVersion.cs
+++ b/source/scripting/Game/GameVersion.cs
@@ -41,5 +41,7 @@ namespace GTA
 		v1_0_1103_2_NoSteam,
 		v1_0_1180_2_Steam,
 		v1_0_1180_2_NoSteam,
+		v1_0_1290_1_Steam,
+		v1_0_1290_1_NoSteam,
 	}
 }

--- a/source/scripting/World/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting/World/Entities/Vehicles/Vehicle.cs
@@ -1564,16 +1564,24 @@ namespace GTA
 				{
 					return false;
 				}
-				//Unsure of the exact version this switched or if it switched over a few title updates
-				//as its shifted by 0x20 bytes where as rest are only 0x10 bytes
+			
 				int offset = Game.Version >= GameVersion.v1_0_372_2_Steam ? 0xA98 : 0xA78;
-				offset = Game.Version >= GameVersion.v1_0_877_1_Steam ? 0xAC8 : offset; // just a guess
-				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0xAD8 : offset; //just a guess but it's probably correct if the offset for v1.0.877.1 is correct
+				offset = Game.Version >= GameVersion.v1_0_877_1_Steam ? 0xAD8 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0xB18 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0xB58 : offset;
 
-				if (MemoryAccess.ReadInt(memoryAddress + offset) <= 8)
+				int maxVehType = Game.Version >= GameVersion.v1_0_944_2_Steam ? 10 : 8;
+
+				if (MemoryAccess.ReadInt(memoryAddress + offset) <= maxVehType)
 				{
-					return MemoryAccess.IsBitSet(memoryAddress + 0x12F9, 1);
+					offset = Game.Version >= GameVersion.v1_0_372_2_Steam ? 0x1319 : 0x12F9;
+					offset = Game.Version >= GameVersion.v1_0_877_1_Steam ? 0x1349 : offset;
+					offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x13B9 : offset;
+					offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x1409 : offset;
+	
+					return MemoryAccess.IsBitSet(memoryAddress + offset, 1);
 				}
+
 				return false;
 			}
 			set

--- a/source/scripting/World/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting/World/Entities/Vehicles/Vehicle.cs
@@ -1936,11 +1936,11 @@ namespace GTA
 
 				if (value)
 				{
-					MemoryAccess.SetBit(MemoryAddress + offset, 0);
+					MemoryAccess.SetBit(MemoryAddress + offset, 1);
 				}
 				else
 				{
-					MemoryAccess.ClearBit(MemoryAddress + offset, 0);
+					MemoryAccess.ClearBit(MemoryAddress + offset, 1);
 				}
 			}
 		}

--- a/source/scripting/World/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting/World/Entities/Vehicles/Vehicle.cs
@@ -424,6 +424,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x181C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x184C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x18EC : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x19F0 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -459,6 +460,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x1820 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x1850 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x18F0 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x19F4 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -494,6 +496,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x1824 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x1854 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x18F4 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x19F8 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -516,6 +519,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7A8 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7B8 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x7D4 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x7F4 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -531,6 +535,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7A8 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7B8 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x7D4 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x7F4 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -552,6 +557,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7AC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7BC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x7D8 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x7E8 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -567,6 +573,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7AC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7BC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x7D8 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x7E8 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -586,6 +593,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0xB7C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0xB8C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0xBAC : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0xBCC : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -601,6 +609,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0xB7C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0xB8C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0xBAC : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0xBCC : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -644,6 +653,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x88A : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x89A : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x8BA : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x8DA : offset;
 
 				return MemoryAccess.IsBitSet(MemoryAddress + offset, 5);
 			}
@@ -715,6 +725,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x9F0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0xA00 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0xA10 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0xA30 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -741,6 +752,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x1810 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x1840 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x18E0 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x19E4 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -771,6 +783,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x824 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x834 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x854 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x874 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -795,6 +808,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x814 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x824 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x844 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x864 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -810,6 +824,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x814 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x824 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x844 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x864 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -829,6 +844,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7E6 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7F6 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x816 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x836 : offset;
 
 				return MemoryAccess.ReadByte(MemoryAddress + offset);
 			}
@@ -849,6 +865,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7E6 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7F6 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x816 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x836 : offset;
 
 				MemoryAccess.WriteByte(MemoryAddress + offset, value);
 			}
@@ -870,6 +887,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7E2 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7F2 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x812 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x832 : offset;
 
 				return MemoryAccess.ReadByte(MemoryAddress + offset);
 			}
@@ -885,6 +903,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7E2 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7F2 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x812 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x832 : offset;
 
 				MemoryAccess.WriteByte(MemoryAddress + offset, value);
 			}
@@ -906,6 +925,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x9AC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x9BC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x9DC : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x9FC : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -959,6 +979,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x820 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x830 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x850 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x870 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -974,6 +995,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x820 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x830 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x850 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x870 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -996,6 +1018,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x838 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x848 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x868 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x888 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -1011,7 +1034,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x838 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x848 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x868 : offset;
-
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x888 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -1034,6 +1057,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7E0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7F0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x810 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x830 : offset;
 
 				return MemoryAccess.ReadInt(MemoryAddress + offset);
 			}
@@ -1049,7 +1073,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7E0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7F0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x810 : offset;
-
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x830 : offset;
 
 				MemoryAccess.WriteInt(MemoryAddress + offset, value);
 			}
@@ -1072,6 +1096,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7E0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7F0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x810 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x830 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -1087,7 +1112,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7E0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7F0 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x810 : offset;
-
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x830 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -1110,6 +1135,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x824 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x834 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x854 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x874 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -1125,6 +1151,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x824 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x834 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x854 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x874 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -1147,6 +1174,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x8FC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x90C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x92C : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x94C : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -1162,6 +1190,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x8FC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x90C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x92C : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x94C : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -1184,6 +1213,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x900 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x910 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x930 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x950 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -1199,6 +1229,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x900 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x910 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x930 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x950 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -1224,6 +1255,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x8F4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x904 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x924 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x944 : offset;
 
 				return (float)(MemoryAccess.ReadFloat(MemoryAddress + offset) * (180.0 / System.Math.PI));
 			}
@@ -1239,6 +1271,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x8F4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x904 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x924 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x944 : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -1260,6 +1293,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x8EC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x8FC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x91C : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x93C : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -1275,6 +1309,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x8EC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x8FC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x91C : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x93C : offset;
 
 				MemoryAccess.WriteFloat(MemoryAddress + offset, value);
 			}
@@ -1319,6 +1354,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x9E4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x9F4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x1018 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0xA38 : offset;
 
 				return (ushort)MemoryAccess.ReadShort(MemoryAddress + offset) == ushort.MaxValue; //The alarm is set when the value is 0xFFFF
 			}
@@ -1358,6 +1394,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x9E4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x9F4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0xA18 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0xA38 : offset;
 
 				ushort alarmTime = (ushort)MemoryAccess.ReadShort(MemoryAddress + offset);
 				if (alarmTime == ushort.MaxValue)
@@ -1385,6 +1422,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x9E4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x9F4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0xA18 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0xA38 : offset;
 
 				MemoryAccess.WriteShort(MemoryAddress + offset, (short)alarmTime);
 			}
@@ -1470,6 +1508,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x894 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x8A4 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x8C4 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x8E4 : offset;
 
 				return MemoryAccess.IsBitSet(MemoryAddress + offset, 3);
 			}
@@ -1500,6 +1539,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x884 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x894 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x8B4 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x8D4 : offset;
 
 				return MemoryAccess.IsBitSet(MemoryAddress + offset, 2);
 			}
@@ -1562,6 +1602,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x88C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x89C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x8BC : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x8DC : offset;
 
 				return MemoryAccess.IsBitSet(MemoryAddress + offset, 1);
 			}
@@ -1591,6 +1632,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x88C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x89C : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x8BC : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x8DC : offset;
 
 				return MemoryAccess.IsBitSet(MemoryAddress + offset, 2);
 			}
@@ -1666,6 +1708,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x889 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x899 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x8B9 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x8D9 : offset;
 
 				return MemoryAccess.IsBitSet(MemoryAddress + offset, 6);
 			}
@@ -1774,6 +1817,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_877_1_Steam ? 0x954 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x964 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x984 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x9A4 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -1797,6 +1841,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x1264 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x1274 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x12A8 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x12C8 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -1857,6 +1902,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7BC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7CC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x7EC : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x80C : offset;
 
 				if (value)
 				{
@@ -1886,6 +1932,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x7BC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x7CC : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x7EC : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x80C : offset;
 
 				if (value)
 				{
@@ -1941,6 +1988,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0xA18 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0xA28 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0xA48 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0xA70 : offset;
 
 				return MemoryAccess.ReadFloat(MemoryAddress + offset);
 			}
@@ -2299,6 +2347,7 @@ namespace GTA
 				offset = Game.Version >= GameVersion.v1_0_944_2_Steam ? 0x883 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1103_2_Steam ? 0x893 : offset;
 				offset = Game.Version >= GameVersion.v1_0_1180_2_Steam ? 0x8B3 : offset;
+				offset = Game.Version >= GameVersion.v1_0_1290_1_Steam ? 0x8D3 : offset;
 
 				return !MemoryAccess.IsBitSet(MemoryAddress + offset, 6);
 			}


### PR DESCRIPTION
I tested the stuff with RPH, I couldn't update `DropsMoneyOnExplosion` and there might be wrong with `EnginePowerMultiplier`, though.
Also, the ped class in GTA5.exe has been changed at least once after v1.0.944.2, so we need to update ped memory offsets.