### PR TITLE
Support long multibyte strings (dev_v3)

### DIFF
--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -28,6 +28,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using GTA.Native;
 
 namespace GTA
 {
@@ -719,14 +720,14 @@ namespace GTA
 			Native.Function.Call(Native.Hash.SET_TEXT_FONT, font);
 			Native.Function.Call(Native.Hash.SET_TEXT_SCALE, scale, scale);
 			Native.Function.Call(Native.Hash.SET_TEXT_COLOUR, color.R, color.G, color.B, color.A);
-			Native.Function.Call(Native.Hash.BEGIN_TEXT_COMMAND_DISPLAY_TEXT, "CELL_EMAIL_BCON");
+			Native.Function.Call(Native.Hash.BEGIN_TEXT_COMMAND_DISPLAY_TEXT, MemoryAccess.CellEmailBcon);
 			Native.Function.PushLongString(text);
 			Native.Function.Call(Native.Hash.END_TEXT_COMMAND_DISPLAY_TEXT, xNew, yNew);
 		}
 
 		private float GetTextLength(string text, float scale, int font) //TODO Maybe implement somewhere else?
 		{
-			Native.Function.Call(Native.Hash._BEGIN_TEXT_COMMAND_WIDTH, "CELL_EMAIL_BCON");
+			Native.Function.Call(Native.Hash._BEGIN_TEXT_COMMAND_WIDTH, MemoryAccess.CellEmailBcon);
 			Native.Function.PushLongString(text);
 			Native.Function.Call(Native.Hash.SET_TEXT_FONT, font);
 			Native.Function.Call(Native.Hash.SET_TEXT_SCALE, scale, scale);

--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -720,28 +720,14 @@ namespace GTA
 			Native.Function.Call(Native.Hash.SET_TEXT_SCALE, scale, scale);
 			Native.Function.Call(Native.Hash.SET_TEXT_COLOUR, color.R, color.G, color.B, color.A);
 			Native.Function.Call(Native.Hash.BEGIN_TEXT_COMMAND_DISPLAY_TEXT, "CELL_EMAIL_BCON");
-
-			const int maxStringLength = 99;
-
-			for (int i = 0; i < text.Length; i += maxStringLength)
-			{
-				Native.Function.Call(Native.Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME, text.Substring(i, System.Math.Min(maxStringLength, text.Length - i)));
-			}
-
+			Native.Function.PushLongString(text);
 			Native.Function.Call(Native.Hash.END_TEXT_COMMAND_DISPLAY_TEXT, xNew, yNew);
 		}
 
 		private float GetTextLength(string text, float scale, int font) //TODO Maybe implement somewhere else?
 		{
 			Native.Function.Call(Native.Hash._BEGIN_TEXT_COMMAND_WIDTH, "CELL_EMAIL_BCON");
-
-			const int maxStringLength = 99;
-
-			for (int i = 0; i < text.Length; i += maxStringLength)
-			{
-				Native.Function.Call(Native.Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME, text.Substring(i, System.Math.Min(maxStringLength, text.Length - i)));
-			}
-
+			Native.Function.PushLongString(text);
 			Native.Function.Call(Native.Hash.SET_TEXT_FONT, font);
 			Native.Function.Call(Native.Hash.SET_TEXT_SCALE, scale, scale);
 

--- a/source/core/Native.cs
+++ b/source/core/Native.cs
@@ -466,7 +466,7 @@ namespace GTA
 			/// Gets the UTF-8 code point size from the character of string at index.
 			/// </summary>
 			/// <returns>The UTF-8 code point size.</returns>
-			private static int GetUtf8CodePointSize(string str, int index)
+			internal static int GetUtf8CodePointSize(string str, int index)
 			{
 				uint chr = str[index];
 

--- a/source/core/Native.cs
+++ b/source/core/Native.cs
@@ -461,6 +461,105 @@ namespace GTA
 
 				throw new InvalidCastException(String.Concat("Unable to cast native value to object of type '", type.FullName, "'"));
 			}
+
+			/// <summary>
+			/// Gets the UTF-8 code point size from the character of string at index.
+			/// </summary>
+			/// <returns>The UTF-8 code point size.</returns>
+			private static int GetUtf8CodePointSize(string str, int index)
+			{
+				uint chr = str[index];
+
+				if (chr < 0x80)
+				{
+					return 1;
+				}
+				if (chr < 0x800)
+				{
+					return 2;
+				}
+				if (chr < 0x10000)
+				{
+					return 3;
+				}
+				#region Surrogate check
+				const int HighSurrogateStart = 0xD800;
+				const int LowSurrogateStart = 0xD800;
+
+				var temp1 = (int)chr - HighSurrogateStart;
+				if (temp1 < 0 || temp1 > 0x7ff)
+				{
+					return 0;
+				}
+				// Found a high surrogate
+				if (index < str.Length - 1)
+				{
+					var temp2 = str[index + 1] - LowSurrogateStart;
+					if (temp2 >= 0 && temp2 <= 0x3ff)
+					{
+						// Found a low surrogate
+						return 4;
+					}
+
+					return 0;
+				}
+				else
+				{
+					return 0;
+				}
+				#endregion
+			}
+			/// <summary>
+			/// Passes a string to the native script function <see cref="Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME"/>.
+			/// This function can process the string properly even if the string byte length in UTF-8 is more than 99 or the string contains non-ASCII characters.
+			/// </summary>
+			/// <param name="str">The string to pass to <see cref="Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME"/>.</param>
+			/// <param name="maxLengthUtf8">The max byte length per call in UTF-8.</param>
+			internal static void PushLongString(string str, int maxLengthUtf8 = 99)
+			{
+				if (maxLengthUtf8 <= 0)
+				{
+					throw new ArgumentOutOfRangeException(nameof(maxLengthUtf8));
+				}
+
+				int size = Encoding.UTF8.GetByteCount(str);
+
+				if (size <= maxLengthUtf8)
+				{
+					Call(Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME, str);
+					return;
+				}
+
+				int currentUtf8StrLength = 0;
+				int startPos = 0;
+				int currentPos;
+
+				for (currentPos = 0; currentPos < str.Length; currentPos++)
+				{
+					int codePointSize = GetUtf8CodePointSize(str, currentPos);
+
+					if (currentUtf8StrLength + codePointSize > maxLengthUtf8)
+					{
+						Call(Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME, str.Substring(startPos, currentPos - startPos));
+
+						currentUtf8StrLength = 0;
+						startPos = currentPos;
+					}
+					else
+					{
+						currentUtf8StrLength += codePointSize;
+					}
+
+					//if the code point size is 4, additional increment is needed
+					if (codePointSize == 4)
+					{
+						currentPos++;
+					}
+				}
+
+				Call(Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME, str.Substring(startPos, str.Length - startPos));
+			}
+
 		}
 		#endregion
 

