### PR TITLE
Support loading the same script from multiple assemblies

### DIFF
--- a/source/core/ScriptDomain.cs
+++ b/source/core/ScriptDomain.cs
@@ -300,6 +300,8 @@ namespace SHVDN
 					};
 
 					var key = BuildComparisonString(type, string.Empty);
+					key = assembly.GetName().Name + "-" + assembly.GetName().Version + key;
+
 					if (scriptTypes.ContainsKey(key))
 					{
 						Log.Message(Log.Level.Warning, "The script name ", type.FullName, " already exists and was loaded from ", Path.GetFileName(scriptTypes[key].Item1), ". Ignoring occurrence loaded from ", Path.GetFileName(filename), ".");


### PR DESCRIPTION
This adds support for loading the same script _name_ from multiple assemblies. This might be necessary if downstream projects implement support for SHVDN 3 using the same namespace, but different major versions (e.g. with `NativeUI`).