### PR TITLE
Add tons of blip methods

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1604,6 +1604,19 @@ namespace SHVDN
 			}
 		}
 
+		public static int GetNorthBlip()
+		{
+			if (RadarBlipPoolAddress != null)
+			{
+				ulong northBlipAddress = *(RadarBlipPoolAddress + 2);
+
+				if (northBlipAddress != 0)
+					return *(int*)(northBlipAddress + 4);
+			}
+
+			return -1;
+		}
+
 		public static IntPtr GetBlipAddress(int handle)
 		{
 			if (RadarBlipPoolAddress == null)

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1604,6 +1604,29 @@ namespace SHVDN
 			}
 		}
 
+		public static IntPtr GetBlipAddress(int handle)
+		{
+			if (RadarBlipPoolAddress == null)
+			{
+				return IntPtr.Zero;
+			}
+
+			int poolIndexOfHandle = handle & 0xFFFF;
+			int possibleBlipCount = *(int*)(RadarBlipPoolAddress - 1);
+
+			if (poolIndexOfHandle >= possibleBlipCount)
+			{
+				return IntPtr.Zero;
+			}
+
+			ulong address = *(RadarBlipPoolAddress + poolIndexOfHandle);
+
+			if (address != 0 && *(int*)(address + 4) == handle)
+				return new IntPtr((long)address);
+
+			return IntPtr.Zero;
+		}
+
 		#endregion
 
 		#region -- Entity Addresses --

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -200,6 +200,9 @@ namespace SHVDN
 			GetCheckpointBaseAddress = GetDelegateForFunctionPointer<GetCheckpointBaseAddressDelegate>(new IntPtr(*(int*)(address - 19) + address - 15));
 			GetCheckpointHandleAddress = GetDelegateForFunctionPointer<GetCheckpointHandleAddressDelegate>(new IntPtr(*(int*)(address - 9) + address - 5));
 
+			address = FindPattern("\x4C\x8D\x05\x00\x00\x00\x00\x0F\xB7\xC1", "xxx????xxx");
+			RadarBlipPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
+
 			address = FindPattern("\x48\x8B\x0B\x33\xD2\xE8\x00\x00\x00\x00\x89\x03", "xxxxxx????xx");
 			GetHashKeyFunc = GetDelegateForFunctionPointer<GetHashKeyDelegate>(new IntPtr(*(int*)(address + 6) + address + 10));
 
@@ -1148,6 +1151,7 @@ namespace SHVDN
 		static ulong* PickupObjectPoolAddress;
 		static ulong* VehiclePoolAddress;
 		static ulong* CheckpointPoolAddress;
+		static ulong* RadarBlipPoolAddress;
 
 		delegate ulong EntityPosFuncDelegate(ulong address, float* position);
 		delegate ulong EntityModel1FuncDelegate(ulong address);
@@ -1533,6 +1537,71 @@ namespace SHVDN
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
 
 			return task.handles.ToArray();
+		}
+
+		#endregion
+
+		#region -- Radar Blip Pool --
+
+		public static int[] GetNonCriticalRadarBlipHandles(params int[] spriteTypes)
+		{
+			return GetNonCriticalRadarBlipHandles(null, 0f, spriteTypes);
+		}
+		public static int[] GetNonCriticalRadarBlipHandles(float[] position = null, float radius = 0f, params int[] spriteTypes)
+		{
+			if (RadarBlipPoolAddress == null)
+			{
+				return new int[0];
+			}
+
+			int possibleBlipCount = *(int*)(RadarBlipPoolAddress - 1);
+
+			var handles = new List<int>(possibleBlipCount);
+
+			// Skip the first 3 critical blips, just like GET_FIRST_BLIP_INFO_ID does
+			// The second critical blip is the player blip and the third is the north blip (The first is unknown)
+			for (int i = 3; i < possibleBlipCount; i++)
+			{
+				ulong address = *(RadarBlipPoolAddress + i);
+
+				if (address == 0)
+					continue;
+
+				if (CheckBlip(address, position, radius, spriteTypes))
+					handles.Add(*(int*)(address + 4));
+			}
+
+			return handles.ToArray();
+
+			bool CheckBlip(ulong blipAddress, float[] position, float radius, params int[] spriteTypes)
+			{
+				if (spriteTypes.Length > 0)
+				{
+					int spriteIndex = *(int*)(blipAddress + 0x40);
+					if (!Array.Exists(spriteTypes, x => x == spriteIndex))
+						return false;
+				}
+
+				if (position != null && radius > 0f)
+				{
+					float* blipPosition = stackalloc float[3];
+
+					blipPosition[0] = *(float*)(blipAddress + 0x10);
+					blipPosition[1] = *(float*)(blipAddress + 0x14);
+					blipPosition[2] = *(float*)(blipAddress + 0x18);
+
+					float x = blipPosition[0] - position[0];
+					float y = blipPosition[1] - position[1];
+					float z = blipPosition[2] - position[2];
+					float distanceSquared = (x * x) + (y * y) + (z * z);
+					float radiusSquared = radius * radius;
+
+					if (distanceSquared > radiusSquared)
+						return false;
+				}
+
+				return true;
+			}
 		}
 
 		#endregion

