### PR TITLE
Improve Native.Call performance and add Native.Call overloads with explicit native args

### DIFF
--- a/source/core/NativeFunc.cs
+++ b/source/core/NativeFunc.cs
@@ -53,6 +53,22 @@ namespace SHVDN
 		}
 
 		/// <summary>
+		/// Internal script task which holds all data necessary for a script function call.
+		/// </summary>
+		class NativeTaskPtrArgs : IScriptTask
+		{
+			internal ulong Hash;
+			internal ulong* ArgumentPtr;
+			internal int ArgumentLength;
+			internal unsafe ulong* Result;
+
+			public void Run()
+			{
+				Result = InvokeInternal(Hash, ArgumentPtr, ArgumentLength);
+			}
+		}
+
+		/// <summary>
 		/// Pushes a single string component on the text stack.
 		/// </summary>
 		/// <param name="str">The string to push.</param>
@@ -219,6 +235,26 @@ namespace SHVDN
 		/// Executes a script function inside the current script domain.
 		/// </summary>
 		/// <param name="hash">The function has to call.</param>
+		/// <param name="argPtr">A pointer of function arguments.</param>
+		/// <param name="argCount">The length of <paramref name="argPtr">.</param>
+		/// <returns>A pointer to the return value of the call.</returns>
+		public static ulong* Invoke(ulong hash, ulong* argPtr, int argCount)
+		{
+			var domain = ScriptDomain.CurrentDomain;
+			if (domain == null)
+			{
+				throw new InvalidOperationException("Illegal scripting call outside script domain.");
+			}
+
+			var task = new NativeTaskPtrArgs { Hash = hash, ArgumentPtr = argPtr, ArgumentLength = argCount };
+			domain.ExecuteTask(task);
+
+			return task.Result;
+		}
+		/// <summary>
+		/// Executes a script function inside the current script domain.
+		/// </summary>
+		/// <param name="hash">The function has to call.</param>
 		/// <param name="args">A list of function arguments.</param>
 		/// <returns>A pointer to the return value of the call.</returns>
 		public static ulong* Invoke(ulong hash, params ulong[] args)
@@ -239,6 +275,20 @@ namespace SHVDN
 			return Invoke(hash, ConvertPrimitiveArguments(args));
 		}
 
+		/// <summary>
+		/// Executes a script function immediately. This may only be called from the main script domain thread.
+		/// </summary>
+		/// <param name="hash">The function has to call.</param>
+		/// <param name="argPtr">A pointer of function arguments.</param>
+		/// <param name="argCount">The length of <paramref name="argPtr">.</param>
+		/// <returns>A pointer to the return value of the call.</returns>
+		public static ulong* InvokeInternal(ulong hash, ulong* argPtr, int argCount)
+		{
+			NativeInit(hash);
+			for (int i = 0; i < argCount; i++)
+				NativePush64(argPtr[i]);
+			return NativeCall();
+		}
 		/// <summary>
 		/// Executes a script function immediately. This may only be called from the main script domain thread.
 		/// </summary>

--- a/source/core/NativeFunc.cs
+++ b/source/core/NativeFunc.cs
@@ -59,12 +59,12 @@ namespace SHVDN
 		{
 			internal ulong Hash;
 			internal ulong* ArgumentPtr;
-			internal int ArgumentLength;
+			internal int ArgumentCount;
 			internal unsafe ulong* Result;
 
 			public void Run()
 			{
-				Result = InvokeInternal(Hash, ArgumentPtr, ArgumentLength);
+				Result = InvokeInternal(Hash, ArgumentPtr, ArgumentCount);
 			}
 		}
 
@@ -246,7 +246,7 @@ namespace SHVDN
 				throw new InvalidOperationException("Illegal scripting call outside script domain.");
 			}
 
