### PR TITLE
Add Model.IsMotorcycle

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1150,6 +1150,11 @@ namespace SHVDN
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Blimp;
 		}
+		public static bool IsModelAMotorcycle(int modelHash)
+		{
+			IntPtr modelInfo = FindCModelInfo(modelHash);
+			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Bike;
+		}
 		public static bool IsModelASubmarine(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);

--- a/source/scripting_v3/GTA/Entities/Model.cs
+++ b/source/scripting_v3/GTA/Entities/Model.cs
@@ -203,7 +203,13 @@ namespace GTA
 		/// <c>true</c> if this <see cref="Model"/> is a regular lowrider; otherwise, <c>false</c>.
 		/// </value>
 		public bool IsLowrider => SHVDN.NativeMemory.HasVehicleFlag(Hash, NativeMemory.VehicleFlag2.HasLowriderHydraulics);
-
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="Model"/> is a motorcycle.
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if this <see cref="Model"/> is a motorcycle; otherwise, <c>false</c>.
+		/// </value>
+		public bool IsMotorcycle => SHVDN.NativeMemory.IsModelAMotorcycle(Hash);
 		/// <summary>
 		/// Gets a value indicating whether this <see cref="Model"/> is an off-road vehicle.
 		/// </summary>


### PR DESCRIPTION
You can detect if the model hash is for a motorcycle with `model.IsBike && !model.IsBicycle`, but this is more obvious and faster.