### PR TITLE
Add Vehicle.HandlingData

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -315,6 +315,12 @@ namespace SHVDN
 				AlarmTimeOffset = *(int*)(address + 52);
 			}
 
+			address = FindPattern("\x44\x0F\x2F\x43\x00\x45\x8D\x74\x24\x01", "xxxx?xxxxx");
+			if (address != null)
+			{
+				HandlingDataOffset = *(int*)(address - 35);
+			}
+
 			// Generate vehicle model list
 			List<int>[] hashes = new List<int>[0x20];
 			for (int i = 0; i < 0x20; i++)
@@ -880,6 +886,8 @@ namespace SHVDN
 		public static int NeedsToBeHotwiredOffset { get; }
 
 		public static int AlarmTimeOffset { get; }
+
+		public static int HandlingDataOffset { get; }
 
 		#endregion
 

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -210,6 +210,20 @@ namespace GTA
 			set => Function.Call(Hash.SET_VEHICLE_LOD_MULTIPLIER, Handle, value);
 		}
 
+		public HandlingData HandlingData
+		{
+			get
+			{
+				var address = MemoryAddress;
+				if (address == IntPtr.Zero || SHVDN.NativeMemory.HandlingDataOffset == 0)
+				{
+					return new HandlingData(IntPtr.Zero);
+				}
+
+				return new HandlingData(SHVDN.NativeMemory.ReadAddress(MemoryAddress + SHVDN.NativeMemory.HandlingDataOffset));
+			}
+		}
+
 		#endregion
 
 		#region Health


### PR DESCRIPTION
The static method name  `HandlingData.GetByVehicleModel` is not that short, but I think the non-static method name `Vehicle.HandlingData` is short enough and easier to find. Besides, you don't have to implicitly call `GET_ENTITY_MODEL` and that automatically avoids unnecessary thread switching. Few scripts would call `HandlingData.GetByVehicleModel` a lot of times though, unlike properties or methods like `Entity.Position`.