--- a/source/scripting/UI/Notification.cs
+++ b/source/scripting/UI/Notification.cs
@@ -16,7 +16,7 @@ namespace GTA.UI
 		/// <returns>The handle of the <see cref="Notification"/> which can be used to hide it using <see cref="Notification.Hide(int)"/>.</returns>
 		public static int Show(string message, bool blinking = false)
 		{
-			Function.Call(Hash._SET_NOTIFICATION_TEXT_ENTRY, "CELL_EMAIL_BCON");
+			Function.Call(Hash._SET_NOTIFICATION_TEXT_ENTRY, MemoryAccess.CellEmailBcon);
 			Native.Function.PushLongString(message);
 			return Function.Call<int>(Hash._DRAW_NOTIFICATION, blinking, true);
 		}

--- a/source/scripting/UI/Notification.cs
+++ b/source/scripting/UI/Notification.cs
@@ -17,14 +17,7 @@ namespace GTA.UI
 		public static int Show(string message, bool blinking = false)
 		{
 			Function.Call(Hash._SET_NOTIFICATION_TEXT_ENTRY, "CELL_EMAIL_BCON");
-
-			const int maxStringLength = 99;
-
-			for (int i = 0; i < message.Length; i += maxStringLength)
-			{
-				Function.Call(Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME, message.Substring(i, System.Math.Min(maxStringLength, message.Length - i)));
-			}
-
+			Native.Function.PushLongString(message);
 			return Function.Call<int>(Hash._DRAW_NOTIFICATION, blinking, true);
 		}
 

--- a/source/scripting/UI/Screen.cs
+++ b/source/scripting/UI/Screen.cs
@@ -316,14 +316,7 @@ namespace GTA.UI
 		public static void ShowSubtitle(string message, int duration = 2500)
 		{
 			Function.Call(Hash.BEGIN_TEXT_COMMAND_PRINT, MemoryAccess.CellEmailBcon);
-
-			const int maxStringLength = 99;
-
-			for (int i = 0; i < message.Length; i += maxStringLength)
-			{
-				Function.Call(Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME, message.Substring(i, System.Math.Min(maxStringLength, message.Length - i)));
-			}
-
+			Function.PushLongString(message);
 			Function.Call(Hash.END_TEXT_COMMAND_PRINT, duration, 1);
 		}
 		/// <summary>
@@ -333,12 +326,7 @@ namespace GTA.UI
 		public static void ShowHelpTextThisFrame(string helpText)
 		{
 			Function.Call(Hash.BEGIN_TEXT_COMMAND_DISPLAY_HELP, MemoryAccess.CellEmailBcon);
-			const int maxStringLength = 99;
-
-			for (int i = 0; i < helpText.Length; i += maxStringLength)
-			{
-				Function.Call(Hash.ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME, helpText.Substring(i, System.Math.Min(maxStringLength, helpText.Length - i)));
-			}
+			Function.PushLongString(helpText);
 			Function.Call(Hash.END_TEXT_COMMAND_DISPLAY_HELP, 0, 0, 1, -1);
 		}
 


### PR DESCRIPTION
Now long multibyte strings are processed properly. Long console texts draw properly even if the texts contain non-ASCII characters.

Before:
![271590_20190116161227_1](https://user-images.githubusercontent.com/9353978/51234168-522a8400-19af-11e9-927a-04b7638cd402.png)
`SSL/ャネル` is drawn instead of `SSL/TLS のセキュリティで保護されているチャネル`, and some characters at the line string of `WARN` aren't drawn.

After:
![271590_20190116161942_1](https://user-images.githubusercontent.com/9353978/51234185-59ea2880-19af-11e9-97eb-184c96ab196a.png)
All the characters in the console are properly drawn.