### PR TITLE
Add new parameters to GET_VEHICLE_NUMBER_OF_PASSENGERS. 

### DIFF
--- a/source/scripting_v2/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/Vehicle.cs
@@ -1133,7 +1133,7 @@ namespace GTA
 			}
 		}
 
-		public int PassengerCount => Function.Call<int>(Hash.GET_VEHICLE_NUMBER_OF_PASSENGERS, Handle);
+		public int PassengerCount => Function.Call<int>(Hash.GET_VEHICLE_NUMBER_OF_PASSENGERS, Handle, false, true);
 
 		public int PassengerSeats => Function.Call<int>(Hash.GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS, Handle);
 

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -1756,7 +1756,7 @@ namespace GTA
 			}
 		}
 
-		public int PassengerCount => Function.Call<int>(Hash.GET_VEHICLE_NUMBER_OF_PASSENGERS, Handle);
+		public int PassengerCount => Function.Call<int>(Hash.GET_VEHICLE_NUMBER_OF_PASSENGERS, Handle, false, true);
 
 		public int PassengerCapacity => Function.Call<int>(Hash.GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS, Handle);
 


### PR DESCRIPTION
These parameters are, respectively, "include driver" and "include dead peds." They should be, respectively, false and true to mirror previous behavior. Source: my own reverse-engineering.