### PR TITLE
Fix IsPersistent and MarkAsNoLongerNeeded() using the wrong natives

### DIFF
--- a/source/scripting_v2/GTA/Entities/Entity.cs
+++ b/source/scripting_v2/GTA/Entities/Entity.cs
@@ -68,7 +68,17 @@ namespace GTA
 		public bool IsPersistent
 		{
 			get => Function.Call<bool>(Hash.IS_ENTITY_A_MISSION_ENTITY, Handle);
-			set => Function.Call(Hash.SET_ENTITY_AS_MISSION_ENTITY, Handle, value, !value);
+			set
+			{
+				if (value)
+				{
+					Function.Call(Hash.SET_ENTITY_AS_MISSION_ENTITY, Handle, true, true);
+				}
+				else
+				{
+					MarkAsNoLongerNeeded();
+				}
+			}
 		}
 
 		public bool FreezePosition
@@ -579,7 +589,6 @@ namespace GTA
 		public void MarkAsNoLongerNeeded()
 		{
 			int handle = Handle;
-			Function.Call(Hash.SET_ENTITY_AS_MISSION_ENTITY, handle, false, true);
 			unsafe
 			{
 				Function.Call(Hash.SET_ENTITY_AS_NO_LONGER_NEEDED, &handle);

--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -116,7 +116,17 @@ namespace GTA
 		public bool IsPersistent
 		{
 			get => Function.Call<bool>(Hash.IS_ENTITY_A_MISSION_ENTITY, Handle);
-			set => Function.Call(Hash.SET_ENTITY_AS_MISSION_ENTITY, Handle, value, !value);
+			set
+			{
+				if (value)
+				{
+					Function.Call(Hash.SET_ENTITY_AS_MISSION_ENTITY, Handle, true, true);
+				}
+				else
+				{
+					MarkAsNoLongerNeeded();
+				}
+			}
 		}
 
 		/// <summary>
@@ -1197,7 +1207,6 @@ namespace GTA
 		public void MarkAsNoLongerNeeded()
 		{
 			int handle = Handle;
-			Function.Call(Hash.SET_ENTITY_AS_MISSION_ENTITY, handle, false, true);
 			unsafe
 			{
 				Function.Call(Hash.SET_ENTITY_AS_NO_LONGER_NEEDED, &handle);


### PR DESCRIPTION
Closes #906

This changes the `IsPersistent` setter to execute `MarkAsNoLongerNeeded()` instead of the native `SET_ENTITY_AS_MISSION_ENTITY` when passed `false`.

This also removed the `SET_ENTITY_AS_MISSION_ENTITY` native call from `MarkAsNoLongerNeeded()`, as all it was doing was marking and then un-marking the entity as a mission entity.

The original changes were made in [this](https://github.com/crosire/scripthookvdotnet/commit/9a22d7a) commit, where it was incorrectly assumed that the `SET_ENTITY_AS_MISSION_ENTITY` native could also make an entity non-persistent.