### PR TITLE
XML comment has badly formed XML

### DIFF
--- a/source/core/NativeFunc.cs
+++ b/source/core/NativeFunc.cs
@@ -236,7 +236,7 @@ namespace SHVDN
 		/// </summary>
 		/// <param name="hash">The function has to call.</param>
 		/// <param name="argPtr">A pointer of function arguments.</param>
-		/// <param name="argCount">The length of <paramref name="argPtr">.</param>
+		/// <param name="argCount">The length of <paramref name="argPtr /">.</param>
 		/// <returns>A pointer to the return value of the call.</returns>
 		public static ulong* Invoke(ulong hash, ulong* argPtr, int argCount)
 		{
@@ -280,7 +280,7 @@ namespace SHVDN
 		/// </summary>
 		/// <param name="hash">The function has to call.</param>
 		/// <param name="argPtr">A pointer of function arguments.</param>
-		/// <param name="argCount">The length of <paramref name="argPtr">.</param>
+		/// <param name="argCount">The length of <paramref name="argPtr" />.</param>
 		/// <returns>A pointer to the return value of the call.</returns>
 		public static ulong* InvokeInternal(ulong hash, ulong* argPtr, int argCount)
 		{


### PR DESCRIPTION
XML comment has badly formed XML -- 'End tag 'param' does not match the start tag 'paramref'.'	
ScriptHookVDotNet
\scripthookvdotnet\source\core\NativeFunc.cs	239	/ 283

Just a minor error flagged when compiling.