### PR TITLE
Execute scripts in the main thread

### DIFF
--- a/source/core/Script.cs
+++ b/source/core/Script.cs
@@ -12,7 +12,6 @@ namespace SHVDN
 {
 	public class Script
 	{
-		Thread thread; // The thread hosting the execution of the script
 		DateTime resumeTime = DateTime.MinValue;
 		bool willInvokeAbortEvent;
 		internal ConcurrentQueue<Tuple<bool, KeyEventArgs>> keyboardEvents = new ConcurrentQueue<Tuple<bool, KeyEventArgs>>();

--- a/source/core/ScriptDomain.cs
+++ b/source/core/ScriptDomain.cs
@@ -517,6 +517,11 @@ namespace SHVDN
 		/// <param name="task">The task to execute.</param>
 		public void ExecuteTask(IScriptTask task)
 		{
+			if (Thread.CurrentThread.ManagedThreadId != executingThreadId)
+			{
+				throw new InvalidOperationException("Illegal scripting call outside the main thread.");
+			}
+
 			task.Run();
 		}
 

--- a/source/core/ScriptDomain.cs
+++ b/source/core/ScriptDomain.cs
@@ -556,7 +556,7 @@ namespace SHVDN
 
 				try
 				{
-					script.MainLoop(DateTime.UtcNow);
+					script.MainLoop();
 				}
 				catch (Exception ex)
 				{


### PR DESCRIPTION
We should test if most scripts work with this change, but this PR will make users and script developers happy if there aren't serious issues!
I just made minimum changes to make scripts execute in the main thread, so we should tidying up code that is (was) related to script threads later.
If this PR is merged, we should be able to add `World.GetAll*IEnumerable` and `World.GetNearby*IEnumerable` variants without being worried about performance issues, too.