--- a/source/scripting_v2/GTA/World.cs
+++ b/source/scripting_v2/GTA/World.cs
@@ -317,21 +317,7 @@ namespace GTA
 
 		public static Blip[] GetActiveBlips()
 		{
-			List<Blip> res = new List<Blip>();
-
-			foreach (BlipSprite sprite in Enum.GetValues(typeof(BlipSprite)))
-			{
-				int handle = Function.Call<int>(Hash.GET_FIRST_BLIP_INFO_ID, (int)sprite);
-
-				while (Function.Call<bool>(Hash.DOES_BLIP_EXIST, handle))
-				{
-					res.Add(new Blip(handle));
-
-					handle = Function.Call<int>(Hash.GET_NEXT_BLIP_INFO_ID, (int)sprite);
-				}
-			}
-
-			return res.ToArray();
+			return Array.ConvertAll(SHVDN.NativeMemory.GetNonCriticalRadarBlipHandles(), handle => new Blip(handle));
 		}
 
 		public static Entity[] GetAllEntities()

--- a/source/scripting_v3/GTA/Blip.cs
+++ b/source/scripting_v3/GTA/Blip.cs
@@ -32,7 +32,7 @@ namespace GTA
 		/// <summary>
 		/// Gets or sets the display type of this <see cref="Blip"/>.
 		/// </summary>
