### PR TITLE
Add startAddress parameter to Game.FindPattern

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -86,7 +86,7 @@ namespace SHVDN
 		/// <param name="mask">The pattern mask.</param>
 		/// <param name="startAddress">The address to start searching at.</param>
 		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
-		static unsafe byte* FindPattern(string pattern, string mask, IntPtr startAddress)
+		public static unsafe byte* FindPattern(string pattern, string mask, IntPtr startAddress)
 		{
 			ProcessModule module = Process.GetCurrentProcess().MainModule;
 

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -551,9 +551,10 @@ namespace GTA
 		/// Searches the address space of the current process for a memory pattern.
 		/// </summary>
 		/// <param name="pattern">The pattern.</param>
+		/// <param name="startAddress">The address to start searching at. If <see cref="IntPtr.Zero" /> (<see langword="default" />), search is started at the base address.</param>
 		/// <returns>The address of a region matching the pattern, or <see cref="IntPtr.Zero" /> if none was found.</returns>
 		/// <remarks>This function takes the Cheat Engine/IDA format ("48 8B 0D ?? ?? ? ? 44 8B C6 8B D5 8B D8" for example, where ?? and ? are wildcards).</remarks>
-		public static IntPtr FindPattern(string pattern)
+		public static IntPtr FindPattern(string pattern, IntPtr startAddress = default)
 		{
 			string newPattern = string.Empty;
 			string newMask = string.Empty;
@@ -577,20 +578,21 @@ namespace GTA
 				newMask += "x";
 			}
 
-			return FindPattern(newPattern, newMask);
+			return FindPattern(newPattern, newMask, startAddress);
 		}
 		/// <summary>
 		/// Searches the address space of the current process for a memory pattern.
 		/// </summary>
 		/// <param name="pattern">The pattern.</param>
 		/// <param name="mask">The pattern mask.</param>
+		/// <param name="startAddress">The address to start searching at. If <see cref="IntPtr.Zero" /> (<see langword="default" />), search is started at the base address.</param>
 		/// <returns>The address of a region matching the pattern, or <see cref="IntPtr.Zero" /> if none was found.</returns>
 		/// <remarks>This function takes the classic format ("\x48\x8B\x0D\x00\x00\x00\x00\x44\x8B\xC6\x8B\xD5\x8B\xD8" as the pattern and "xxx????xxxxxxx" as the mask for example, where \x00 in the pattern and ? In the mask is a wildcard).</remarks>
-		public static IntPtr FindPattern(string pattern, string mask)
+		public static IntPtr FindPattern(string pattern, string mask, IntPtr startAddress = default)
 		{
 			unsafe
 			{
-				byte* address = SHVDN.NativeMemory.FindPattern(pattern, mask);
+				byte* address = (startAddress == IntPtr.Zero ? SHVDN.NativeMemory.FindPattern(pattern, mask) : SHVDN.NativeMemory.FindPattern(pattern, mask, startAddress));
 				return address == null ? IntPtr.Zero : new IntPtr(address);
 			}
 		}


### PR DESCRIPTION
In #1034, the start address parameter wasn't added, but sometimes you'll need this. Specifying the start address will be useful when you have to find values indirectly.
For example, if search is started at the base address of the exe when values you're looking for are in a procedure that is not unique enough, it'll be difficult to identify. If you find some `call` instruction for the procedure and search is started at the start address of the procedure, it'll be easy.

```
// Simple procedure in assembly. The format could be wrong.
mov    eax, 0x40200000 // 2.5 in float. In this case, you could find the value by searching for the procedure address.
ret

// More complex procedure
(some instructions)
mov    edx, 345 // if instructions are added or removed in procedure, searching procedure would be a better option
(some instructions)
ret
```