### PR TITLE
Support long multibyte strings

### DIFF
--- a/source/core/Native.cpp
+++ b/source/core/Native.cpp
@@ -282,5 +282,104 @@ namespace GTA
 
 			return static_cast<T>(ObjectFromNative(T::typeid, task->_result));
 		}
+
+		int GetUtf8CodePointSize(System::String ^string, int index)
+		{
+			unsigned int chr = static_cast<unsigned int>(string[index]);
+
+			if (chr < 0)
+			{
+				return 0;
+			}
+			if (chr < 128)
+			{
+				return 1;
+			}
+			else if (chr < 2048)
+			{
+				return 2;
+			}
+			else if (chr < 65536)
+			{
+				return 3;
+			}
+			else
+			{
+#pragma region Surrogate check
+				int temp1 = static_cast<int>(chr) - HIGH_SURROGATE_START;
+				if (temp1 >= 0 && temp1 <= 0x7ff)
+				{
+					// Found a high surrogate
+					if (index < string->Length - 1)
+					{
+						int temp2 = (int)string[index + 1] - LOW_SURROGATE_START;
+						if (temp2 >= 0 && temp2 <= 0x3ff)
+						{
+							// Found a low surrogate
+							return 4;
+						}
+						else
+						{
+							return 0;
+						}
+					}
+					else
+					{
+						return 0;
+					}
+				}
+#pragma endregion
+			}
+
+			return 0;
+		}
+		void Function::PushLongString(System::String ^string)
+		{
+			PushLongString(string, 99);
+		}
+		void Function::PushLongString(System::String ^string, int maxLengthUtf8)
+		{
+			if (maxLengthUtf8 <= 0)
+			{
+				throw gcnew ArgumentOutOfRangeException("maxLengthUtf8");
+			}
+
+			const int size = Text::Encoding::UTF8->GetByteCount(string);
+
+			if (size <= maxLengthUtf8)
+			{
+				Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, string);
+				return;
+			}
+
+			int currentUtf8StrLength = 0;
+			int startPos = 0;
+			int currentPos;
+
+			for (currentPos = 0; currentPos < string->Length; currentPos++)
+			{
+				int codePointSize = GetUtf8CodePointSize(string, currentPos);
+
+				if (currentUtf8StrLength + codePointSize > maxLengthUtf8)
+				{
+					Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, string->Substring(startPos, currentPos - startPos));
+
+					currentUtf8StrLength = 0;
+					startPos = currentPos;
+				}
+				else
+				{
+					currentUtf8StrLength += codePointSize;
+				}
+
+				//if the code point size is 4, additional increment is needed
+				if (codePointSize == 4)
+				{
+					currentPos++;
+				}
+			}
+
+			Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, string->Substring(startPos, string->Length - startPos));
+		}
 	}
 }

--- a/source/core/Native.hpp
+++ b/source/core/Native.hpp
@@ -211,6 +211,8 @@ namespace GTA
 		internal:
 			generic <typename T>
 			static T Call(System::UInt64 hash, ... array<InputArgument ^> ^arguments);
+			static void PushLongString(System::String ^string);
+			static void PushLongString(System::String ^string, int maxLengthUtf8);
 		};
 	}
 }

--- a/source/scripting/Blip.cpp
+++ b/source/scripting/Blip.cpp
@@ -53,8 +53,8 @@ namespace GTA
 	}
 	void Blip::Name::set(System::String ^value)
 	{
-		Native::Function::Call(Native::Hash::_0xF9113A30DE5C6670, "STRING");
-		Native::Function::Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, value);
+		Native::Function::Call(Native::Hash::_0xF9113A30DE5C6670, "CELL_EMAIL_BCON");
+		Native::Function::PushLongString(value);
 		Native::Function::Call(Native::Hash::_0xBC38B49BCB83BC9B, Handle);
 	}
 	Math::Vector3 Blip::Position::get()

--- a/source/scripting/Scaleform.cpp
+++ b/source/scripting/Scaleform.cpp
@@ -71,14 +71,14 @@ namespace GTA
 			}
 			else if (argument->GetType() == String::typeid)
 			{
-				Native::Function::Call(Native::Hash::_BEGIN_TEXT_COMPONENT, "STRING");
-				Native::Function::Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, static_cast<String ^>(argument));
+				Native::Function::Call(Native::Hash::_BEGIN_TEXT_COMPONENT, "CELL_EMAIL_BCON");
+				Native::Function::PushLongString(static_cast<String ^>(argument));
 				Native::Function::Call(Native::Hash::_END_TEXT_COMPONENT);
 			}
 			else if (argument->GetType() == Char::typeid)
 			{
-				Native::Function::Call(Native::Hash::_BEGIN_TEXT_COMPONENT, "STRING");
-				Native::Function::Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, static_cast<char>(argument).ToString());
+				Native::Function::Call(Native::Hash::_BEGIN_TEXT_COMPONENT, "CELL_EMAIL_BCON");
+				Native::Function::PushLongString(static_cast<String ^>(argument));
 				Native::Function::Call(Native::Hash::_END_TEXT_COMPONENT);
 			}
 			else if (argument->GetType() == Single::typeid)

