### PR TITLE
Register Entities created by scripts

### DIFF
--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -6,12 +6,16 @@
 using GTA.Math;
 using GTA.Native;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GTA
 {
 	public abstract class Entity : PoolObject, ISpatial
 	{
+		// Register entities created by a script.
+		internal static readonly HashSet<int> CreatedByScript = new HashSet<int>();
+
 		#region Fields
 		EntityBoneCollection _bones;
 		EntityDamageRecordCollection _damageRecords;
@@ -111,6 +115,15 @@ namespace GTA
 				SHVDN.NativeMemory.WriteByte(address + 0xDA, (byte)((int)value & 0xF));
 			}
 		}
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="Entity"/> is created by the currently running script.
+		/// </summary>
+		/// <value>
+		///   <see langword="true" /> if this <see cref="Entity"/> is created by this script; otherwise, <see langword="false" />.
+		/// </value>
+		/// <seealso cref="Exists"/>
+		public bool IsCreatedByScript => CreatedByScript.Contains(Handle);
 
 		/// <summary>
 		/// Gets a value indicating whether this <see cref="Entity"/> is dead or does not exist.

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -71,7 +71,9 @@ namespace GTA
 		/// <param name="heading">The direction the clone should be facing.</param>
 		public Ped Clone(float heading = 0.0f)
 		{
-			return new Ped(Function.Call<int>(Hash.CLONE_PED, Handle, heading, false, false));
+			var clone = new Ped(Function.Call<int>(Hash.CLONE_PED, Handle, heading, false, false));
+			CreatedByScript.Add(clone.Handle);
+			return clone;
 		}
 
 		/// <summary>

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -948,7 +948,9 @@ namespace GTA
 				return null;
 			}
 
-			return new Ped(Function.Call<int>(Hash.CREATE_PED, 26, model.Hash, position.X, position.Y, position.Z, heading, false, false));
+			var handle = Function.Call<int>(Hash.CREATE_PED, 26, model.Hash, position.X, position.Y, position.Z, heading, false, false);
+			Entity.CreatedByScript.Add(handle);
+			return new Ped(handle);
 		}
 		/// <summary>
 		/// Spawns a <see cref="Ped"/> of a random <see cref="Model"/> at the position specified.
@@ -961,7 +963,9 @@ namespace GTA
 				return null;
 			}
 
-			return new Ped(Function.Call<int>(Hash.CREATE_RANDOM_PED, position.X, position.Y, position.Z));
+			var handle = Function.Call<int>(Hash.CREATE_RANDOM_PED, position.X, position.Y, position.Z);
+			Entity.CreatedByScript.Add(handle);
+			return new Ped(handle);
 		}
 		/// <summary>
 		/// Spawns a <see cref="Ped"/> of a random <see cref="Model"/> at the position specified.
@@ -997,6 +1001,7 @@ namespace GTA
 			Function.Call(Hash.SET_PED_RANDOM_COMPONENT_VARIATION, createdPed.Handle, 0);
 			Function.Call(Hash.SET_PED_RANDOM_PROPS, createdPed.Handle);
 
+			Entity.CreatedByScript.Add(createdPed.Handle);
 			return createdPed;
 		}
 
@@ -1014,7 +1019,9 @@ namespace GTA
 				return null;
 			}
 
-			return new Vehicle(Function.Call<int>(Hash.CREATE_VEHICLE, model.Hash, position.X, position.Y, position.Z, heading, false, false));
+			var handle = Function.Call<int>(Hash.CREATE_VEHICLE, model.Hash, position.X, position.Y, position.Z, heading, false, false);
+			Entity.CreatedByScript.Add(handle);
+			return new Vehicle(handle);
 		}
 		/// <summary>
 		/// Spawns a <see cref="Vehicle"/> of a random <see cref="Model"/> at the position specified.
@@ -1040,7 +1047,10 @@ namespace GTA
 			var pickedModel = filteredVehModels.ElementAt(rand.Next(filteredModelCount));
 
 			// the model should be loaded at this moment, so call CREATE_VEHICLE immediately
-			return new Vehicle(Function.Call<int>(Hash.CREATE_VEHICLE, pickedModel, position.X, position.Y, position.Z, heading, false, false));
+			var handle = Function.Call<int>(Hash.CREATE_VEHICLE, pickedModel, position.X, position.Y, position.Z,
+				heading, false, false);
+			Entity.CreatedByScript.Add(handle);
+			return new Vehicle(handle);
 		}
 
 		/// <summary>
@@ -1063,7 +1073,9 @@ namespace GTA
 				position.Z = GetGroundHeight(position);
 			}
 
-			return new Prop(Function.Call<int>(Hash.CREATE_OBJECT, model.Hash, position.X, position.Y, position.Z, 1, 1, dynamic));
+			var handle = Function.Call<int>(Hash.CREATE_OBJECT, model.Hash, position.X, position.Y, position.Z, 1, 1, dynamic);
+			Entity.CreatedByScript.Add(handle);
+			return new Prop(handle);
 		}
 		/// <summary>
 		/// Spawns a <see cref="Prop"/> of the given <see cref="Model"/> at the specified position.
@@ -1099,7 +1111,9 @@ namespace GTA
 				return null;
 			}
 
-			return new Prop(Function.Call<int>(Hash.CREATE_OBJECT_NO_OFFSET, model.Hash, position.X, position.Y, position.Z, 1, 1, dynamic));
+			var handle = Function.Call<int>(Hash.CREATE_OBJECT_NO_OFFSET, model.Hash, position.X, position.Y, position.Z, 1, 1, dynamic);
+			Entity.CreatedByScript.Add(handle);
+			return new Prop(handle);
 		}
 		/// <summary>
 		/// Spawns a <see cref="Prop"/> of the given <see cref="Model"/> at the specified position without any offset.
@@ -1138,6 +1152,7 @@ namespace GTA
 				return null;
 			}
 
+			Entity.CreatedByScript.Add(handle);
 			return new Prop(handle);
 		}
 
@@ -1158,6 +1173,7 @@ namespace GTA
 				return null;
 			}
 
+			Entity.CreatedByScript.Add(handle);
 			return new Pickup(handle);
 		}
 		/// <summary>
@@ -1177,6 +1193,7 @@ namespace GTA
 				return null;
 			}
 
+			Entity.CreatedByScript.Add(handle);
 			return new Pickup(handle);
 		}
 


### PR DESCRIPTION
Similar to Entity.CreatedByTheCallingPlugin in Ragehook, registers entities that are created via a script so devs who only want to work on entities spawned by the game can simply check this property.