### PR TITLE
Add the possibility to use weapon names when giving weapons to entities.

### DIFF
--- a/source/scripting_v2/GTA/Weapons/WeaponCollection.cs
+++ b/source/scripting_v2/GTA/Weapons/WeaponCollection.cs
@@ -155,6 +155,11 @@ namespace GTA
 			return weapon;
 		}
 
+		public Weapon Give(string name, int ammoCount, bool equipNow, bool isAmmoLoaded)
+		{
+			return Give((WeaponHash)Game.GenerateHash(name), ammoCount, equipNow, isAmmoLoaded);
+		}
+
 		public void Drop()
 		{
 			Function.Call(Hash.SET_PED_DROPS_WEAPON, owner.Handle);

--- a/source/scripting_v3/GTA/Weapons/WeaponCollection.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponCollection.cs
@@ -155,6 +155,11 @@ namespace GTA
 			return weapon;
 		}
 
+		public Weapon Give(string name, int ammoCount, bool equipNow, bool isAmmoLoaded)
+		{
+			return Give((WeaponHash)Game.GenerateHash(name), ammoCount, equipNow, isAmmoLoaded);
+		}
+
 		public void Drop()
 		{
 			Function.Call(Hash.SET_PED_DROPS_WEAPON, owner.Handle);


### PR DESCRIPTION
Useful for weapon addons. As of now the way of giving custom weapons is:

```
WeaponHash screwdriverHash = Function.Call<WeaponHash>(Hash.GET_HASH_KEY, "WEAPON_SCREWDRIVER"); // WEAPON_SCREWDRIVER Is the name given in `C:\Program Files (x86)\Steam\steamapps\common\Grand Theft Auto V\mods\update\x64\dlcpacks\dlcname\dlc.rpf\common\data\ai\weaponname.meta`

Weapon weapon = player.Character.Weapons.Give(screwdriverHash, 1, true, true);
```

This PR makes it simple as:

`player.Character.Weapons.Give("WEAPON_SCREWDRIVER", 1, true, true);`

