### PR TITLE
Add GameVersionNotSupportedException class

### DIFF
--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
@@ -313,6 +313,12 @@ namespace GTA
 		{
 			get
 			{
+				if (Game.Version < GameVersion.v1_0_505_2_Steam)
+				{
+					var errorMessage = GameVersionNotSupportedException.BuildErrorMessage(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(TrimColor));
+					throw new GameVersionNotSupportedException(errorMessage, GameVersion.v1_0_505_2_Steam);
+				}
+
 				int color;
 				unsafe
 				{
@@ -323,6 +329,12 @@ namespace GTA
 			}
 			set
 			{
+				if (Game.Version < GameVersion.v1_0_505_2_Steam)
+				{
+					var errorMessage = GameVersionNotSupportedException.BuildErrorMessage(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(TrimColor));
+					throw new GameVersionNotSupportedException(errorMessage, GameVersion.v1_0_505_2_Steam);
+				}
+
 				Function.Call(Hash._SET_VEHICLE_INTERIOR_COLOR, _owner.Handle, value);
 			}
 		}
@@ -330,6 +342,12 @@ namespace GTA
 		{
 			get
 			{
+				if (Game.Version < GameVersion.v1_0_505_2_Steam)
+				{
+					var errorMessage = GameVersionNotSupportedException.BuildErrorMessage(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(DashboardColor));
+					throw new GameVersionNotSupportedException(errorMessage, GameVersion.v1_0_505_2_Steam);
+				}
+
 				int color;
 				unsafe
 				{
@@ -340,6 +358,12 @@ namespace GTA
 			}
 			set
 			{
+				if (Game.Version < GameVersion.v1_0_505_2_Steam)
+				{
+					var errorMessage = GameVersionNotSupportedException.BuildErrorMessage(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(DashboardColor));
+					throw new GameVersionNotSupportedException(errorMessage, GameVersion.v1_0_505_2_Steam);
+				}
+
 				Function.Call(Hash._SET_VEHICLE_DASHBOARD_COLOR, _owner.Handle, value);
 			}
 		}

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
@@ -314,10 +314,7 @@ namespace GTA
 			get
 			{
 				if (Game.Version < GameVersion.v1_0_505_2_Steam)
-				{
-					var errorMessage = GameVersionNotSupportedException.BuildErrorMessage(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(TrimColor));
-					throw new GameVersionNotSupportedException(errorMessage, GameVersion.v1_0_505_2_Steam);
-				}
+					throw new GameVersionNotSupportedException(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(TrimColor));
 
 				int color;
 				unsafe
@@ -330,10 +327,7 @@ namespace GTA
 			set
 			{
 				if (Game.Version < GameVersion.v1_0_505_2_Steam)
-				{
-					var errorMessage = GameVersionNotSupportedException.BuildErrorMessage(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(TrimColor));
-					throw new GameVersionNotSupportedException(errorMessage, GameVersion.v1_0_505_2_Steam);
-				}
+					throw new GameVersionNotSupportedException(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(TrimColor));
 
 				Function.Call(Hash._SET_VEHICLE_INTERIOR_COLOR, _owner.Handle, value);
 			}
@@ -343,10 +337,7 @@ namespace GTA
 			get
 			{
 				if (Game.Version < GameVersion.v1_0_505_2_Steam)
-				{
-					var errorMessage = GameVersionNotSupportedException.BuildErrorMessage(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(DashboardColor));
-					throw new GameVersionNotSupportedException(errorMessage, GameVersion.v1_0_505_2_Steam);
-				}
+					throw new GameVersionNotSupportedException(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(DashboardColor));
 
 				int color;
 				unsafe
@@ -359,10 +350,7 @@ namespace GTA
 			set
 			{
 				if (Game.Version < GameVersion.v1_0_505_2_Steam)
-				{
-					var errorMessage = GameVersionNotSupportedException.BuildErrorMessage(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(DashboardColor));
-					throw new GameVersionNotSupportedException(errorMessage, GameVersion.v1_0_505_2_Steam);
-				}
+					throw new GameVersionNotSupportedException(GameVersion.v1_0_505_2_Steam, nameof(VehicleModCollection), nameof(DashboardColor));
 
 				Function.Call(Hash._SET_VEHICLE_DASHBOARD_COLOR, _owner.Handle, value);
 			}

--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
@@ -11,28 +11,16 @@ using System.Text.RegularExpressions;
 namespace GTA
 {
 	[Serializable]
-	public class GameVersionNotSupportedException : Exception
+	public sealed class GameVersionNotSupportedException : Exception
 	{
 		public GameVersion MinimumSupportedGameVersion { get; }
 
-		public GameVersionNotSupportedException()
-		{
-		}
-
-		public GameVersionNotSupportedException(string message) : base(message)
-		{
-		}
-
-		public GameVersionNotSupportedException(string message, Exception inner) : base(message, inner)
-		{
-		}
-
-		public GameVersionNotSupportedException(string message, GameVersion minimumSupportedGameVersion) : base(message)
+		public GameVersionNotSupportedException(GameVersion minimumSupportedGameVersion, string className, string propertyOrMethodName) : base(BuildErrorMessage(minimumSupportedGameVersion, className, propertyOrMethodName))
 		{
 			MinimumSupportedGameVersion = minimumSupportedGameVersion;
 		}
 
-		protected GameVersionNotSupportedException(SerializationInfo info, StreamingContext context) : base(info, context)
+		private GameVersionNotSupportedException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 			MinimumSupportedGameVersion = (GameVersion)info.GetValue("MinimumSupportedGameVersion", typeof(GameVersion));
 		}

--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
@@ -1,0 +1,46 @@
+﻿//
+// Copyright (C) 2015 crosire & contributors
+// License: https://github.com/crosire/scripthookvdotnet#license
+//
+
+using System;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+
+namespace GTA
+{
+	[Serializable]
+	public class GameVersionNotSupportedException : Exception
+	{
+		public GameVersion MinimumSupportedGameVersion { get; }
+
+		public GameVersionNotSupportedException()
+		{
+		}
+
+		public GameVersionNotSupportedException(string message) : base(message)
+		{
+		}
+
+		public GameVersionNotSupportedException(string message, Exception inner) : base(message, inner)
+		{
+		}
+
+		public GameVersionNotSupportedException(string message, GameVersion minimumSupportedGameVersion) : base(message)
+		{
+			MinimumSupportedGameVersion = minimumSupportedGameVersion;
+		}
+
+		protected GameVersionNotSupportedException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+			MinimumSupportedGameVersion = (GameVersion)info.GetValue("MinimumSupportedGameVersion", typeof(GameVersion));
+		}
+
+		[SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+		public override void GetObjectData(SerializationInfo info, StreamingContext context)
+		{
+			info.AddValue("MinimumSupportedVersion", MinimumSupportedGameVersion, typeof(GameVersion));
+			base.GetObjectData(info, context);
+		}
+	}
+}

--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
+using System.Text.RegularExpressions;
 
 namespace GTA
 {
@@ -41,6 +42,16 @@ namespace GTA
 		{
 			info.AddValue("MinimumSupportedVersion", MinimumSupportedGameVersion, typeof(GameVersion));
 			base.GetObjectData(info, context);
+		}
+
+		internal static string BuildErrorMessage(GameVersion minimumSupportedGameVersion, string className, string propertyOrMethodName)
+		{
+			string maximumNotSupportedGameVersionEnumStr = Enum.GetName(typeof(GameVersion), (GameVersion)((int)minimumSupportedGameVersion - 1)).Replace('_', '.');
+
+			string versionRegexPattern = @"v1\.0\.\d{3,5}\.\d";
+			string maximumNotSupportedGameVersionWithoutPlatformName = Regex.Match(maximumNotSupportedGameVersionEnumStr, versionRegexPattern).Value;
+
+			return $"{className}.{propertyOrMethodName} is not supported in between v1.0.335.2 to ${maximumNotSupportedGameVersionWithoutPlatformName}.";
 		}
 	}
 }

--- a/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
+++ b/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
@@ -179,6 +179,7 @@
     <Compile Include="GTA\PoolObject.cs" />
     <Compile Include="GTA\RadioStation.cs" />
     <Compile Include="GTA\RaycastResult.cs" />
+    <Compile Include="GTA\GameVersionNotSupportedException.cs" />
     <Compile Include="GTA\RequireScript.cs" />
     <Compile Include="GTA\Rope.cs" />
     <Compile Include="GTA\RopeType.cs" />


### PR DESCRIPTION
Properties that return a `bool` value would be fine if the feature is not available in older versions (just return `false`, just like `IS_ENTITY_DEAD` returns `true` if a invalid handle is passed), but what if properties return some enums or nothing (`void`)? I think this class might be useful.