-		public BlipDisplayType BlipDisplayType
+		public BlipDisplayType DisplayType
 		{
 			get
 			{

--- a/source/scripting_v3/GTA/Blip.cs
+++ b/source/scripting_v3/GTA/Blip.cs
@@ -50,7 +50,7 @@ namespace GTA
 		/// <summary>
 		/// Gets or sets the category type of this <see cref="Blip"/>.
 		/// </summary>
-		public BlipCategoryType BlipCategoryType
+		public BlipCategoryType CategoryType
 		{
 			get
 			{

--- a/source/scripting_v3/GTA/Blip.cs
+++ b/source/scripting_v3/GTA/Blip.cs
@@ -363,11 +363,12 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets or sets the interval in ms between each blip flashing.
-		/// The value is up to 65534.
+		/// Gets or sets the flash time left in ms before this <see cref="Blip"/> stops flashing.
+		/// The max value is up to 65534.
+		/// Set <c>-1</c> to let the <see cref="Blip"/> flash forever.
 		/// </summary>
-		/// <remarks>returns <c>-1</c> if the internal value of this property value is set to <c>65535</c>, which indicates that the flashing timer is not set.</remarks>
-		public int FlashTimer
+		/// <remarks>returns <c>-1</c> if the internal value of this property value is set to <c>65535</c>, which indicates that the flash timer is explicitly not set.</remarks>
+		public int FlashTimeLeft
 		{
 			get
 			{

--- a/source/scripting_v3/GTA/BlipCategoryType.cs
+++ b/source/scripting_v3/GTA/BlipCategoryType.cs
@@ -1,0 +1,29 @@
+//
+// Copyright (C) 2015 crosire & contributors
+// License: https://github.com/crosire/scripthookvdotnet#license
+//
+
+namespace GTA
+{
+	public enum BlipCategoryType
+	{
+		NoDistanceShown = 1,
+		DistanceShown,
+		/// <summary>
+		/// <para>Blips will show under the "Other Players" category listing in the map legend, regardless of name. Also shows distance in the map legend.</para>
+		/// <para>
+		/// When the game language is set to a non-CJK language, the blip name will show with <see cref="UI.Font.ChaletComprimeCologne"/>.
+		/// When the game language is set to a CJK language and the vanilla font files are used, the blip name will show with the default CJK font used for the current language.
+		/// </para>
+		/// </summary>
+		OtherPlayers = 7,
+		/// <summary>
+		/// <para>Blips will show under the "Property" category listing in the map legend, regardless of name.</para>
+		/// </summary>
+		Property = 10,
+		/// <summary>
+		/// <para>Blips will show under the "Owned Property" category listing in the map legend, regardless of name.</para>
+		/// </summary>
+		OwnedProperty,
+	}
+}

--- a/source/scripting_v3/GTA/BlipDisplayType.cs
+++ b/source/scripting_v3/GTA/BlipDisplayType.cs
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2015 crosire & contributors
+// License: https://github.com/crosire/scripthookvdotnet#license
+//
+
+namespace GTA
+{
+	public enum BlipDisplayType
+	{
+		NoDisplay,
+		BothMapSelectable = 2,
+		MainMapSelectable,
+		/// <summary>
+		/// The default value on blip creation. Works in the same way as <see cref="BothMapSelectable"/>.
+		/// </summary>
+		Default,
+		MiniMapOnly,
+		BothMapNoSelectable = 8,
+	}
+}

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -79,9 +79,9 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets the main blip of the <see cref="GTA.Player"/> that you are controlling.
+		/// Gets the blip of the <see cref="GTA.Player"/> that you are controlling.
 		/// </summary>
-		public static Blip MainPlayerBlip => new Blip(Function.Call<int>(Hash.GET_MAIN_PLAYER_BLIP_ID));
+		public static Blip PlayerBlip => new Blip(Function.Call<int>(Hash.GET_MAIN_PLAYER_BLIP_ID));
 
 		/// <summary>
 		/// Gets the north blip, which is shown on the radar.

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -79,6 +79,16 @@ namespace GTA
 		}
 
 		/// <summary>
+		/// Gets the main blip of the <see cref="GTA.Player"/> that you are controlling.
+		/// </summary>
+		public static Blip MainPlayerBlip => new Blip(Function.Call<int>(Hash.GET_MAIN_PLAYER_BLIP_ID));
+
+		/// <summary>
+		/// Gets the north blip, which is shown on the radar.
+		/// </summary>
+		public static Blip NorthBlip => Version >= GameVersion.v1_0_463_1_Steam ? new Blip(Function.Call<int>((Hash)0x3F0CF9CB7E589B88)) : new Blip(SHVDN.NativeMemory.GetNorthBlip());
+
+		/// <summary>
 		/// Gets the current game language.
 		/// </summary>
 		public static Language Language => Function.Call<Language>(Hash.GET_CURRENT_LANGUAGE);

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -283,23 +283,8 @@ namespace GTA
 		/// <param name="blipTypes">The blip types to include, leave blank to get all <see cref="Blip"/>s.</param>
 		public static Blip[] GetAllBlips(params BlipSprite[] blipTypes)
 		{
-			var res = new List<Blip>();
-			if (blipTypes.Length == 0)
-			{
-				blipTypes = Enum.GetValues(typeof(BlipSprite)).Cast<BlipSprite>().ToArray();
-			}
-			foreach (BlipSprite sprite in blipTypes)
-			{
-				int handle = Function.Call<int>(Hash.GET_FIRST_BLIP_INFO_ID, sprite);
-
-				while (Function.Call<bool>(Hash.DOES_BLIP_EXIST, handle))
-				{
-					res.Add(new Blip(handle));
-
-					handle = Function.Call<int>(Hash.GET_NEXT_BLIP_INFO_ID, sprite);
-				}
-			}
-			return res.ToArray();
+			int[] blipTypesInt = Array.ConvertAll(blipTypes, blipType => (int)blipType);
+			return Array.ConvertAll(SHVDN.NativeMemory.GetNonCriticalRadarBlipHandles(blipTypesInt), handle => new Blip(handle));
 		}
 
 		/// <summary>

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -288,6 +288,18 @@ namespace GTA
 		}
 
 		/// <summary>
+		/// Gets an <c>array</c> of all <see cref="Blip"/>s in a given region in the World.
+		/// </summary>
+		/// <param name="position">The position to check the <see cref="Blip"/> against.</param>
+		/// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="Blip"/>s.</param>
+		/// <param name="blipTypes">The blip types to include, leave blank to get all <see cref="Blip"/>s.</param>
+		public static Blip[] GetNearbyBlips(Vector3 position, float radius, params BlipSprite[] blipTypes)
+		{
+			int[] blipTypesInt = Array.ConvertAll(blipTypes, blipType => (int)blipType);
+			return Array.ConvertAll(SHVDN.NativeMemory.GetNonCriticalRadarBlipHandles(position.ToArray(), radius, blipTypesInt), handle => new Blip(handle));
+		}
+
+		/// <summary>
 		/// Creates a <see cref="Blip"/> at the given position on the map.
 		/// </summary>
 		/// <param name="position">The position of the blip on the map.</param>

--- a/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
+++ b/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
@@ -81,7 +81,9 @@
     <Compile Include="GTA\Audio.cs" />
     <Compile Include="GTA\AudioFlags.cs" />
     <Compile Include="GTA\Blip.cs" />
+    <Compile Include="GTA\BlipCategoryType.cs" />
     <Compile Include="GTA\BlipColor.cs" />
+    <Compile Include="GTA\BlipDisplayType.cs" />
     <Compile Include="GTA\BlipSprite.cs" />
     <Compile Include="GTA\Button.cs" />
     <Compile Include="GTA\Camera.cs" />


### PR DESCRIPTION
This PR mainly consists of tons of blip properties and several blip methods. Also changes how to retrieve all blip handles `World.GetAllBlips` in v3 API and `World.GetActiveBlips` in in v2 API, to make them perform faster and retrieve all (non-critical) blips without `BlipSprite` getting updated.
I'm not sure which class `MainPlayerBlip` and `NorthBlip` should be in, though.