### PR TITLE
Altered ScriptHookVDotNet Class to expose Console.IsOpen.

### DIFF
--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -107,6 +107,8 @@ public:
 			console->PrintInfo(IO::Path::GetFileName(script->Filename) + " ~h~" + script->Name + (script->IsRunning ? (script->IsPaused ? " ~o~[paused]" : " ~g~[running]") : " ~r~[aborted]"));
 	}
 
+	static bool IsOpen = console->IsOpen;
+
 internal:
 	static SHVDN::Console ^console = nullptr;
 	static SHVDN::ScriptDomain ^domain = SHVDN::ScriptDomain::CurrentDomain;

--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -107,7 +107,10 @@ public:
 			console->PrintInfo(IO::Path::GetFileName(script->Filename) + " ~h~" + script->Name + (script->IsRunning ? (script->IsPaused ? " ~o~[paused]" : " ~g~[running]") : " ~r~[aborted]"));
 	}
 
-	static bool IsOpen = console->IsOpen;
+	static bool IsOpen()
+	{
+		return console->IsOpen;
+	}
 
 internal:
 	static SHVDN::Console ^console = nullptr;

--- a/source/scripting_v3/GTA/Script.cs
+++ b/source/scripting_v3/GTA/Script.cs
@@ -173,6 +173,17 @@ namespace GTA
 		}
 
 		/// <summary>
+		/// Checks if this <see cref="Script"/> is executing.
+		/// </summary>
+		public static bool IsConsoleOpen
+		{
+			get
+			{
+				return ScriptHookVDotNet.IsOpen;
+			}
+		}
+
+		/// <summary>
 		/// Gets an INI file associated with this <see cref="Script"/>.
 		/// The File will be in the same location as this <see cref="Script"/> but with an extension of ".ini".
 		/// Use this to save and load settings for this <see cref="Script"/>.

--- a/source/scripting_v3/GTA/Script.cs
+++ b/source/scripting_v3/GTA/Script.cs
@@ -179,7 +179,7 @@ namespace GTA
 		{
 			get
 			{
-				return ScriptHookVDotNet.IsOpen;
+				return ScriptHookVDotNet.IsOpen();
 			}
 		}
 


### PR DESCRIPTION
Added static IsConsoleOpen to GTA.Script.

Put this into a Pull Request just to start a discussion on if we can expose something like this for use in scripts. This exact implementation could be altered based on best use but it would make scripts able to close features when the console is opened. Such as NativeUI menu which takes up the same screen space as the console.

Its just a simple user friendly addition.
