### PR TITLE
Expose the FindPattern function as part of the Game class

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -73,7 +73,7 @@ namespace SHVDN
 		/// <param name="pattern">The pattern.</param>
 		/// <param name="mask">The pattern mask.</param>
 		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
-		static unsafe byte* FindPattern(string pattern, string mask)
+		public static unsafe byte* FindPattern(string pattern, string mask)
 		{
 			ProcessModule module = Process.GetCurrentProcess().MainModule;
 			return FindPattern(pattern, mask, module.BaseAddress, (ulong)module.ModuleMemorySize);

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -543,5 +543,16 @@ namespace GTA
 		{
 			return Function.Call<int>(Hash.GET_PROFILE_SETTING, index);
 		}
+
+		/// <summary>
+		/// Searches the address space of the current process for a memory pattern.
+		/// </summary>
+		/// <param name="pattern">The pattern.</param>
+		/// <param name="mask">The pattern mask.</param>
+		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
+		public static unsafe byte* FindPattern(string pattern, string mask)
+		{
+			return SHVDN.NativeMemory.FindPattern(pattern, mask);
+		}
 	}
 }


### PR DESCRIPTION
You might be thinking: Why?

I feel that it would be a good idea to just have a `byte* FindPattern(string, string)` class to use wherever is required instead of copy pasting the same function on every single project.

I don't know if a function that sets the start location is required (`byte* FindPattern(string, string, IntPtr)`), but if it is just let me know to update the PR.