### PR TITLE
Add fragment object features for entity

### DIFF
--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -695,6 +695,67 @@ namespace GTA
 
 		#endregion
 
+		#region Fragment Object
+
+		/// <summary>
+		/// Returns the number of fragment group of this <see cref="Entity"/>.
+		/// </summary>
+		public int FragmentGroupCount
+		{
+			get
+			{
+				var address = MemoryAddress;
+				if (address == IntPtr.Zero)
+				{
+					return 0;
+				}
+
+				return SHVDN.NativeMemory.GetFragmentGroupCountFromEntity(address);
+			}
+		}
+
+		/// <summary>
+		/// Determines if this <see cref="Entity"/> is a fragment object.
+		/// </summary>
+		/// <returns>
+		/// <see langword="true" /> if this <see cref="Entity"/> is a fragment object; otherwise, <see langword="false" />.
+		/// This will return <see langword="true" /> if this <see cref="Entity"/> is a <see cref="Ped"/> or a <see cref="Vehicle"/>.
+		/// </returns>
+		public bool IsFragmentObject
+		{
+			get
+			{
+				var address = MemoryAddress;
+				if (address == IntPtr.Zero)
+				{
+					return false;
+				}
+
+				return SHVDN.NativeMemory.IsEntityFragmentObject(address);
+			}
+		}
+
+		/// <summary>
+		/// Detachs a fragment part of this <see cref="Entity"/>. Can create a new <see cref="Entity"/>.
+		/// </summary>
+		/// <returns>
+		///   <para><see langword="true" /> if a new <see cref="Entity"/> is created; otherwise, <see langword="false" />.</para>
+		///   <para>Returning <see langword="false" /> does not necessarily mean detaching the part did not changed the <see cref="Entity"/> in any ways.
+		///   For example, detaching <c>seat_f</c> for <see cref="Vehicle"/> will return <see langword="false" /> but the <see cref="Ped"/> on the front seat will not be able to sit properly.</para>
+		/// </returns>
+		public bool DetachFragmentPart(int fragmentGroupIndex)
+		{
+			var address = MemoryAddress;
+			if (address == IntPtr.Zero)
+			{
+				return false;
+			}
+
+			return SHVDN.NativeMemory.DetachFragmentPartByIndex(address, fragmentGroupIndex);
+		}
+
+		#endregion
+
 		#region Invincibility
 
 		/// <summary>

--- a/source/scripting_v3/GTA/Entities/EntityBone.cs
+++ b/source/scripting_v3/GTA/Entities/EntityBone.cs
@@ -231,6 +231,23 @@ namespace GTA
 		}
 
 		/// <summary>
+		/// Gets the fragment group index of this <see cref="EntityBone"/>. -1 will be returned if the <see cref="Entity"/> does not exist or <see cref="Index"/> is invalid.
+		/// </summary>
+		public int FragmentGroupIndex
+		{
+			get
+			{
+				IntPtr address = Owner.MemoryAddress;
+				if (address == IntPtr.Zero)
+				{
+					return -1;
+				}
+
+				return SHVDN.NativeMemory.GetFragmentGroupIndexByEntityBoneIndex(address, Index);
+			}
+		}
+
+		/// <summary>
 		/// Gets the position in world coordinates of an offset relative this <see cref="EntityBone"/>
 		/// </summary>
 		/// <param name="offset">The offset from this <see cref="EntityBone"/>.</param>

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -363,6 +363,11 @@ namespace GTA
 		public static int ProjectileCount => SHVDN.NativeMemory.GetProjectileCount();
 
 		/// <summary>
+		/// Returns the total number of <see cref="Entity"/> colliders used.
+		/// </summary>
+		public static int EntityColliderCount => SHVDN.NativeMemory.GetEntityColliderCount();
+
+		/// <summary>
 		/// The total number of <see cref="Vehicle"/>s that can exist in the world.
 		/// </summary>
 		/// <remarks>The game will crash when the number of <see cref="Vehicle"/> is the same as this limit and the game tries to create a <see cref="Vehicle"/>.</remarks>
@@ -386,6 +391,12 @@ namespace GTA
 		/// Always returns 50 currently since the limit is hard-coded in the exe.
 		/// </summary>
 		public static int ProjectileCapacity => SHVDN.NativeMemory.GetProjectileCapacity();
+		/// <summary>
+		/// <para>The total number of <see cref="Entity"/> colliders can be used. The return value can be different in different versions.</para>
+		/// <para>When <see cref="EntityColliderCount"/> reaches this value, no more <see cref="Entity"/> will not be able to be physically moved
+		/// and <see cref="Vehicle"/>s and <see cref="Prop"/>s will not be able to detach fragment parts properly.</para>
+		/// </summary>
+		public static int EntityColliderCapacity => SHVDN.NativeMemory.GetEntityColliderCapacity();
 
 		/// <summary>
 		/// Gets the closest <see cref="Ped"/> to a given position in the World.


### PR DESCRIPTION
Memory patterns for fragment object features are taken from [Zolika1351's Trainer](https://www.gta5-mods.com/scripts/zolika1351-s-trainer) (yes, I disassembled the asi to take, but altered the patterns to support all the versions) and ones for entity collider are taken from [a PR for Chaos Mod V](https://github.com/gta-chaos-mod/ChaosModV/pull/2645).