### PR TITLE
Add "Ped.GetAllModels" and "Weapon.GetAllModels" methods

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -322,9 +322,12 @@ namespace SHVDN
 			}
 
 			// Generate vehicle model list
-			List<int>[] hashes = new List<int>[0x20];
+			var vehicleHashes = new List<int>[0x20];
 			for (int i = 0; i < 0x20; i++)
-				hashes[i] = new List<int>();
+				vehicleHashes[i] = new List<int>();
+
+			var weaponObjectHashes = new List<int>();
+			var pedHashes = new List<int>();
 
 			for (int i = 0; i < modelHashEntries; i++)
 			{
@@ -340,9 +343,17 @@ namespace SHVDN
 							ulong addr2 = *(ulong*)(addr1);
 							if (addr2 != 0)
 							{
-								if ((*(byte*)(addr2 + 157) & 0x1F) == 5)
+								switch ((ModelInfoClassType)(*(byte*)(addr2 + 157) & 0x1F))
 								{
-									hashes[*(byte*)(addr2 + vehicleClassOffset) & 0x1F].Add(cur->hash);
+									case ModelInfoClassType.Weapon:
+										weaponObjectHashes.Add(cur->hash);
+										break;
+									case ModelInfoClassType.Vehicle:
+										vehicleHashes[*(byte*)(addr2 + vehicleClassOffset) & 0x1F].Add(cur->hash);
+										break;
+									case ModelInfoClassType.Ped:
+										pedHashes.Add(cur->hash);
+										break;
 								}
 							}
 						}
@@ -350,10 +361,13 @@ namespace SHVDN
 				}
 			}
 
-			var result = new ReadOnlyCollection<int>[0x20];
+			var vehicleResult = new ReadOnlyCollection<int>[0x20];
 			for (int i = 0; i < 0x20; i++)
-				result[i] = Array.AsReadOnly(hashes[i].ToArray());
-			VehicleModels = Array.AsReadOnly(result);
+				vehicleResult[i] = Array.AsReadOnly(vehicleHashes[i].ToArray());
+			VehicleModels = Array.AsReadOnly(vehicleResult);
+
+			WeaponModels = Array.AsReadOnly(weaponObjectHashes.ToArray());
+			PedModels = Array.AsReadOnly(pedHashes.ToArray());
 
 			#region -- Enable All DLC Vehicles --
 			// no need to patch the global variable in v1.0.573.1 or older builds
@@ -1028,7 +1042,9 @@ namespace SHVDN
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Trailer;
 		}
 
+		public static ReadOnlyCollection<int> WeaponModels { get; }
 		public static ReadOnlyCollection<ReadOnlyCollection<int>> VehicleModels { get; }
+		public static ReadOnlyCollection<int> PedModels { get; }
 
 		delegate ulong GetHandlingDataByHashDelegate(IntPtr hashAddress);
 		delegate ulong GetHandlingDataByIndexDelegate(int index);

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -7,6 +7,7 @@ using GTA.Math;
 using GTA.Native;
 using GTA.NaturalMotion;
 using System;
+using System.Linq;
 
 namespace GTA
 {
@@ -1124,5 +1125,10 @@ namespace GTA
 		}
 
 		#endregion
+
+		public static PedHash[] GetAllPedModels()
+		{
+			return SHVDN.NativeMemory.PedModels.Select(x => (PedHash)x).ToArray();
+		}
 	}
 }

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -1126,7 +1126,7 @@ namespace GTA
 
 		#endregion
 
-		public static PedHash[] GetAllPedModels()
+		public static PedHash[] GetAllModels()
 		{
 			return SHVDN.NativeMemory.PedModels.Select(x => (PedHash)x).ToArray();
 		}

--- a/source/scripting_v3/GTA/Weapons/Weapon.cs
+++ b/source/scripting_v3/GTA/Weapons/Weapon.cs
@@ -291,7 +291,7 @@ namespace GTA
 			return "WT_INVALID";
 		}
 
-		public static Model[] GetAllWeaponObjectModels()
+		public static Model[] GetAllModels()
 		{
 			return SHVDN.NativeMemory.WeaponModels.Select(x => new Model(x)).ToArray();
 		}

--- a/source/scripting_v3/GTA/Weapons/Weapon.cs
+++ b/source/scripting_v3/GTA/Weapons/Weapon.cs
@@ -3,6 +3,7 @@
 // License: https://github.com/crosire/scripthookvdotnet#license
 //
 
+using System.Linq;
 using GTA.Native;
 
 namespace GTA
@@ -288,6 +289,11 @@ namespace GTA
 			}
 
 			return "WT_INVALID";
+		}
+
+		public static Model[] GetAllWeaponObjectModels()
+		{
+			return SHVDN.NativeMemory.WeaponModels.Select(x => new Model(x)).ToArray();
 		}
 	}
 }


### PR DESCRIPTION
I'm not adding `Prop.GetAllPropModels()` this time because the number of `CBaseModelInfo` (iirc) can be changed on interior loading/unloading and that changes what `Prop.GetAllPropModels()` returns.