### PR TITLE
make beeping optional in Screen.ShowHelpTextThisFrame()

### DIFF
--- a/source/scripting_v3/GTA.UI/Screen.cs
+++ b/source/scripting_v3/GTA.UI/Screen.cs
@@ -239,11 +239,12 @@ namespace GTA.UI
 		/// Displays a help message in the top corner of the screen this frame.
 		/// </summary>
 		/// <param name="helpText">The text to display.</param>
-		public static void ShowHelpTextThisFrame(string helpText)
+		/// <param name="beep">Beeping sound will play if <c>true</c></param>
+		public static void ShowHelpTextThisFrame(string helpText, bool beep = true)
 		{
 			Function.Call(Hash.BEGIN_TEXT_COMMAND_DISPLAY_HELP, SHVDN.NativeMemory.CellEmailBcon);
 			SHVDN.NativeFunc.PushLongString(helpText);
-			Function.Call(Hash.END_TEXT_COMMAND_DISPLAY_HELP, 0, 0, 1, -1);
+			Function.Call(Hash.END_TEXT_COMMAND_DISPLAY_HELP, 0, 0, beep, -1);
 		}
 
 		// Space Conversion

--- a/source/scripting_v3/GTA.UI/Screen.cs
+++ b/source/scripting_v3/GTA.UI/Screen.cs
@@ -236,16 +236,25 @@ namespace GTA.UI
 			Function.Call(Hash.END_TEXT_COMMAND_PRINT, duration, 1);
 		}
 		/// <summary>
-		/// Displays a help message in the top corner of the screen this frame.
+		/// Displays a help message in the top corner of the screen this frame. Beeping sound will be played.
 		/// </summary>
 		/// <param name="helpText">The text to display.</param>
-		/// <param name="beep">Beeping sound will play if <c>true</c></param>
-		public static void ShowHelpTextThisFrame(string helpText, bool beep = true)
+		public static void ShowHelpTextThisFrame(string helpText)
+		{
+			ShowHelpTextThisFrame(helpText, true);			// keeping it DRY :)
+		}
+		/// <summary>
+		/// Displays a help message in the top corner of the screen this frame. Specify whether beeping sound plays.
+		/// </summary>
+		/// <param name="helpText">The text to display.</param>
+		/// <param name="beep">Whether to play beeping sound</param>
+		public static void ShowHelpTextThisFrame(string helpText, bool beep)
 		{
 			Function.Call(Hash.BEGIN_TEXT_COMMAND_DISPLAY_HELP, SHVDN.NativeMemory.CellEmailBcon);
 			SHVDN.NativeFunc.PushLongString(helpText);
 			Function.Call(Hash.END_TEXT_COMMAND_DISPLAY_HELP, 0, 0, beep, -1);
 		}
+
 
 		// Space Conversion
 


### PR DESCRIPTION
Added a parameter in `Screen.ShowHelpTextThisFrame()` to optionally suppress beeping sound when showing help text.

Motivation:  
I'd like to display elapsed time of a [race](https://github.com/DavidLiuGit/GTAV_Lap_Timer) in real time without the constant beeping sound.

Also, the help text lingers on screen for 3 seconds. According to [NativeDB](http://www.dev-c.com/nativedb/func/info/238ffe5c7b0498a6), the last param dictates how long the help text is shown. The current value `-1` is the default, which shows the help text for 3 seconds.