### PR TITLE
Add item count and capacity methods for Entity

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1182,6 +1182,61 @@ namespace SHVDN
 			}
 			return 0;
 		}
+		public static int GetObjectCount()
+		{
+			if (*ObjectPoolAddress != 0)
+			{
+				GenericPool* pool = (GenericPool*)(*ObjectPoolAddress);
+				return (int)pool->itemCount;
+			}
+			return 0;
+		}
+		public static int GetPickupObjectCount()
+		{
+			if (*PickupObjectPoolAddress != 0)
+			{
+				GenericPool* pool = (GenericPool*)(*PickupObjectPoolAddress);
+				return (int)pool->itemCount;
+			}
+			return 0;
+		}
+
+		public static int GetPedCapacity()
+		{
+			if (*PedPoolAddress != 0)
+			{
+				GenericPool* pool = (GenericPool*)(*PedPoolAddress);
+				return (int)pool->size;
+			}
+			return 0;
+		}
+		public static int GetVehicleCapacity()
+		{
+			if (*VehiclePoolAddress != 0)
+			{
+				VehiclePool* pool = *(VehiclePool**)(*VehiclePoolAddress);
+				return (int)pool->size;
+			}
+			return 0;
+		}
+		public static int GetObjectCapacity()
+		{
+			if (*ObjectPoolAddress != 0)
+			{
+				GenericPool* pool = (GenericPool*)(*ObjectPoolAddress);
+				return (int)pool->size;
+			}
+			return 0;
+		}
+		public static int GetPickupObjectCapacity()
+		{
+			if (*PickupObjectPoolAddress != 0)
+			{
+				GenericPool* pool = (GenericPool*)(*PickupObjectPoolAddress);
+				return (int)pool->size;
+			}
+			return 0;
+		}
 
 		public static int[] GetPedHandles(int[] modelHashes = null)
 		{

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -945,6 +945,8 @@ namespace SHVDN
 			public uint size;
 			[FieldOffset(0x14)]
 			public uint itemSize;
+			[FieldOffset(0x20)]
+			public ushort itemCount;
 
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			public bool IsValid(uint index)
@@ -1167,7 +1169,7 @@ namespace SHVDN
 			if (*PedPoolAddress != 0)
 			{
 				GenericPool* pool = (GenericPool*)(*PedPoolAddress);
-				return (int)pool->itemSize;
+				return (int)pool->itemCount;
 			}
 			return 0;
 		}

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -615,7 +615,7 @@ namespace GTA
 		/// <remarks>returns <c>null</c> if the <see cref="Ped"/> could not be spawned</remarks>
 		public static Ped CreatePed(Model model, Vector3 position, float heading = 0f)
 		{
-			if (!model.IsPed || !model.Request(1000))
+			if (PedCount >= PedCapacity || !model.IsPed || !model.Request(1000))
 			{
 				return null;
 			}
@@ -628,6 +628,11 @@ namespace GTA
 		/// <param name="position">The position to spawn the <see cref="Ped"/> at.</param>
 		public static Ped CreateRandomPed(Vector3 position)
 		{
+			if (PedCount >= PedCapacity)
+			{
+				return null;
+			}
+
 			return new Ped(Function.Call<int>(Hash.CREATE_RANDOM_PED, position.X, position.Y, position.Z));
 		}
 
@@ -640,7 +645,7 @@ namespace GTA
 		/// <remarks>returns <c>null</c> if the <see cref="Vehicle"/> could not be spawned</remarks>
 		public static Vehicle CreateVehicle(Model model, Vector3 position, float heading = 0f)
 		{
-			if (!model.IsVehicle || !model.Request(1000))
+			if (VehicleCount >= VehicleCapacity || !model.IsVehicle || !model.Request(1000))
 			{
 				return null;
 			}
@@ -679,7 +684,7 @@ namespace GTA
 		/// <remarks>returns <c>null</c> if the <see cref="Prop"/> could not be spawned</remarks>
 		public static Prop CreateProp(Model model, Vector3 position, bool dynamic, bool placeOnGround)
 		{
-			if (!model.Request(1000))
+			if (PropCount >= PropCapacity || !model.Request(1000))
 			{
 				return null;
 			}
@@ -720,7 +725,7 @@ namespace GTA
 		/// <remarks>returns <c>null</c> if the <see cref="Prop"/> could not be spawned</remarks>
 		public static Prop CreatePropNoOffset(Model model, Vector3 position, bool dynamic)
 		{
-			if (!model.Request(1000))
+			if (PropCount >= PropCapacity || !model.Request(1000))
 			{
 				return null;
 			}

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -325,9 +325,41 @@ namespace GTA
 		#region Entities
 
 		/// <summary>
-		/// A fast way to get the total number of vehicles spawned in the world.
+		/// A fast way to get the total number of <see cref="Vehicle"/>s spawned in the world.
 		/// </summary>
 		public static int VehicleCount => SHVDN.NativeMemory.GetVehicleCount();
+		/// <summary>
+		/// A fast way to get the total number of <see cref="Ped"/>s spawned in the world.
+		/// </summary>
+		public static int PedCount => SHVDN.NativeMemory.GetPedCount();
+		/// <summary>
+		/// A fast way to get the total number of <see cref="Prop"/>s spawned in the world.
+		/// </summary>
+		public static int PropCount => SHVDN.NativeMemory.GetObjectCount();
+		/// <summary>
+		/// A fast way to get the total number of <see cref="Prop"/>s in the world associated with a <see cref="Pickup"/>.
+		/// </summary>
+		public static int PickupObjectCount => SHVDN.NativeMemory.GetPickupObjectCount();
+
+		/// <summary>
+		/// The total number of <see cref="Vehicle"/>s that can exist in the world.
+		/// </summary>
+		/// <remarks>The game will crash when the number of <see cref="Vehicle"/> is the same as this limit and the game tries to create a <see cref="Vehicle"/>.</remarks>
+		public static int VehicleCapacity => SHVDN.NativeMemory.GetVehicleCapacity();
+		/// <summary>
+		/// The total number of <see cref="Ped"/>s that can exist in the world.
+		/// </summary>
+		/// <remarks>The game will crash when the number of <see cref="Ped"/> is the same as this limit and the game tries to create a <see cref="Ped"/>.</remarks>
+		public static int PedCapacity => SHVDN.NativeMemory.GetPedCapacity();
+		/// <summary>
+		/// The total number of <see cref="Prop"/>s that can exist in the world.
+		/// </summary>
+		/// <remarks>The game will crash when the number of <see cref="Prop"/> is the same as this limit and the game tries to create a <see cref="Prop"/>.</remarks>
+		public static int PropCapacity => SHVDN.NativeMemory.GetObjectCapacity();
+		/// <summary>
+		/// The total number of <see cref="Prop"/>s in the world associated with a <see cref="Pickup"/> that can exist in the world.
+		/// </summary>
+		public static int PickupObjectCapacity => SHVDN.NativeMemory.GetPickupObjectCapacity();
 
 		/// <summary>
 		/// Gets the closest <see cref="Ped"/> to a given position in the World.


### PR DESCRIPTION
It's really important not to exceed pool size limits. It's because the game will crash when the number of entity is the same as pool size and you try to create more entities. This doesn't change since GTA III. I'm not sure if the same will apply to the pool for pickup objects, though.
The methods to get pool capacities will help you when you want to spawn so many entities.