### PR TITLE
Update vehicle offsets for b1604.0

### DIFF
--- a/source/scripting/Game.hpp
+++ b/source/scripting/Game.hpp
@@ -55,7 +55,9 @@ namespace GTA
 		VER_1_0_1493_0_STEAM,
 		VER_1_0_1493_0_NOSTEAM,
 		VER_1_0_1493_1_STEAM,
-		VER_1_0_1493_1_NOSTEAM
+		VER_1_0_1493_1_NOSTEAM,
+		VER_1_0_1604_0_STEAM,
+		VER_1_0_1604_0_NOSTEAM
 	};
 	public enum class Language
 	{

--- a/source/scripting/Vehicle.cpp
+++ b/source/scripting/Vehicle.cpp
@@ -450,6 +450,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7CC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x7EC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x80C : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x84C : offset);
 
 		const unsigned char mask = 1 << 0;
 
@@ -481,6 +483,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7CC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x7EC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x80C : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x84C : offset);
 
 		const unsigned char mask = 1 << 1;
 

--- a/source/scripting/Vehicle.cpp
+++ b/source/scripting/Vehicle.cpp
@@ -450,7 +450,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7CC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x7EC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x80C : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x84C : offset);
 
 		const unsigned char mask = 1 << 0;
@@ -483,7 +482,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7CC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x7EC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x80C : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x84C : offset);
 
 		const unsigned char mask = 1 << 1;
@@ -543,7 +541,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x89C : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x8BC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x8DC : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x92C : offset);
 
 		return address == 0 ? false : (*reinterpret_cast<int *>(address + offset) & (1 << 2)) != 0;
@@ -578,7 +575,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x89C : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x8BC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x8DC : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x92C : offset);
 
 		return address == 0 ? false : (*reinterpret_cast<int *>(address + offset) & (1 << 1)) != 0;
@@ -714,7 +710,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7F0 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x810 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x830 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x870 : offset);
 
 		return address == 0 ? 0 : static_cast<int>(*reinterpret_cast<const unsigned char *>(address + offset));
@@ -729,7 +724,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7F6 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x816 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x836 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x876 : offset);
 
 		return address == 0 ? 0 : static_cast<int>(*reinterpret_cast<const unsigned char *>(address + offset));
@@ -754,7 +748,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7F6 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x816 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x836 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x876 : offset);
 		
 		*reinterpret_cast<unsigned char *>(address + offset) = static_cast<unsigned char>(value);
@@ -769,7 +762,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7B8 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x7D4 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x7F4 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x834 : offset);
 		
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
@@ -789,7 +781,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7B8 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x7D4 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x7F4 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x834 : offset);
 		
 		*reinterpret_cast<float *>(address + offset) = value;
@@ -804,7 +795,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x824 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x844 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x864 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x8B4 : offset);
 		
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
@@ -819,7 +809,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x824 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x844 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x864 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x8B4 : offset);
 		
 		*reinterpret_cast<float *>(address + offset) = value;
@@ -834,7 +823,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x834 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x854 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x874 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x8C4 : offset);
 		
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
@@ -849,7 +837,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0xA00 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0xA10 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0xA30 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0xA80 : offset);
 		
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
@@ -864,7 +851,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x904 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x924 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x944 : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x994 : offset);
 
 		if (!address == 0)
@@ -887,7 +873,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x8FC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x91C : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x93C : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x98C : offset);
 
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
@@ -907,7 +892,6 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x8FC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x91C : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x93C : offset);
-		// TODO: 1365, 1493.0/1
 		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x98C : offset);
 
 		*reinterpret_cast<float *>(address + offset) = value;

--- a/source/scripting/Vehicle.cpp
+++ b/source/scripting/Vehicle.cpp
@@ -539,6 +539,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x89C : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x8BC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x8DC : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x92C : offset);
 
 		return address == 0 ? false : (*reinterpret_cast<int *>(address + offset) & (1 << 2)) != 0;
 	}
@@ -572,6 +574,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x89C : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x8BC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x8DC : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x92C : offset);
 
 		return address == 0 ? false : (*reinterpret_cast<int *>(address + offset) & (1 << 1)) != 0;
 	}
@@ -706,6 +710,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7F0 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x810 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x830 : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x870 : offset);
 
 		return address == 0 ? 0 : static_cast<int>(*reinterpret_cast<const unsigned char *>(address + offset));
 	}
@@ -719,6 +725,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7F6 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x816 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x836 : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x876 : offset);
 
 		return address == 0 ? 0 : static_cast<int>(*reinterpret_cast<const unsigned char *>(address + offset));
 	}
@@ -742,7 +750,9 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7F6 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x816 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x836 : offset);
-
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x876 : offset);
+		
 		*reinterpret_cast<unsigned char *>(address + offset) = static_cast<unsigned char>(value);
 	}
 	float Vehicle::FuelLevel::get()
@@ -755,7 +765,9 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7B8 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x7D4 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x7F4 : offset);
-
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x834 : offset);
+		
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
 	void Vehicle::FuelLevel::set(float value)
@@ -773,7 +785,9 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x7B8 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x7D4 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x7F4 : offset);
-
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x834 : offset);
+		
 		*reinterpret_cast<float *>(address + offset) = value;
 	}
 	float Vehicle::CurrentRPM::get()
@@ -786,7 +800,9 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x824 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x844 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x864 : offset);
-
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x8B4 : offset);
+		
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
 	void Vehicle::CurrentRPM::set(float value)
@@ -799,7 +815,9 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x824 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x844 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x864 : offset);
-
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x8B4 : offset);
+		
 		*reinterpret_cast<float *>(address + offset) = value;
 	}
 	float Vehicle::Acceleration::get()
@@ -812,7 +830,9 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x834 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x854 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x874 : offset);
-
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x8C4 : offset);
+		
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
 	float Vehicle::WheelSpeed::get()
@@ -825,7 +845,9 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0xA00 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0xA10 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0xA30 : offset);
-
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0xA80 : offset);
+		
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
 	float Vehicle::SteeringAngle::get()
@@ -838,6 +860,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x904 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x924 : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x944 : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x994 : offset);
 
 		if (!address == 0)
 		{
@@ -859,6 +883,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x8FC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x91C : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x93C : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x98C : offset);
 
 		return address == 0 ? 0.0f : *reinterpret_cast<const float *>(address + offset);
 	}
@@ -877,6 +903,8 @@ namespace GTA
 		offset = (Game::Version >= GameVersion::VER_1_0_1103_2_STEAM ? 0x8FC : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1180_2_STEAM ? 0x91C : offset);
 		offset = (Game::Version >= GameVersion::VER_1_0_1290_1_STEAM ? 0x93C : offset);
+		// TODO: 1365, 1493.0/1
+		offset = (Game::Version >= GameVersion::VER_1_0_1604_0_STEAM ? 0x98C : offset);
 
 		*reinterpret_cast<float *>(address + offset) = value;
 	}


### PR DESCRIPTION
I'm not able to check if the offsets are correct for b1365 and b1493, so if anybody is sure, please let me know so I can either add the correct offsets or remove the TODO note.

If you have a b1365 and/or b1493 at hand but no RE tool to verify, use v4.6.3 or v4.6.4 of my [manual transmission script](https://www.gta5-mods.com/scripts/manual-transmission-ikt) and enable logging debug stuff:

In the `ManualTransmission` directory, find `settings_general.ini`: In there, find `[DEBUG]` and change/add `LogLevel = 0`. The detected offsets will appear in `Gears.log` in the same directory.