--- a/source/scripting/UI.cpp
+++ b/source/scripting/UI.cpp
@@ -25,12 +25,7 @@ namespace GTA
 	Notification ^UI::Notify(String ^message, bool blinking)
 	{
 		Native::Function::Call(Native::Hash::_SET_NOTIFICATION_TEXT_ENTRY, "CELL_EMAIL_BCON");
-		const int strLen = 99;
-		for (int i = 0; i < message->Length; i += strLen)
-		{
-			System::String ^substr = message->Substring(i, System::Math::Min(strLen, message->Length - i));
-			Native::Function::Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, substr);
-		}
+		Native::Function::PushLongString(message);
 
 		return gcnew Notification(Native::Function::Call<int>(Native::Hash::_DRAW_NOTIFICATION, blinking, 1));
 	}
@@ -42,12 +37,7 @@ namespace GTA
 	void UI::ShowSubtitle(String ^message, int duration)
 	{
 		Native::Function::Call(Native::Hash::_SET_TEXT_ENTRY_2, "CELL_EMAIL_BCON");
-		const int strLen = 99;
-		for (int i = 0; i < message->Length; i += strLen)
-		{
-			System::String ^substr = message->Substring(i, System::Math::Min(strLen, message->Length - i));
-			Native::Function::Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, substr);
-		}
+		Native::Function::PushLongString(message);
 		Native::Function::Call(Native::Hash::_DRAW_SUBTITLE_TIMED, duration, 1);
 	}
 

--- a/source/scripting/UIElement.cpp
+++ b/source/scripting/UIElement.cpp
@@ -81,8 +81,8 @@ namespace GTA
 		Native::Function::Call(Native::Hash::SET_TEXT_SCALE, Scale, Scale);
 		Native::Function::Call(Native::Hash::SET_TEXT_COLOUR, Color.R, Color.G, Color.B, Color.A);
 		Native::Function::Call(Native::Hash::SET_TEXT_CENTRE, Centered ? 1 : 0);
-		Native::Function::Call(Native::Hash::_SET_TEXT_ENTRY, "STRING");
-		Native::Function::Call(Native::Hash::_ADD_TEXT_COMPONENT_STRING, Caption);
+		Native::Function::Call(Native::Hash::_SET_TEXT_ENTRY, "CELL_EMAIL_BCON");
+		Native::Function::PushLongString(Caption);
 		Native::Function::Call(Native::Hash::_DRAW_TEXT, x, y);
 	}
 


### PR DESCRIPTION
Now supports long strings that contain non-ASCII characters.
Should `PushLongString` be public? It would be useful for script developers.

You can test if the function works by this
```
UI.Notify("Manufacturer of weapons - and reasons to own weapons, Ammu-Nation has zealously defended arms profiteering for over 50 years.");
UI.Notify("Fabricant d'armes et pourvoyeur de bonnes raisons pour en acheter, Ammu-Nation défend farouchement le commerce de l'armement depuis plus de 50 ans.");
UI.Notify("Ammu-Nation ist ein Waffenhersteller, der die Gründe, eine Waffe zu besitzen, gleich mitliefert. Seit mehr als 50 Jahren ein unerschütterlicher Verfechter des freien Waffenhandels.");
UI.Notify("Fabbricante d'armi e di motivi per possederne, da oltre 50 anni la Ammu-Nation difende il diritto di arricchirsi con le armi.");
UI.Notify("Ammu-Nation, fabricante de armas y de razones para tenerlas, lleva beneficiándose con su venta desde hace más de 50 años.");
UI.Notify("Fabricante de armas - e de motivos para se ter armas - a Ammu-Nation tem defendido o lucro com armamentos com zelo há mais de 50 anos.");
UI.Notify("Благодаря \"Амму- Нации\" у нас есть как оружие, так и повод им владеть. \"Амму-Нация\" - ревностно поддерживает торговлю оружием вот уже свыше 50 лет!");
UI.Notify("「アミュネーション」は武器を製造し(同時に武器を持つ理由をでっち上げながら)、50年以上に渡って銃器業界の利権を精力的に守ってきた。"); //this text shows properly only when the game language is set to Japanese
UI.Notify("既是武器制造商，也是您持有武器的理由，武装国度狂热鼓吹枪械暴利已有五十年之久。"); //this text shows properly only when the game language is set to Simplefied Chinese (this text shows almost properly when the language is set to Japanese, but the game show some tofus instead of missing characters
```
![character test 1](https://user-images.githubusercontent.com/9353978/51190910-a2a9cf00-1926-11e9-8ccd-c09aff46a47f.png)
![character test 2](https://user-images.githubusercontent.com/9353978/51190899-9cb3ee00-1926-11e9-8e28-8ac756c8a445.png)

