### PR TITLE
Public function "GetEntityAddress" added

### DIFF
--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -17,7 +17,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B2933D8F-F922-40BD-BB70-18622A81AB8F}</ProjectGuid>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>SHVDN</RootNamespace>
   </PropertyGroup>
@@ -46,15 +46,6 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='NativeGen'">
     <ConfigurationType>Utility</ConfigurationType>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='NativeGen|x64'">
-    <PlatformToolset>v143</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v143</PlatformToolset>
-  </PropertyGroup>
-  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Global compilation settings -->
@@ -138,11 +129,31 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <!-- Compile C# source files -->
-  <Target Name="CsCompile" BeforeTargets="ClCompile" Inputs="@(CsCompile)" Outputs="$(IntDir)$(TargetName).netmodule">
-    <Csc Sources="@(CsCompile)" AllowUnsafeBlocks="%(CsCompile.AllowUnsafeBlocks)" DisabledWarnings="%(CsCompile.NoWarn)" DocumentationFile="$(IntDir)$(TargetName).xdc" LangVersion="%(CsCompile.LangVersion)" Optimize="%(CsCompile.Optimize)" OutputAssembly="$(IntDir)$(TargetName).netmodule" TargetType="Module" Utf8Output="%(CsCompile.Utf8Output)" WarningLevel="%(CsCompile.WarningLevel)" WarningsAsErrors="%(CsCompile.WarningsAsErrors)" WarningsNotAsErrors="%(CsCompile.WarningsNotAsErrors)" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" />
+  <Target
+    Name="CsCompile"
+    BeforeTargets="ClCompile"
+    Inputs="@(CsCompile)"
+    Outputs="$(IntDir)$(TargetName).netmodule">
+    <Csc
+      Sources="@(CsCompile)"
+      AllowUnsafeBlocks="%(CsCompile.AllowUnsafeBlocks)"
+      DisabledWarnings="%(CsCompile.NoWarn)"
+      DocumentationFile="$(IntDir)$(TargetName).xdc"
+      LangVersion="%(CsCompile.LangVersion)"
+      Optimize="%(CsCompile.Optimize)"
+      OutputAssembly="$(IntDir)$(TargetName).netmodule"
+      TargetType="Module"
+      Utf8Output="%(CsCompile.Utf8Output)"
+      WarningLevel="%(CsCompile.WarningLevel)"
+      WarningsAsErrors="%(CsCompile.WarningsAsErrors)"
+      WarningsNotAsErrors="%(CsCompile.WarningsNotAsErrors)"
+      ToolExe="$(CscToolExe)"
+      ToolPath="$(CscToolPath)" />
   </Target>
   <!-- Verify SDK files exist before generating anything -->
-  <Target Name="VerifySDKFiles" BeforeTargets="BeforeBuildGenerateSources">
+  <Target
+    Name="VerifySDKFiles"
+    BeforeTargets="BeforeBuildGenerateSources">
     <ItemGroup>
       <!-- Look for the header files and the library -->
       <SDKFiles Include="sdk\inc\*.h" />

--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -17,7 +17,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B2933D8F-F922-40BD-BB70-18622A81AB8F}</ProjectGuid>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>SHVDN</RootNamespace>
   </PropertyGroup>
@@ -46,6 +46,15 @@
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='NativeGen'">
     <ConfigurationType>Utility</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='NativeGen|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <!-- Global compilation settings -->
@@ -129,31 +138,11 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <!-- Compile C# source files -->
-  <Target
-    Name="CsCompile"
-    BeforeTargets="ClCompile"
-    Inputs="@(CsCompile)"
-    Outputs="$(IntDir)$(TargetName).netmodule">
-    <Csc
-      Sources="@(CsCompile)"
-      AllowUnsafeBlocks="%(CsCompile.AllowUnsafeBlocks)"
-      DisabledWarnings="%(CsCompile.NoWarn)"
-      DocumentationFile="$(IntDir)$(TargetName).xdc"
-      LangVersion="%(CsCompile.LangVersion)"
-      Optimize="%(CsCompile.Optimize)"
-      OutputAssembly="$(IntDir)$(TargetName).netmodule"
-      TargetType="Module"
-      Utf8Output="%(CsCompile.Utf8Output)"
-      WarningLevel="%(CsCompile.WarningLevel)"
-      WarningsAsErrors="%(CsCompile.WarningsAsErrors)"
-      WarningsNotAsErrors="%(CsCompile.WarningsNotAsErrors)"
-      ToolExe="$(CscToolExe)"
-      ToolPath="$(CscToolPath)" />
+  <Target Name="CsCompile" BeforeTargets="ClCompile" Inputs="@(CsCompile)" Outputs="$(IntDir)$(TargetName).netmodule">
+    <Csc Sources="@(CsCompile)" AllowUnsafeBlocks="%(CsCompile.AllowUnsafeBlocks)" DisabledWarnings="%(CsCompile.NoWarn)" DocumentationFile="$(IntDir)$(TargetName).xdc" LangVersion="%(CsCompile.LangVersion)" Optimize="%(CsCompile.Optimize)" OutputAssembly="$(IntDir)$(TargetName).netmodule" TargetType="Module" Utf8Output="%(CsCompile.Utf8Output)" WarningLevel="%(CsCompile.WarningLevel)" WarningsAsErrors="%(CsCompile.WarningsAsErrors)" WarningsNotAsErrors="%(CsCompile.WarningsNotAsErrors)" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" />
   </Target>
   <!-- Verify SDK files exist before generating anything -->
-  <Target
-    Name="VerifySDKFiles"
-    BeforeTargets="BeforeBuildGenerateSources">
+  <Target Name="VerifySDKFiles" BeforeTargets="BeforeBuildGenerateSources">
     <ItemGroup>
       <!-- Look for the header files and the library -->
       <SDKFiles Include="sdk\inc\*.h" />

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -154,7 +154,7 @@ namespace GTA
 				{
 					value = 0;
 				}
-				if (value > 5)
+				else if (value > 5)
 				{
 					value = 5;
 				}
@@ -545,6 +545,15 @@ namespace GTA
 			return Function.Call<int>(Hash.GET_PROFILE_SETTING, index);
 		}
 
+		/// <summary>
+		/// Get the current address of an entity with a handle
+		/// </summary>
+		/// <param name="handle">The handle of an entity.</param>
+		/// <returns>The address of an entity, or <see cref="IntPtr.Zero" /> if none was found.</returns>
+		public static IntPtr GetEntityAddress(int handle)
+		{
+			return SHVDN.NativeMemory.GetEntityAddress(handle);
+		}
 
 		/// <summary>
 		/// Searches the address space of the current process for a memory pattern.


### PR DESCRIPTION
This function helps me to create my own SteeringAngle function in my [project](https://github.com/GTACOOP-R/GTACoop-R/blob/main/Client/Util.cs#L73).

Or maybe we can change [this](https://github.com/crosire/scripthookvdotnet/blob/main/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs#L1153) to:
`SHVDN.NativeMemory.WriteFloat(address + SHVDN.NativeMemory.SteeringAngleOffset, (float)(value * (System.Math.PI / 180.0)));`
because the steeringangle has a wrong value currently and [this](https://github.com/crosire/scripthookvdotnet/blob/main/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs#L1152) is not true (tested for months).

