### PR TITLE
Get or set entity health without changing the value internally

### DIFF
--- a/source/scripting/World/Entities/Entity.cs
+++ b/source/scripting/World/Entities/Entity.cs
@@ -45,7 +45,7 @@ namespace GTA
 
 		/// <summary>
 		/// Gets or sets the health of this <see cref="Entity"/> as an <see cref="int"/>.
-		/// <para>Use <see cref="HealthFloat"/> instead if you need to get or set the value strictly, since a health value of <see cref="Entity"/> are stored as a <see cref="float"/>.</para>
+		/// <para>Use <see cref="HealthFloat"/> instead if you need to get or set the value strictly, since a health value of a <see cref="Entity"/> are stored as a <see cref="float"/>.</para>
 		/// </summary>
 		/// <value>
 		/// The health as an integer.

--- a/source/scripting/World/Entities/Entity.cs
+++ b/source/scripting/World/Entities/Entity.cs
@@ -54,11 +54,11 @@ namespace GTA
 		{
 			get
 			{
-				return Function.Call<int>(Hash.GET_ENTITY_HEALTH, Handle) - 100;
+				return Function.Call<int>(Hash.GET_ENTITY_HEALTH, Handle);
 			}
 			set
 			{
-				Function.Call(Hash.SET_ENTITY_HEALTH, Handle, value + 100);
+				Function.Call(Hash.SET_ENTITY_HEALTH, Handle, value);
 			}
 		}
 		/// <summary>

--- a/source/scripting/World/Entities/Entity.cs
+++ b/source/scripting/World/Entities/Entity.cs
@@ -91,20 +91,20 @@ namespace GTA
 		}
 		/// <summary>
 		/// Gets or sets the maximum health of this <see cref="Entity"/> as an <see cref="int"/>.
+		/// <para>Use <see cref="MaxHealthFloat"/> instead if you need to get or set the value strictly, since a max health value of a <see cref="Entity"/> are stored as a <see cref="float"/>.</para>
 		/// </summary>
 		/// <value>
-		/// The maximum health from 0 - 100 as an integer.
+		/// The maximum health as an integer.
 		/// </value>
-		/// <remarks>if you need to get or set the value strictly, use <see cref="MaxHealthFloat"/> instead.</remarks>
 		public int MaxHealth
 		{
 			get
 			{
-				return Function.Call<int>(Hash.GET_ENTITY_MAX_HEALTH, Handle) - 100;
+				return Function.Call<int>(Hash.GET_ENTITY_MAX_HEALTH, Handle);
 			}
 			set
 			{
-				Function.Call(Hash.SET_ENTITY_MAX_HEALTH, Handle, value + 100);
+				Function.Call(Hash.SET_ENTITY_MAX_HEALTH, Handle, value);
 			}
 		}
 		/// <summary>

--- a/source/scripting/World/Entities/Entity.cs
+++ b/source/scripting/World/Entities/Entity.cs
@@ -45,11 +45,12 @@ namespace GTA
 
 		/// <summary>
 		/// Gets or sets the health of this <see cref="Entity"/> as an <see cref="int"/>.
+		/// <para>Use <see cref="HealthFloat"/> instead if you need to get or set the value strictly, since a health value of <see cref="Entity"/> are stored as a <see cref="float"/>.</para>
 		/// </summary>
 		/// <value>
-		/// The health from 0 - 100 as an integer.
+		/// The health as an integer.
 		/// </value>
-		/// <remarks>if you need to get or set the value strictly, use <see cref="HealthFloat"/> instead.</remarks>
+		/// <seealso cref="HealthFloat"/>
 		public int Health
 		{
 			get


### PR DESCRIPTION
I believe we shouldn't change a value in `Entity.Health`, because it's obviously inconsistent with `Entity.HealthFloat` (the internal health value) and the ped threshold of death can be changed by changing the injury health threshold values. They can be changed via `Ped.FatalInjuryHealthThreshold` and `Ped.InjuryHealthThreshold`.