-			var task = new NativeTaskPtrArgs { Hash = hash, ArgumentPtr = argPtr, ArgumentLength = argCount };
+			var task = new NativeTaskPtrArgs { Hash = hash, ArgumentPtr = argPtr, ArgumentCount = argCount };
 			domain.ExecuteTask(task);
 
 			return task.Result;

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -362,21 +362,19 @@ namespace GTA.Native
 	public static class Function
 	{
 		const int MAX_ARG_COUNT = 32;
-		static ulong[] argPool = new ulong[MAX_ARG_COUNT];
 
 		public static T Call<T>(Hash hash, params InputArgument[] arguments)
 		{
 			unsafe
 			{
-				int argLength = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
-				fixed (ulong* argPoolPtr = &argPool[0])
-				{
-					for (int i = 0; i < argLength; ++i)
-						argPoolPtr[i] = arguments[i].data;
+				int argCount = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
+				var argPtr = stackalloc ulong[argCount];
 
-					var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPoolPtr, argLength);
-					return ReturnValueFromNativeIfNotNull<T>(res);
-				}
+				for (int i = 0; i < argCount; ++i)
+					argPtr[i] = arguments[i].data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		public static T Call<T>(Hash hash)
@@ -469,14 +467,13 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				int argLength = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
-				fixed (ulong* argPoolPtr = &argPool[0])
-				{
-					for (int i = 0; i < argLength; ++i)
-						argPoolPtr[i] = arguments[i].data;
+				int argCount = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
+				var argPtr = stackalloc ulong[argCount];
 
-					SHVDN.NativeFunc.Invoke((ulong)hash, argPoolPtr, argLength);
-				}
+				for (int i = 0; i < argCount; ++i)
+					argPtr[i] = arguments[i].data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
 		public static void Call(Hash hash)

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -372,20 +372,79 @@ namespace GTA.Native
 			{
 				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args);
 
-				// The result will be null when this method is called from a thread other than the main thread
-				if (res == null)
-				{
-					throw new InvalidOperationException("Native.Function.Call can only be called from the main thread.");
-				}
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash)
+		{
+			return CallInternalNoParamArray<T>(hash, null, null, null, null);
+		}
+		public static T Call<T>(Hash hash, InputArgument argument0)
+		{
+			return CallInternalNoParamArray<T>(hash, argument0, null, null, null);
+		}
+		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
+		{
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, null, null);
+		}
+		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
+		{
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, null);
+		}
+		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		{
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, argument3);
+		}
+		static unsafe T CallInternalNoParamArray<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		{
+			bool isArg0Null = argument0 == null;
+			bool isArg1Null = argument1 == null;
+			bool isArg2Null = argument2 == null;
+			bool isArg3Null = argument3 == null;
 
-				if (typeof(T).IsEnum || typeof(T).IsPrimitive || typeof(T) == typeof(Vector3) || typeof(T) == typeof(Vector2))
-				{
-					return ObjectFromNative<T>(res);
-				}
-				else
-				{
-					return (T)ObjectFromNative(typeof(T), res);
-				}
+			int argCount = 0;
+			if (!isArg0Null)
+				argCount++;
+			if (!isArg1Null)
+				argCount++;
+			if (!isArg2Null)
+				argCount++;
+			if (!isArg3Null)
+				argCount++;
+
+			unsafe
+			{
+				var args = stackalloc ulong[argCount];
+
+				if (!isArg0Null)
+					args[0] = argument0.data;
+				if (!isArg1Null)
+					args[1] = argument1.data;
+				if (!isArg2Null)
+					args[2] = argument2.data;
+				if (!isArg3Null)
+					args[3] = argument3.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
+
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		static unsafe T ReturnValueFromNativeIfNotNull<T>(ulong* result)
+		{
+			// The result will be null when this method is called from a thread other than the main thread
+			if (result == null)
+			{
+				throw new InvalidOperationException("Native.Function.Call can only be called from the main thread.");
+			}
+
+			if (typeof(T).IsEnum || typeof(T).IsPrimitive || typeof(T) == typeof(Vector3) || typeof(T) == typeof(Vector2))
+			{
+				return ObjectFromNative<T>(result);
+			}
+			else
+			{
+				return (T)ObjectFromNative(typeof(T), result);
 			}
 		}
 		public static void Call(Hash hash, params InputArgument[] arguments)
@@ -399,6 +458,59 @@ namespace GTA.Native
 			unsafe
 			{
 				SHVDN.NativeFunc.Invoke((ulong)hash, args);
+			}
+		}
+		public static void Call(Hash hash)
+		{
+			CallInternalNoParamArray(hash, null, null, null, null);
+		}
+		public static void Call(Hash hash, InputArgument argument0)
+		{
+			CallInternalNoParamArray(hash, argument0, null, null, null);
+		}
+		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1)
+		{
+			CallInternalNoParamArray(hash, argument0, argument1, null, null);
+		}
+		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
+		{
+			CallInternalNoParamArray(hash, argument0, argument1, argument2, null);
+		}
+		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		{
+			CallInternalNoParamArray(hash, argument0, argument1, argument2, argument3);
+		}
+		static void CallInternalNoParamArray(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		{
+			bool isArg0Null = argument0 == null;
+			bool isArg1Null = argument1 == null;
+			bool isArg2Null = argument2 == null;
+			bool isArg3Null = argument3 == null;
+
+			int argCount = 0;
+			if (!isArg0Null)
+				argCount++;
+			if (!isArg1Null)
+				argCount++;
+			if (!isArg2Null)
+				argCount++;
+			if (!isArg3Null)
+				argCount++;
+
+			unsafe
+			{
+				var args = stackalloc ulong[argCount];
+
+				if (!isArg0Null)
+					args[0] = argument0.data;
+				if (!isArg1Null)
+					args[1] = argument1.data;
+				if (!isArg2Null)
+					args[2] = argument2.data;
+				if (!isArg3Null)
+					args[3] = argument3.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
 			}
 		}
 

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -377,6 +377,8 @@ namespace GTA.Native
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
+
+		#region Call with Return Value Overloads with Normal InputArgument Paramaters
 		public static T Call<T>(Hash hash)
 		{
 			unsafe
@@ -443,6 +445,404 @@ namespace GTA.Native
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4)
+		{
+			unsafe
+			{
+				const int argCount = 5;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5)
+		{
+			unsafe
+			{
+				const int argCount = 6;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6)
+		{
+			unsafe
+			{
+				const int argCount = 7;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7)
+		{
+			unsafe
+			{
+				const int argCount = 8;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8)
+		{
+			unsafe
+			{
+				const int argCount = 9;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9)
+		{
+			unsafe
+			{
+				const int argCount = 10;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10)
+		{
+			unsafe
+			{
+				const int argCount = 11;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11)
+		{
+			unsafe
+			{
+				const int argCount = 12;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12)
+		{
+			unsafe
+			{
+				const int argCount = 13;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+				argPtr[12] = argument12.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13)
+		{
+			unsafe
+			{
+				const int argCount = 14;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+				argPtr[12] = argument12.data;
+				argPtr[13] = argument13.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13,
+			InputArgument argument14)
+		{
+			unsafe
+			{
+				const int argCount = 15;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+				argPtr[12] = argument12.data;
+				argPtr[13] = argument13.data;
+				argPtr[14] = argument14.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13,
+			InputArgument argument14,
+			InputArgument argument15)
+		{
+			unsafe
+			{
+				const int argCount = 16;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+				argPtr[12] = argument12.data;
+				argPtr[13] = argument13.data;
+				argPtr[14] = argument14.data;
+				argPtr[15] = argument15.data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		#endregion
+
 		static unsafe T ReturnValueFromNativeIfNotNull<T>(ulong* result)
 		{
 			// The result will be null when this method is called from a thread other than the main thread
@@ -476,6 +876,8 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
+
+		#region void Call Overloads with Normal InputArgument Paramaters
 		public static void Call(Hash hash)
 		{
 			unsafe
@@ -537,6 +939,391 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4)
+		{
+			unsafe
+			{
+				const int argCount = 5;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5)
+		{
+			unsafe
+			{
+				const int argCount = 6;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6)
+		{
+			unsafe
+			{
+				const int argCount = 7;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7)
+		{
+			unsafe
+			{
+				const int argCount = 8;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8)
+		{
+			unsafe
+			{
+				const int argCount = 9;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9)
+		{
+			unsafe
+			{
+				const int argCount = 10;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10)
+		{
+			unsafe
+			{
+				const int argCount = 11;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11)
+		{
+			unsafe
+			{
+				const int argCount = 12;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12)
+		{
+			unsafe
+			{
+				const int argCount = 13;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+				argPtr[12] = argument12.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13)
+		{
+			unsafe
+			{
+				const int argCount = 14;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+				argPtr[12] = argument12.data;
+				argPtr[13] = argument13.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13,
+			InputArgument argument14)
+		{
+			unsafe
+			{
+				const int argCount = 15;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+				argPtr[12] = argument12.data;
+				argPtr[13] = argument13.data;
+				argPtr[14] = argument14.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13,
+			InputArgument argument14,
+			InputArgument argument15)
+		{
+			unsafe
+			{
+				const int argCount = 16;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
+				argPtr[4] = argument4.data;
+				argPtr[5] = argument5.data;
+				argPtr[6] = argument6.data;
+				argPtr[7] = argument7.data;
+				argPtr[8] = argument8.data;
+				argPtr[9] = argument9.data;
+				argPtr[10] = argument10.data;
+				argPtr[11] = argument11.data;
+				argPtr[12] = argument12.data;
+				argPtr[13] = argument13.data;
+				argPtr[14] = argument14.data;
+				argPtr[15] = argument15.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		#endregion
 
 		internal static unsafe ulong ObjectToNative(object value)
 		{

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -361,13 +361,14 @@ namespace GTA.Native
 
 	public static class Function
 	{
-		static ulong[] argPool = new ulong[32];
+		const int MAX_ARG_COUNT = 32;
+		static ulong[] argPool = new ulong[MAX_ARG_COUNT];
 
 		public static T Call<T>(Hash hash, params InputArgument[] arguments)
 		{
 			unsafe
 			{
-				int argLength = arguments.Length <= 32 ? arguments.Length : 32;
+				int argLength = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
 				fixed (ulong* argPoolPtr = &argPool[0])
 				{
 					for (int i = 0; i < argLength; ++i)
@@ -468,7 +469,7 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				int argLength = arguments.Length <= 32 ? arguments.Length : 32;
+				int argLength = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
 				fixed (ulong* argPoolPtr = &argPool[0])
 				{
 					for (int i = 0; i < argLength; ++i)

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -377,64 +377,76 @@ namespace GTA.Native
 		}
 		public static T Call<T>(Hash hash)
 		{
-			return CallInternalNoParamArray<T>(hash, null, null, null, null, 0);
+			unsafe
+			{
+				return CallInternalNoParamArray<T>(hash, null, 0);
+			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, null, null, null, 1);
+			unsafe
+			{
+				const int argCount = 1;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+
+				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
+			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, null, null, 2);
+			unsafe
+			{
+				const int argCount = 2;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument0.data;
+
+				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
+			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, null, 3);
+			unsafe
+			{
+				const int argCount = 3;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+
+				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
+			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, argument3, 4);
-		}
-		static unsafe T CallInternalNoParamArray<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3, int argCount)
-		{
 			unsafe
 			{
-				var args = stackalloc ulong[argCount];
+				const int argCount = 4;
+				var argPtr = stackalloc ulong[argCount];
 
-				switch (argCount)
-				{
-					case 0:
-						break;
-					case 1:
-						args[0] = argument0.data;
-						break;
-					case 2:
-						args[0] = argument0.data;
-						args[1] = argument1.data;
-						break;
-					case 3:
-						args[0] = argument0.data;
-						args[1] = argument1.data;
-						args[2] = argument2.data;
-						break;
-					default:
-						args[0] = argument0.data;
-						args[1] = argument1.data;
-						args[2] = argument2.data;
-						args[3] = argument3.data;
-						break;
-				}
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
 
-				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
-				return ReturnValueFromNativeIfNotNull<T>(res);
+				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
 			}
+		}
+		static unsafe T CallInternalNoParamArray<T>(Hash hash, ulong* argPtr, int argCount)
+		{
+			var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			return ReturnValueFromNativeIfNotNull<T>(res);
 		}
 		static unsafe T ReturnValueFromNativeIfNotNull<T>(ulong* result)
 		{
 			// The result will be null when this method is called from a thread other than the main thread
 			if (result == null)
 			{
-				throw new InvalidOperationException("Native.Function.Call can only be called from the main thread.");
+				ThrowInvalidOperationExceptionForInvalidNativeCall();
 			}
 
 			if (typeof(T).IsEnum || typeof(T).IsPrimitive || typeof(T) == typeof(Vector3) || typeof(T) == typeof(Vector2))
@@ -446,6 +458,9 @@ namespace GTA.Native
 				return (T)ObjectFromNative(typeof(T), result);
 			}
 		}
+		// have to create this method to let JIT inline ReturnValueFromNativeIfNotNull
+		static void ThrowInvalidOperationExceptionForInvalidNativeCall() => throw new InvalidOperationException("Native.Function.Call can only be called from the main thread.");
+
 		public static void Call(Hash hash, params InputArgument[] arguments)
 		{
 			ulong[] args = new ulong[arguments.Length];
@@ -461,55 +476,63 @@ namespace GTA.Native
 		}
 		public static void Call(Hash hash)
 		{
-			CallInternalNoParamArray(hash, null, null, null, null, 0);
+			unsafe
+			{
+				SHVDN.NativeFunc.Invoke((ulong)hash, null, 0);
+			}
 		}
 		public static void Call(Hash hash, InputArgument argument0)
 		{
-			CallInternalNoParamArray(hash, argument0, null, null, null, 1);
+			unsafe
+			{
+				const int argCount = 1;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, null, null, 2);
+			unsafe
+			{
+				const int argCount = 2;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, argument2, null, 3);
+			unsafe
+			{
+				const int argCount = 3;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, argument2, argument3, 4);
-		}
-		static void CallInternalNoParamArray(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3, int argCount)
-		{
 			unsafe
 			{
-				var args = stackalloc ulong[argCount];
+				const int argCount = 4;
+				var argPtr = stackalloc ulong[argCount];
 
-				switch (argCount)
-				{
-					case 0:
-						break;
-					case 1:
-						args[0] = argument0.data;
-						break;
-					case 2:
-						args[0] = argument0.data;
-						args[1] = argument1.data;
-						break;
-					case 3:
-						args[0] = argument0.data;
-						args[1] = argument1.data;
-						args[2] = argument2.data;
-						break;
-					default:
-						args[0] = argument0.data;
-						args[1] = argument1.data;
-						args[2] = argument2.data;
-						args[3] = argument3.data;
-						break;
-				}
+				argPtr[0] = argument0.data;
+				argPtr[1] = argument1.data;
+				argPtr[2] = argument2.data;
+				argPtr[3] = argument3.data;
 
-				SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
 

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -381,7 +381,8 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				return CallInternalNoParamArray<T>(hash, null, 0);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, null, 0);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0)
@@ -393,7 +394,8 @@ namespace GTA.Native
 
 				argPtr[0] = argument0.data;
 
-				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
@@ -406,7 +408,8 @@ namespace GTA.Native
 				argPtr[0] = argument0.data;
 				argPtr[1] = argument1.data;
 
-				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
@@ -420,7 +423,8 @@ namespace GTA.Native
 				argPtr[1] = argument1.data;
 				argPtr[2] = argument2.data;
 
-				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
@@ -435,13 +439,9 @@ namespace GTA.Native
 				argPtr[2] = argument2.data;
 				argPtr[3] = argument3.data;
 
-				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
-		}
-		static unsafe T CallInternalNoParamArray<T>(Hash hash, ulong* argPtr, int argCount)
-		{
-			var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
-			return ReturnValueFromNativeIfNotNull<T>(res);
 		}
 		static unsafe T ReturnValueFromNativeIfNotNull<T>(ulong* result)
 		{

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -377,54 +377,44 @@ namespace GTA.Native
 		}
 		public static T Call<T>(Hash hash)
 		{
-			return CallInternalNoParamArray<T>(hash, null, null, null, null);
+			return CallInternalNoParamArray<T>(hash, null, null, null, null, 0);
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, null, null, null);
+			return CallInternalNoParamArray<T>(hash, argument0, null, null, null, 1);
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, null, null);
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, null, null, 2);
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, null);
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, null, 3);
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, argument3);
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, argument3, 4);
 		}
-		static unsafe T CallInternalNoParamArray<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		static unsafe T CallInternalNoParamArray<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3, int argCount)
 		{
-			bool isArg0Null = argument0 == null;
-			bool isArg1Null = argument1 == null;
-			bool isArg2Null = argument2 == null;
-			bool isArg3Null = argument3 == null;
-
-			int argCount = 0;
-			if (!isArg0Null)
-				argCount++;
-			if (!isArg1Null)
-				argCount++;
-			if (!isArg2Null)
-				argCount++;
-			if (!isArg3Null)
-				argCount++;
-
 			unsafe
 			{
 				var args = stackalloc ulong[argCount];
 
-				if (!isArg0Null)
-					args[0] = argument0.data;
-				if (!isArg1Null)
-					args[1] = argument1.data;
-				if (!isArg2Null)
-					args[2] = argument2.data;
-				if (!isArg3Null)
-					args[3] = argument3.data;
+				if (argCount <= 0)
+					goto CallNative;
+				args[0] = argument0.data;
+				if (argCount == 1)
+					goto CallNative;
+				args[1] = argument1.data;
+				if (argCount == 2)
+					goto CallNative;
+				args[2] = argument2.data;
+				if (argCount == 3)
+					goto CallNative;
+				args[3] = argument3.data;
 
+			CallNative:
 				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
 
 				return ReturnValueFromNativeIfNotNull<T>(res);
@@ -462,54 +452,44 @@ namespace GTA.Native
 		}
 		public static void Call(Hash hash)
 		{
-			CallInternalNoParamArray(hash, null, null, null, null);
+			CallInternalNoParamArray(hash, null, null, null, null, 0);
 		}
 		public static void Call(Hash hash, InputArgument argument0)
 		{
-			CallInternalNoParamArray(hash, argument0, null, null, null);
+			CallInternalNoParamArray(hash, argument0, null, null, null, 1);
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, null, null);
+			CallInternalNoParamArray(hash, argument0, argument1, null, null, 2);
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, argument2, null);
+			CallInternalNoParamArray(hash, argument0, argument1, argument2, null, 3);
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, argument2, argument3);
+			CallInternalNoParamArray(hash, argument0, argument1, argument2, argument3, 4);
 		}
-		static void CallInternalNoParamArray(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		static void CallInternalNoParamArray(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3, int argCount)
 		{
-			bool isArg0Null = argument0 == null;
-			bool isArg1Null = argument1 == null;
-			bool isArg2Null = argument2 == null;
-			bool isArg3Null = argument3 == null;
-
-			int argCount = 0;
-			if (!isArg0Null)
-				argCount++;
-			if (!isArg1Null)
-				argCount++;
-			if (!isArg2Null)
-				argCount++;
-			if (!isArg3Null)
-				argCount++;
-
 			unsafe
 			{
 				var args = stackalloc ulong[argCount];
 
-				if (!isArg0Null)
-					args[0] = argument0.data;
-				if (!isArg1Null)
-					args[1] = argument1.data;
-				if (!isArg2Null)
-					args[2] = argument2.data;
-				if (!isArg3Null)
-					args[3] = argument3.data;
+				if (argCount <= 0)
+					goto CallNative;
+				args[0] = argument0.data;
+				if (argCount == 1)
+					goto CallNative;
+				args[1] = argument1.data;
+				if (argCount == 2)
+					goto CallNative;
+				args[2] = argument2.data;
+				if (argCount == 3)
+					goto CallNative;
+				args[3] = argument3.data;
 
+			CallNative:
 				SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
 			}
 		}

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -360,19 +360,21 @@ namespace GTA.Native
 
 	public static class Function
 	{
+		static ulong[] argPool = new ulong[32];
+
 		public static T Call<T>(Hash hash, params InputArgument[] arguments)
 		{
-			ulong[] args = new ulong[arguments.Length];
-			for (int i = 0; i < arguments.Length; ++i)
-			{
-				args[i] = arguments[i].data;
-			}
-
 			unsafe
 			{
-				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args);
+				int argLength = arguments.Length <= 32 ? arguments.Length : 32;
+				fixed (ulong* argPoolPtr = &argPool[0])
+				{
+					for (int i = 0; i < argLength; ++i)
+						argPoolPtr[i] = arguments[i].data;
 
-				return ReturnValueFromNativeIfNotNull<T>(res);
+					var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPoolPtr, argLength);
+					return ReturnValueFromNativeIfNotNull<T>(res);
+				}
 			}
 		}
 		public static T Call<T>(Hash hash)
@@ -463,15 +465,16 @@ namespace GTA.Native
 
 		public static void Call(Hash hash, params InputArgument[] arguments)
 		{
-			ulong[] args = new ulong[arguments.Length];
-			for (int i = 0; i < arguments.Length; ++i)
-			{
-				args[i] = arguments[i].data;
-			}
-
 			unsafe
 			{
-				SHVDN.NativeFunc.Invoke((ulong)hash, args);
+				int argLength = arguments.Length <= 32 ? arguments.Length : 32;
+				fixed (ulong* argPoolPtr = &argPool[0])
+				{
+					for (int i = 0; i < argLength; ++i)
+						argPoolPtr[i] = arguments[i].data;
+
+					SHVDN.NativeFunc.Invoke((ulong)hash, argPoolPtr, argLength);
+				}
 			}
 		}
 		public static void Call(Hash hash)

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -401,22 +401,31 @@ namespace GTA.Native
 			{
 				var args = stackalloc ulong[argCount];
 
-				if (argCount <= 0)
-					goto CallNative;
-				args[0] = argument0.data;
-				if (argCount == 1)
-					goto CallNative;
-				args[1] = argument1.data;
-				if (argCount == 2)
-					goto CallNative;
-				args[2] = argument2.data;
-				if (argCount == 3)
-					goto CallNative;
-				args[3] = argument3.data;
+				switch (argCount)
+				{
+					case 0:
+						break;
+					case 1:
+						args[0] = argument0.data;
+						break;
+					case 2:
+						args[0] = argument0.data;
+						args[1] = argument1.data;
+						break;
+					case 3:
+						args[0] = argument0.data;
+						args[1] = argument1.data;
+						args[2] = argument2.data;
+						break;
+					default:
+						args[0] = argument0.data;
+						args[1] = argument1.data;
+						args[2] = argument2.data;
+						args[3] = argument3.data;
+						break;
+				}
 
-			CallNative:
 				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
-
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
@@ -476,20 +485,30 @@ namespace GTA.Native
 			{
 				var args = stackalloc ulong[argCount];
 
-				if (argCount <= 0)
-					goto CallNative;
-				args[0] = argument0.data;
-				if (argCount == 1)
-					goto CallNative;
-				args[1] = argument1.data;
-				if (argCount == 2)
-					goto CallNative;
-				args[2] = argument2.data;
-				if (argCount == 3)
-					goto CallNative;
-				args[3] = argument3.data;
+				switch (argCount)
+				{
+					case 0:
+						break;
+					case 1:
+						args[0] = argument0.data;
+						break;
+					case 2:
+						args[0] = argument0.data;
+						args[1] = argument1.data;
+						break;
+					case 3:
+						args[0] = argument0.data;
+						args[1] = argument1.data;
+						args[2] = argument2.data;
+						break;
+					default:
+						args[0] = argument0.data;
+						args[1] = argument1.data;
+						args[2] = argument2.data;
+						args[3] = argument3.data;
+						break;
+				}
 
-			CallNative:
 				SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
 			}
 		}

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -402,7 +402,7 @@ namespace GTA.Native
 				var argPtr = stackalloc ulong[argCount];
 
 				argPtr[0] = argument0.data;
-				argPtr[1] = argument0.data;
+				argPtr[1] = argument1.data;
 
 				return CallInternalNoParamArray<T>(hash, argPtr, argCount);
 			}

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using GTA.Math;
 
 namespace GTA.Native

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -363,7 +363,7 @@ namespace GTA.Native
 		/// </summary>
 		/// <param name="hash">The hashed name of the native script function.</param>
 		/// <param name="arguments">A list of input and output arguments to pass to the native script function.</param>
-		/// <returns>The return value of the native</returns>
+		/// <returns>The return value of the native.</returns>
 		public static T Call<T>(Hash hash, params InputArgument[] arguments)
 		{
 			ulong[] args = new ulong[arguments.Length];
@@ -378,6 +378,11 @@ namespace GTA.Native
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and returns its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <returns>The return value of the native.</returns>
 		public static T Call<T>(Hash hash)
 		{
 			unsafe
@@ -385,17 +390,30 @@ namespace GTA.Native
 				return CallInternalNoParamArray<T>(hash, null, 0);
 			}
 		}
-		public static T Call<T>(Hash hash, InputArgument argument0)
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument">The input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash, InputArgument argument)
 		{
 			unsafe
 			{
 				var argPtr = stackalloc ulong[1];
 
-				argPtr[0] = argument0._data;
+				argPtr[0] = argument._data;
 
 				return CallInternalNoParamArray<T>(hash, argPtr, 1);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
 			unsafe
@@ -403,11 +421,19 @@ namespace GTA.Native
 				var argPtr = stackalloc ulong[2];
 
 				argPtr[0] = argument0._data;
-				argPtr[1] = argument0._data;
+				argPtr[1] = argument1._data;
 
 				return CallInternalNoParamArray<T>(hash, argPtr, 2);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
 			unsafe
@@ -421,6 +447,15 @@ namespace GTA.Native
 				return CallInternalNoParamArray<T>(hash, argPtr, 3);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The fourth input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
 			unsafe
@@ -478,6 +513,10 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, args);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
 		public static void Call(Hash hash)
 		{
 			unsafe
@@ -485,6 +524,11 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, null, 0);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The input or output argument to pass to the native script function.</param>
 		public static void Call(Hash hash, InputArgument argument0)
 		{
 			unsafe
@@ -497,6 +541,14 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The fourth input or output argument to pass to the native script function.</param>
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
 			unsafe
@@ -510,6 +562,13 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
 			unsafe
@@ -524,6 +583,14 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The fourth input or output argument to pass to the native script function.</param>
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
 			unsafe

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -376,20 +376,79 @@ namespace GTA.Native
 			{
 				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args);
 
-				// The result will be null when this method is called from a thread other than the main thread
-				if (res == null)
-				{
-					throw new InvalidOperationException("Native.Function.Call can only be called from the main thread.");
-				}
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		public static T Call<T>(Hash hash)
+		{
+			return CallInternalNoParamArray<T>(hash, null, null, null, null);
+		}
+		public static T Call<T>(Hash hash, InputArgument argument0)
+		{
+			return CallInternalNoParamArray<T>(hash, argument0, null, null, null);
+		}
+		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
+		{
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, null, null);
+		}
+		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
+		{
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, null);
+		}
+		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		{
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, argument3);
+		}
+		static unsafe T CallInternalNoParamArray<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		{
+			bool isArg0Null = argument0 == null;
+			bool isArg1Null = argument1 == null;
+			bool isArg2Null = argument2 == null;
+			bool isArg3Null = argument3 == null;
 
-				if (typeof(T).IsValueType || typeof(PoolObject).IsAssignableFrom(typeof(T)) || typeof(T).IsEnum)
-				{
-					return ObjectFromNative<T>(res);
-				}
-				else
-				{
-					return (T)ObjectFromNative(typeof(T), res);
-				}
+			int argCount = 0;
+			if (!isArg0Null)
+				argCount++;
+			if (!isArg1Null)
+				argCount++;
+			if (!isArg2Null)
+				argCount++;
+			if (!isArg3Null)
+				argCount++;
+
+			unsafe
+			{
+				var args = stackalloc ulong[argCount];
+
+				if (!isArg0Null)
+					args[0] = argument0._data;
+				if (!isArg1Null)
+					args[1] = argument1._data;
+				if (!isArg2Null)
+					args[2] = argument2._data;
+				if (!isArg3Null)
+					args[3] = argument3._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
+
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		static unsafe T ReturnValueFromNativeIfNotNull<T>(ulong* result)
+		{
+			// The result will be null when this method is called from a thread other than the main thread
+			if (result == null)
+			{
+				throw new InvalidOperationException("Native.Function.Call can only be called from the main thread.");
+			}
+
+			if (typeof(T).IsValueType || typeof(PoolObject).IsAssignableFrom(typeof(T)) || typeof(T).IsEnum)
+			{
+				return ObjectFromNative<T>(result);
+			}
+			else
+			{
+				return (T)ObjectFromNative(typeof(T), result);
 			}
 		}
 		/// <summary>
@@ -408,6 +467,59 @@ namespace GTA.Native
 			unsafe
 			{
 				SHVDN.NativeFunc.Invoke((ulong)hash, args);
+			}
+		}
+		public static void Call(Hash hash)
+		{
+			CallInternalNoParamArray(hash, null, null, null, null);
+		}
+		public static void Call(Hash hash, InputArgument argument0)
+		{
+			CallInternalNoParamArray(hash, argument0, null, null, null);
+		}
+		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1)
+		{
+			CallInternalNoParamArray(hash, argument0, argument1, null, null);
+		}
+		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
+		{
+			CallInternalNoParamArray(hash, argument0, argument1, argument2, null);
+		}
+		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		{
+			CallInternalNoParamArray(hash, argument0, argument1, argument2, argument3);
+		}
+		static void CallInternalNoParamArray(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		{
+			bool isArg0Null = argument0 == null;
+			bool isArg1Null = argument1 == null;
+			bool isArg2Null = argument2 == null;
+			bool isArg3Null = argument3 == null;
+
+			int argCount = 0;
+			if (!isArg0Null)
+				argCount++;
+			if (!isArg1Null)
+				argCount++;
+			if (!isArg2Null)
+				argCount++;
+			if (!isArg3Null)
+				argCount++;
+
+			unsafe
+			{
+				var args = stackalloc ulong[argCount];
+
+				if (!isArg0Null)
+					args[0] = argument0._data;
+				if (!isArg1Null)
+					args[1] = argument1._data;
+				if (!isArg2Null)
+					args[2] = argument2._data;
+				if (!isArg3Null)
+					args[3] = argument3._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
 			}
 		}
 

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -391,7 +391,8 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				return CallInternalNoParamArray<T>(hash, null, 0);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, null, 0);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		/// <summary>
@@ -404,11 +405,13 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				var argPtr = stackalloc ulong[1];
+				const int argCount = 1;
+				var argPtr = stackalloc ulong[argCount];
 
 				argPtr[0] = argument._data;
 
-				return CallInternalNoParamArray<T>(hash, argPtr, 1);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		/// <summary>
@@ -422,12 +425,14 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				var argPtr = stackalloc ulong[2];
+				const int argCount = 2;
+				var argPtr = stackalloc ulong[argCount];
 
 				argPtr[0] = argument0._data;
 				argPtr[1] = argument1._data;
 
-				return CallInternalNoParamArray<T>(hash, argPtr, 2);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		/// <summary>
@@ -442,13 +447,15 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				var argPtr = stackalloc ulong[3];
+				const int argCount = 3;
+				var argPtr = stackalloc ulong[argCount];
 
 				argPtr[0] = argument0._data;
 				argPtr[1] = argument1._data;
 				argPtr[2] = argument2._data;
 
-				return CallInternalNoParamArray<T>(hash, argPtr, 3);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		/// <summary>
@@ -464,20 +471,17 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				var argPtr = stackalloc ulong[4];
+				const int argCount = 4;
+				var argPtr = stackalloc ulong[argCount];
 
 				argPtr[0] = argument0._data;
 				argPtr[1] = argument1._data;
 				argPtr[2] = argument2._data;
 				argPtr[3] = argument3._data;
 
-				return CallInternalNoParamArray<T>(hash, argPtr, 4);
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
-		}
-		static unsafe T CallInternalNoParamArray<T>(Hash hash, ulong* argPtr, int argCount)
-		{
-			var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
-			return ReturnValueFromNativeIfNotNull<T>(res);
 		}
 		static unsafe T ReturnValueFromNativeIfNotNull<T>(ulong* result)
 		{

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -8,7 +8,9 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Text;
+
 
 namespace GTA.Native
 {
@@ -616,6 +618,7 @@ namespace GTA.Native
 		/// </summary>
 		/// <param name="value">The object to convert.</param>
 		/// <returns>A native value representing the input <paramref name="value"/>.</returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		internal static ulong ObjectToNative(object value)
 		{
 			if (value is null)
@@ -633,8 +636,10 @@ namespace GTA.Native
 				return ((INativeValue)value).NativeValue;
 			}
 
-			throw new InvalidCastException(string.Concat("Unable to cast object of type '", value.GetType(), "' to native value"));
+			ThrowExceptionForObjectToNative(value);
+			return 0;
 		}
+		static void ThrowExceptionForObjectToNative(object value) => throw new InvalidCastException(string.Concat("Unable to cast object of type '", value.GetType(), "' to native value"));
 
 		/// <summary>
 		/// Converts a native value to a managed object of a value type.

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -360,7 +360,8 @@ namespace GTA.Native
 	/// </summary>
 	public static class Function
 	{
-		static ulong[] argPool = new ulong[32];
+		const int MAX_ARG_COUNT = 32;
+		static ulong[] argPool = new ulong[MAX_ARG_COUNT];
 
 		/// <summary>
 		/// Calls the specified native script function and returns its return value.
@@ -372,7 +373,7 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				int argLength = arguments.Length <= 32 ? arguments.Length : 32;
+				int argLength = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
 				fixed (ulong* argPoolPtr = &argPool[0])
 				{
 					for (int i = 0; i < argLength; ++i)
@@ -509,7 +510,7 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				int argLength = arguments.Length <= 32 ? arguments.Length : 32;
+				int argLength = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
 				fixed (ulong* argPoolPtr = &argPool[0])
 				{
 					for (int i = 0; i < argLength; ++i)

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -361,7 +361,6 @@ namespace GTA.Native
 	public static class Function
 	{
 		const int MAX_ARG_COUNT = 32;
-		static ulong[] argPool = new ulong[MAX_ARG_COUNT];
 
 		/// <summary>
 		/// Calls the specified native script function and returns its return value.
@@ -373,15 +372,14 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				int argLength = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
-				fixed (ulong* argPoolPtr = &argPool[0])
-				{
-					for (int i = 0; i < argLength; ++i)
-						argPoolPtr[i] = arguments[i]._data;
+				int argCount = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
+				var argPtr = stackalloc ulong[argCount];
 
-					var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPoolPtr, argLength);
-					return ReturnValueFromNativeIfNotNull<T>(res);
-				}
+				for (int i = 0; i < argCount; ++i)
+					argPtr[i] = arguments[i]._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		/// <summary>
@@ -510,14 +508,13 @@ namespace GTA.Native
 		{
 			unsafe
 			{
-				int argLength = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
-				fixed (ulong* argPoolPtr = &argPool[0])
-				{
-					for (int i = 0; i < argLength; ++i)
-						argPoolPtr[i] = arguments[i]._data;
+				int argCount = arguments.Length <= MAX_ARG_COUNT ? arguments.Length : MAX_ARG_COUNT;
+				var argPtr = stackalloc ulong[argCount];
 
-					SHVDN.NativeFunc.Invoke((ulong)hash, argPoolPtr, argLength);
-				}
+				for (int i = 0; i < argCount; ++i)
+					argPtr[i] = arguments[i]._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
 		/// <summary>

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -405,20 +405,30 @@ namespace GTA.Native
 			{
 				var args = stackalloc ulong[argCount];
 
-				if (argCount <= 0)
-					goto CallNative;
-				args[0] = argument0._data;
-				if (argCount == 1)
-					goto CallNative;
-				args[1] = argument1._data;
-				if (argCount == 2)
-					goto CallNative;
-				args[2] = argument2._data;
-				if (argCount == 3)
-					goto CallNative;
-				args[3] = argument3._data;
+				switch (argCount)
+				{
+					case 0:
+						break;
+					case 1:
+						args[0] = argument0._data;
+						break;
+					case 2:
+						args[0] = argument0._data;
+						args[1] = argument1._data;
+						break;
+					case 3:
+						args[0] = argument0._data;
+						args[1] = argument1._data;
+						args[2] = argument2._data;
+						break;
+					default:
+						args[0] = argument0._data;
+						args[1] = argument1._data;
+						args[2] = argument2._data;
+						args[3] = argument3._data;
+						break;
+				}
 
-			CallNative:
 				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
@@ -484,20 +494,30 @@ namespace GTA.Native
 			{
 				var args = stackalloc ulong[argCount];
 
-				if (argCount <= 0)
-					goto CallNative;
-				args[0] = argument0._data;
-				if (argCount == 1)
-					goto CallNative;
-				args[1] = argument1._data;
-				if (argCount == 2)
-					goto CallNative;
-				args[2] = argument2._data;
-				if (argCount == 3)
-					goto CallNative;
-				args[3] = argument3._data;
+				switch (argCount)
+				{
+					case 0:
+						break;
+					case 1:
+						args[0] = argument0._data;
+						break;
+					case 2:
+						args[0] = argument0._data;
+						args[1] = argument1._data;
+						break;
+					case 3:
+						args[0] = argument0._data;
+						args[1] = argument1._data;
+						args[2] = argument2._data;
+						break;
+					default:
+						args[0] = argument0._data;
+						args[1] = argument1._data;
+						args[2] = argument2._data;
+						args[3] = argument3._data;
+						break;
+				}
 
-			CallNative:
 				SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
 			}
 		}

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -375,70 +375,77 @@ namespace GTA.Native
 			unsafe
 			{
 				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args);
-
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
 		public static T Call<T>(Hash hash)
 		{
-			return CallInternalNoParamArray<T>(hash, null, null, null, null, 0);
+			unsafe
+			{
+				return CallInternalNoParamArray<T>(hash, null, 0);
+			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, null, null, null, 1);
+			unsafe
+			{
+				var argPtr = stackalloc ulong[1];
+
+				argPtr[0] = argument0._data;
+
+				return CallInternalNoParamArray<T>(hash, argPtr, 1);
+			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, null, null, 2);
+			unsafe
+			{
+				var argPtr = stackalloc ulong[2];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument0._data;
+
+				return CallInternalNoParamArray<T>(hash, argPtr, 2);
+			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, null, 3);
+			unsafe
+			{
+				var argPtr = stackalloc ulong[3];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+
+				return CallInternalNoParamArray<T>(hash, argPtr, 3);
+			}
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, argument3, 4);
-		}
-		static unsafe T CallInternalNoParamArray<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3, int argCount)
-		{
 			unsafe
 			{
-				var args = stackalloc ulong[argCount];
+				var argPtr = stackalloc ulong[4];
 
-				switch (argCount)
-				{
-					case 0:
-						break;
-					case 1:
-						args[0] = argument0._data;
-						break;
-					case 2:
-						args[0] = argument0._data;
-						args[1] = argument1._data;
-						break;
-					case 3:
-						args[0] = argument0._data;
-						args[1] = argument1._data;
-						args[2] = argument2._data;
-						break;
-					default:
-						args[0] = argument0._data;
-						args[1] = argument1._data;
-						args[2] = argument2._data;
-						args[3] = argument3._data;
-						break;
-				}
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
 
-				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
-				return ReturnValueFromNativeIfNotNull<T>(res);
+				return CallInternalNoParamArray<T>(hash, argPtr, 4);
 			}
+		}
+		static unsafe T CallInternalNoParamArray<T>(Hash hash, ulong* argPtr, int argCount)
+		{
+			var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			return ReturnValueFromNativeIfNotNull<T>(res);
 		}
 		static unsafe T ReturnValueFromNativeIfNotNull<T>(ulong* result)
 		{
 			// The result will be null when this method is called from a thread other than the main thread
 			if (result == null)
 			{
-				throw new InvalidOperationException("Native.Function.Call can only be called from the main thread.");
+				ThrowInvalidOperationExceptionForInvalidNativeCall();
 			}
 
 			if (typeof(T).IsValueType || typeof(PoolObject).IsAssignableFrom(typeof(T)) || typeof(T).IsEnum)
@@ -450,6 +457,9 @@ namespace GTA.Native
 				return (T)ObjectFromNative(typeof(T), result);
 			}
 		}
+		// have to create this method to let JIT inline ReturnValueFromNativeIfNotNull
+		static void ThrowInvalidOperationExceptionForInvalidNativeCall() => throw new InvalidOperationException("Native.Function.Call can only be called from the main thread.");
+
 		/// <summary>
 		/// Calls the specified native script function and ignores its return value.
 		/// </summary>
@@ -470,55 +480,63 @@ namespace GTA.Native
 		}
 		public static void Call(Hash hash)
 		{
-			CallInternalNoParamArray(hash, null, null, null, null, 0);
+			unsafe
+			{
+				SHVDN.NativeFunc.Invoke((ulong)hash, null, 0);
+			}
 		}
 		public static void Call(Hash hash, InputArgument argument0)
 		{
-			CallInternalNoParamArray(hash, argument0, null, null, null, 1);
+			unsafe
+			{
+				const int argCount = 1;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, null, null, 2);
+			unsafe
+			{
+				const int argCount = 2;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, argument2, null, 3);
+			unsafe
+			{
+				const int argCount = 3;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, argument2, argument3, 4);
-		}
-		static void CallInternalNoParamArray(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3, int argCount)
-		{
 			unsafe
 			{
-				var args = stackalloc ulong[argCount];
+				const int argCount = 4;
+				var argPtr = stackalloc ulong[argCount];
 
-				switch (argCount)
-				{
-					case 0:
-						break;
-					case 1:
-						args[0] = argument0._data;
-						break;
-					case 2:
-						args[0] = argument0._data;
-						args[1] = argument1._data;
-						break;
-					case 3:
-						args[0] = argument0._data;
-						args[1] = argument1._data;
-						args[2] = argument2._data;
-						break;
-					default:
-						args[0] = argument0._data;
-						args[1] = argument1._data;
-						args[2] = argument2._data;
-						args[3] = argument3._data;
-						break;
-				}
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
 
-				SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
 

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -381,56 +381,45 @@ namespace GTA.Native
 		}
 		public static T Call<T>(Hash hash)
 		{
-			return CallInternalNoParamArray<T>(hash, null, null, null, null);
+			return CallInternalNoParamArray<T>(hash, null, null, null, null, 0);
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, null, null, null);
+			return CallInternalNoParamArray<T>(hash, argument0, null, null, null, 1);
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, null, null);
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, null, null, 2);
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, null);
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, null, 3);
 		}
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
-			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, argument3);
+			return CallInternalNoParamArray<T>(hash, argument0, argument1, argument2, argument3, 4);
 		}
-		static unsafe T CallInternalNoParamArray<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		static unsafe T CallInternalNoParamArray<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3, int argCount)
 		{
-			bool isArg0Null = argument0 == null;
-			bool isArg1Null = argument1 == null;
-			bool isArg2Null = argument2 == null;
-			bool isArg3Null = argument3 == null;
-
-			int argCount = 0;
-			if (!isArg0Null)
-				argCount++;
-			if (!isArg1Null)
-				argCount++;
-			if (!isArg2Null)
-				argCount++;
-			if (!isArg3Null)
-				argCount++;
-
 			unsafe
 			{
 				var args = stackalloc ulong[argCount];
 
-				if (!isArg0Null)
-					args[0] = argument0._data;
-				if (!isArg1Null)
-					args[1] = argument1._data;
-				if (!isArg2Null)
-					args[2] = argument2._data;
-				if (!isArg3Null)
-					args[3] = argument3._data;
+				if (argCount <= 0)
+					goto CallNative;
+				args[0] = argument0._data;
+				if (argCount == 1)
+					goto CallNative;
+				args[1] = argument1._data;
+				if (argCount == 2)
+					goto CallNative;
+				args[2] = argument2._data;
+				if (argCount == 3)
+					goto CallNative;
+				args[3] = argument3._data;
 
+			CallNative:
 				var res = SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
-
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
@@ -471,54 +460,44 @@ namespace GTA.Native
 		}
 		public static void Call(Hash hash)
 		{
-			CallInternalNoParamArray(hash, null, null, null, null);
+			CallInternalNoParamArray(hash, null, null, null, null, 0);
 		}
 		public static void Call(Hash hash, InputArgument argument0)
 		{
-			CallInternalNoParamArray(hash, argument0, null, null, null);
+			CallInternalNoParamArray(hash, argument0, null, null, null, 1);
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, null, null);
+			CallInternalNoParamArray(hash, argument0, argument1, null, null, 2);
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, argument2, null);
+			CallInternalNoParamArray(hash, argument0, argument1, argument2, null, 3);
 		}
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
-			CallInternalNoParamArray(hash, argument0, argument1, argument2, argument3);
+			CallInternalNoParamArray(hash, argument0, argument1, argument2, argument3, 4);
 		}
-		static void CallInternalNoParamArray(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
+		static void CallInternalNoParamArray(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3, int argCount)
 		{
-			bool isArg0Null = argument0 == null;
-			bool isArg1Null = argument1 == null;
-			bool isArg2Null = argument2 == null;
-			bool isArg3Null = argument3 == null;
-
-			int argCount = 0;
-			if (!isArg0Null)
-				argCount++;
-			if (!isArg1Null)
-				argCount++;
-			if (!isArg2Null)
-				argCount++;
-			if (!isArg3Null)
-				argCount++;
-
 			unsafe
 			{
 				var args = stackalloc ulong[argCount];
 
-				if (!isArg0Null)
-					args[0] = argument0._data;
-				if (!isArg1Null)
-					args[1] = argument1._data;
-				if (!isArg2Null)
-					args[2] = argument2._data;
-				if (!isArg3Null)
-					args[3] = argument3._data;
+				if (argCount <= 0)
+					goto CallNative;
+				args[0] = argument0._data;
+				if (argCount == 1)
+					goto CallNative;
+				args[1] = argument1._data;
+				if (argCount == 2)
+					goto CallNative;
+				args[2] = argument2._data;
+				if (argCount == 3)
+					goto CallNative;
+				args[3] = argument3._data;
 
+			CallNative:
 				SHVDN.NativeFunc.Invoke((ulong)hash, args, argCount);
 			}
 		}

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -382,6 +382,8 @@ namespace GTA.Native
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
+
+		#region Call with Return Value Overloads with Normal InputArgument Paramaters
 		/// <summary>
 		/// Calls the specified native script function and returns its return value.
 		/// </summary>
@@ -418,8 +420,8 @@ namespace GTA.Native
 		/// Calls the specified native script function and ignores its return value.
 		/// </summary>
 		/// <param name="hash">The hashed name of the script function.</param>
-		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
-		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
 		/// <returns>The return value of the native.</returns>
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
@@ -439,9 +441,9 @@ namespace GTA.Native
 		/// Calls the specified native script function and ignores its return value.
 		/// </summary>
 		/// <param name="hash">The hashed name of the script function.</param>
-		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
-		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
-		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
 		/// <returns>The return value of the native.</returns>
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
@@ -462,10 +464,10 @@ namespace GTA.Native
 		/// Calls the specified native script function and ignores its return value.
 		/// </summary>
 		/// <param name="hash">The hashed name of the script function.</param>
-		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
-		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
-		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
-		/// <param name="argument3">The fourth input or output argument to pass to the native script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
 		/// <returns>The return value of the native.</returns>
 		public static T Call<T>(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
@@ -483,6 +485,590 @@ namespace GTA.Native
 				return ReturnValueFromNativeIfNotNull<T>(res);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4)
+		{
+			unsafe
+			{
+				const int argCount = 5;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5)
+		{
+			unsafe
+			{
+				const int argCount = 6;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6)
+		{
+			unsafe
+			{
+				const int argCount = 7;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7)
+		{
+			unsafe
+			{
+				const int argCount = 8;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8)
+		{
+			unsafe
+			{
+				const int argCount = 9;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9)
+		{
+			unsafe
+			{
+				const int argCount = 10;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10)
+		{
+			unsafe
+			{
+				const int argCount = 11;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11)
+		{
+			unsafe
+			{
+				const int argCount = 12;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <param name="argument12">The 13th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12)
+		{
+			unsafe
+			{
+				const int argCount = 13;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+				argPtr[12] = argument12._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <param name="argument12">The 13th input or output argument to pass to the native script function.</param>
+		/// <param name="argument13">The 14th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13)
+		{
+			unsafe
+			{
+				const int argCount = 14;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+				argPtr[12] = argument12._data;
+				argPtr[13] = argument13._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <param name="argument12">The 13th input or output argument to pass to the native script function.</param>
+		/// <param name="argument13">The 14th input or output argument to pass to the native script function.</param>
+		/// <param name="argument14">The 15th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13,
+			InputArgument argument14)
+		{
+			unsafe
+			{
+				const int argCount = 15;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+				argPtr[12] = argument12._data;
+				argPtr[13] = argument13._data;
+				argPtr[14] = argument14._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <param name="argument12">The 13th input or output argument to pass to the native script function.</param>
+		/// <param name="argument13">The 14th input or output argument to pass to the native script function.</param>
+		/// <param name="argument14">The 15th input or output argument to pass to the native script function.</param>
+		/// <param name="argument15">The 16th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static T Call<T>(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13,
+			InputArgument argument14,
+			InputArgument argument15)
+		{
+			unsafe
+			{
+				const int argCount = 16;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+				argPtr[12] = argument12._data;
+				argPtr[13] = argument13._data;
+				argPtr[14] = argument14._data;
+				argPtr[15] = argument15._data;
+
+				var res = SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+				return ReturnValueFromNativeIfNotNull<T>(res);
+			}
+		}
+		#endregion
+
 		static unsafe T ReturnValueFromNativeIfNotNull<T>(ulong* result)
 		{
 			// The result will be null when this method is called from a thread other than the main thread
@@ -521,6 +1107,8 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
+
+		#region void Call Overloads with Normal InputArgument Paramaters
 		/// <summary>
 		/// Calls the specified native script function and ignores its return value.
 		/// </summary>
@@ -553,10 +1141,8 @@ namespace GTA.Native
 		/// Calls the specified native script function and ignores its return value.
 		/// </summary>
 		/// <param name="hash">The hashed name of the script function.</param>
-		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
-		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
-		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
-		/// <param name="argument3">The fourth input or output argument to pass to the native script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1)
 		{
 			unsafe
@@ -574,9 +1160,9 @@ namespace GTA.Native
 		/// Calls the specified native script function and ignores its return value.
 		/// </summary>
 		/// <param name="hash">The hashed name of the script function.</param>
-		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
-		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
-		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2)
 		{
 			unsafe
@@ -595,10 +1181,10 @@ namespace GTA.Native
 		/// Calls the specified native script function and ignores its return value.
 		/// </summary>
 		/// <param name="hash">The hashed name of the script function.</param>
-		/// <param name="argument0">The first input or output argument to pass to the native script function.</param>
-		/// <param name="argument1">The second input or output argument to pass to the native script function.</param>
-		/// <param name="argument2">The third input or output argument to pass to the native script function.</param>
-		/// <param name="argument3">The fourth input or output argument to pass to the native script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
 		public static void Call(Hash hash, InputArgument argument0, InputArgument argument1, InputArgument argument2, InputArgument argument3)
 		{
 			unsafe
@@ -614,6 +1200,577 @@ namespace GTA.Native
 				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
 			}
 		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4)
+		{
+			unsafe
+			{
+				const int argCount = 5;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5)
+		{
+			unsafe
+			{
+				const int argCount = 6;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6)
+		{
+			unsafe
+			{
+				const int argCount = 7;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7)
+		{
+			unsafe
+			{
+				const int argCount = 8;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8)
+		{
+			unsafe
+			{
+				const int argCount = 9;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9)
+		{
+			unsafe
+			{
+				const int argCount = 10;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10)
+		{
+			unsafe
+			{
+				const int argCount = 11;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11)
+		{
+			unsafe
+			{
+				const int argCount = 12;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <param name="argument12">The 13th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12)
+		{
+			unsafe
+			{
+				const int argCount = 13;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+				argPtr[12] = argument12._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <param name="argument12">The 13th input or output argument to pass to the native script function.</param>
+		/// <param name="argument13">The 14th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13)
+		{
+			unsafe
+			{
+				const int argCount = 14;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+				argPtr[12] = argument12._data;
+				argPtr[13] = argument13._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <param name="argument12">The 13th input or output argument to pass to the native script function.</param>
+		/// <param name="argument13">The 14th input or output argument to pass to the native script function.</param>
+		/// <param name="argument14">The 15th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13,
+			InputArgument argument14)
+		{
+			unsafe
+			{
+				const int argCount = 15;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+				argPtr[12] = argument12._data;
+				argPtr[13] = argument13._data;
+				argPtr[14] = argument14._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		/// <summary>
+		/// Calls the specified native script function and ignores its return value.
+		/// </summary>
+		/// <param name="hash">The hashed name of the script function.</param>
+		/// <param name="argument0">The 1st input or output argument to pass to the native script function.</param>
+		/// <param name="argument1">The 2nd input or output argument to pass to the native script function.</param>
+		/// <param name="argument2">The 3rd input or output argument to pass to the native script function.</param>
+		/// <param name="argument3">The 4th input or output argument to pass to the native script function.</param>
+		/// <param name="argument4">The 5th input or output argument to pass to the native script function.</param>
+		/// <param name="argument5">The 6th input or output argument to pass to the native script function.</param>
+		/// <param name="argument6">The 7th input or output argument to pass to the native script function.</param>
+		/// <param name="argument7">The 8th input or output argument to pass to the native script function.</param>
+		/// <param name="argument8">The 9th input or output argument to pass to the native script function.</param>
+		/// <param name="argument9">The 10th input or output argument to pass to the native script function.</param>
+		/// <param name="argument10">The 11th input or output argument to pass to the native script function.</param>
+		/// <param name="argument11">The 12th input or output argument to pass to the native script function.</param>
+		/// <param name="argument12">The 13th input or output argument to pass to the native script function.</param>
+		/// <param name="argument13">The 14th input or output argument to pass to the native script function.</param>
+		/// <param name="argument14">The 15th input or output argument to pass to the native script function.</param>
+		/// <param name="argument15">The 16th input or output argument to pass to the native script function.</param>
+		/// <returns>The return value of the native.</returns>
+		public static void Call(Hash hash,
+			InputArgument argument0,
+			InputArgument argument1,
+			InputArgument argument2,
+			InputArgument argument3,
+			InputArgument argument4,
+			InputArgument argument5,
+			InputArgument argument6,
+			InputArgument argument7,
+			InputArgument argument8,
+			InputArgument argument9,
+			InputArgument argument10,
+			InputArgument argument11,
+			InputArgument argument12,
+			InputArgument argument13,
+			InputArgument argument14,
+			InputArgument argument15)
+		{
+			unsafe
+			{
+				const int argCount = 16;
+				var argPtr = stackalloc ulong[argCount];
+
+				argPtr[0] = argument0._data;
+				argPtr[1] = argument1._data;
+				argPtr[2] = argument2._data;
+				argPtr[3] = argument3._data;
+				argPtr[4] = argument4._data;
+				argPtr[5] = argument5._data;
+				argPtr[6] = argument6._data;
+				argPtr[7] = argument7._data;
+				argPtr[8] = argument8._data;
+				argPtr[9] = argument9._data;
+				argPtr[10] = argument10._data;
+				argPtr[11] = argument11._data;
+				argPtr[12] = argument12._data;
+				argPtr[13] = argument13._data;
+				argPtr[14] = argument14._data;
+				argPtr[15] = argument15._data;
+
+				SHVDN.NativeFunc.Invoke((ulong)hash, argPtr, argCount);
+			}
+		}
+		#endregion
 
 		/// <summary>
 		/// Converts a managed object to a native value.


### PR DESCRIPTION
Why I created PR like this? Because I think heap allocation should not happen so much for native calls in common cases.

Thy these regular expressions with natives.h generated from [alloc8or's Native DB](https://alloc8or.re/gta5/nativedb/). Line counts are for natives.h for b2372.
no args: `>\(0x[0-9A-F]{1,16}\)` (Line count: 1043)
one arg: `>\(0x[0-9A-F]{1,16}, [A-Za-z0-9]{1,32}\)` (Line count: 2242)
two args: `>\(0x[0-9A-F]{1,16}, [A-Za-z0-9]{1,32}, [A-Za-z0-9]{1,32}\)` (Line count: 1508)
three args: `>\(0x[0-9A-F]{1,16}, [A-Za-z0-9]{1,32}, [A-Za-z0-9]{1,32}, [A-Za-z0-9]{1,32}\)` (Line count: 546)
four args: `>\(0x[0-9A-F]{1,16}, [A-Za-z0-9]{1,32}, [A-Za-z0-9]{1,32}, [A-Za-z0-9]{1,32}, [A-Za-z0-9]{1,32}\)` (Line count: 357)
natives with between no args to four args: (1043 + 2242 + 1508 + 546 + 357) = 5696
total natives: `NATIVE_INLINE static` (Line count: 6350)

So I can say this PR will add `Native.Call` overloads for about 90% natives to avoid heap allocation for the param array. We could define `Native.Call` overloads with 5 to 16 args so SHVDN can avoid `params` array allocations for almost all natives that some scripts call frequently (like 60 times on 1 second), such as `START_EXPENSIVE_SYNCHRONOUS_SHAPE_TEST_LOS_PROBE`, `DRAW_MARKER`, `DRAW_SPRITE`, and `DRAW_SPOT_LIGHT`.
If `InputArgument` was defined as struct, things would be better but it's too late.
_I would create 33 overloads for `Native.Call` (with no params to 32 params or at least 16 ones) if I was the owner of this repo or if I create .NET 5 (.NET Core in other words) variant of SHVDN, btw._