### PR TITLE
Entities/Peds/Style

### DIFF
--- a/source/scripting/World/Entities/Peds/Style.cs
+++ b/source/scripting/World/Entities/Peds/Style.cs
@@ -156,8 +156,8 @@ namespace GTA
 		bool HasVariations { get; }
 		bool HasTextureVariations { get; }
 		bool HasAnyVariations { get; }
-
-	}
+        string Name { get; }
+    }
 	public class PedComponent : IPedVariation
 	{
 		#region Fields
@@ -171,7 +171,11 @@ namespace GTA
 			_componentdId = componentId;
 		}
 
-		public int Count
+        public PedComponents ComponentType { get { return _componentdId; } }
+
+        public string Name { get { return _componentdId.ToString(); } }
+
+        public int Count
 		{
 			get { return Function.Call<int>(Hash.GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS, _ped.Handle, _componentdId); }
 		}
@@ -254,7 +258,11 @@ namespace GTA
 			_propId = propId;
 		}
 
-		public int Count
+        public PedProps PropType { get { return _propId; } }
+
+        public string Name { get { return _propId.ToString(); } }
+
+        public int Count
 		{
 			get { return Function.Call<int>(Hash.GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS, _ped.Handle, _propId) + 1; }//+1 to accomodate for no prop selected(value = -1);
 		}

--- a/source/scripting/World/Entities/Peds/Style.cs
+++ b/source/scripting/World/Entities/Peds/Style.cs
@@ -156,8 +156,8 @@ namespace GTA
 		bool HasVariations { get; }
 		bool HasTextureVariations { get; }
 		bool HasAnyVariations { get; }
-        string Name { get; }
-    }
+		string Name { get; }
+        }
 	public class PedComponent : IPedVariation
 	{
 		#region Fields
@@ -171,11 +171,11 @@ namespace GTA
 			_componentdId = componentId;
 		}
 
-        public PedComponents ComponentType { get { return _componentdId; } }
+		public PedComponents ComponentType { get { return _componentdId; } }
 
-        public string Name { get { return _componentdId.ToString(); } }
+		public string Name { get { return _componentdId.ToString(); } }
 
-        public int Count
+		public int Count
 		{
 			get { return Function.Call<int>(Hash.GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS, _ped.Handle, _componentdId); }
 		}
@@ -258,11 +258,11 @@ namespace GTA
 			_propId = propId;
 		}
 
-        public PedProps PropType { get { return _propId; } }
+		public PedProps PropType { get { return _propId; } }
 
-        public string Name { get { return _propId.ToString(); } }
+		public string Name { get { return _propId.ToString(); } }
 
-        public int Count
+		public int Count
 		{
 			get { return Function.Call<int>(Hash.GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS, _ped.Handle, _propId) + 1; }//+1 to accomodate for no prop selected(value = -1);
 		}


### PR DESCRIPTION
I added a simple name / type to Props / Components to allow GetAll to be used with simple iteration to build a relevant structure of available items.

Something like...
```
PedProp[] props = ped.Style.GetAllProps();

                if (props.Length > 0)
                {
                    foreach (PedProp prop in props)
                    {
                        menu.AddItem(new UIMenuListItem(prop.PropType.ToString() + ": ", IntegerList(ped, prop), ped.Style[prop.PropType].Index, "Available: " + prop.Count));
                    }
                }
```