### PR TITLE
Improvements

### DIFF
--- a/ScriptHookVDotNet.sln
+++ b/ScriptHookVDotNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.329
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32901.215
 MinimumVisualStudioVersion = 15.0.26228.04
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ScriptHookVDotNet", "ScriptHookVDotNet.vcxproj", "{B2933D8F-F922-40BD-BB70-18622A81AB8F}"
 EndProject
@@ -27,20 +27,20 @@ Global
 		{B2933D8F-F922-40BD-BB70-18622A81AB8F}.Release|x64.Build.0 = Release|x64
 		{B2933D8F-F922-40BD-BB70-18622A81AB8F}.Run NativeGen|x64.ActiveCfg = NativeGen|x64
 		{B2933D8F-F922-40BD-BB70-18622A81AB8F}.Run NativeGen|x64.Build.0 = NativeGen|x64
-		{019193A7-50C0-444A-84CA-777595E702CD}.Debug|x64.ActiveCfg = Debug|x64
-		{019193A7-50C0-444A-84CA-777595E702CD}.Debug|x64.Build.0 = Debug|x64
-		{019193A7-50C0-444A-84CA-777595E702CD}.Release + Examples|x64.ActiveCfg = Release|x64
-		{019193A7-50C0-444A-84CA-777595E702CD}.Release + Examples|x64.Build.0 = Release|x64
-		{019193A7-50C0-444A-84CA-777595E702CD}.Release|x64.ActiveCfg = Release|x64
-		{019193A7-50C0-444A-84CA-777595E702CD}.Release|x64.Build.0 = Release|x64
-		{019193A7-50C0-444A-84CA-777595E702CD}.Run NativeGen|x64.ActiveCfg = Release|x64
-		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Debug|x64.ActiveCfg = Debug|x64
-		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Debug|x64.Build.0 = Debug|x64
-		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Release + Examples|x64.ActiveCfg = Release|x64
-		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Release + Examples|x64.Build.0 = Release|x64
-		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Release|x64.ActiveCfg = Release|x64
-		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Release|x64.Build.0 = Release|x64
-		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Run NativeGen|x64.ActiveCfg = Release|x64
+		{019193A7-50C0-444A-84CA-777595E702CD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{019193A7-50C0-444A-84CA-777595E702CD}.Debug|x64.Build.0 = Debug|Any CPU
+		{019193A7-50C0-444A-84CA-777595E702CD}.Release + Examples|x64.ActiveCfg = Release|Any CPU
+		{019193A7-50C0-444A-84CA-777595E702CD}.Release + Examples|x64.Build.0 = Release|Any CPU
+		{019193A7-50C0-444A-84CA-777595E702CD}.Release|x64.ActiveCfg = Release|Any CPU
+		{019193A7-50C0-444A-84CA-777595E702CD}.Release|x64.Build.0 = Release|Any CPU
+		{019193A7-50C0-444A-84CA-777595E702CD}.Run NativeGen|x64.ActiveCfg = Release|Any CPU
+		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Debug|x64.Build.0 = Debug|Any CPU
+		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Release + Examples|x64.ActiveCfg = Release|Any CPU
+		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Release + Examples|x64.Build.0 = Release|Any CPU
+		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Release|x64.ActiveCfg = Release|Any CPU
+		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Release|x64.Build.0 = Release|Any CPU
+		{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}.Run NativeGen|x64.ActiveCfg = Release|Any CPU
 		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Debug|x64.ActiveCfg = Debug|x64
 		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Release + Examples|x64.ActiveCfg = Release|x64
 		{A717AD5D-C5B5-4769-BD40-F14C09F269BB}.Release + Examples|x64.Build.0 = Release|x64

--- a/source/scripting_v2/ScriptHookVDotNet_APIv2.csproj
+++ b/source/scripting_v2/ScriptHookVDotNet_APIv2.csproj
@@ -1,264 +1,210 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">x64</Platform>
-    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
-    <ProjectGuid>{019193A7-50C0-444A-84CA-777595E702CD}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>GTA</RootNamespace>
-    <AssemblyName>ScriptHookVDotNet2</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <OutputPath>..\..\bin\Debug\</OutputPath>
-    <BaseIntermediateOutputPath>..\..\intermediate\ScriptHookVDotNet2\</BaseIntermediateOutputPath>
-    <DocumentationFile>..\..\bin\Debug\ScriptHookVDotNet2.xml</DocumentationFile>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>false</Optimize>
-    <NoWarn>1591</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>latest</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>..\..\bin\Release\</OutputPath>
-    <BaseIntermediateOutputPath>..\..\intermediate\ScriptHookVDotNet2\</BaseIntermediateOutputPath>
-    <DocumentationFile>..\..\bin\Release\ScriptHookVDotNet2.xml</DocumentationFile>
-    <DefineConstants>TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <NoWarn>1591</NoWarn>
-    <DebugType>none</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>latest</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\ScriptHookVDotNet.vcxproj">
-      <Name>ScriptHookVDotNet</Name>
-      <Project>{b2933d8f-f922-40bd-bb70-18622a81ab8f}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <!-- Add custom Build Action to Visual Studio Properties -->
-    <AvailableItemName Include="CppCompile">
-      <Targets>CppCompile</Targets>
-    </AvailableItemName>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="GTA.Math\Matrix.cs" />
-    <Compile Include="GTA.Math\Quaternion.cs" />
-    <Compile Include="GTA.Math\Vector2.cs" />
-    <Compile Include="GTA.Math\Vector3.cs" />
-    <Compile Include="GTA.Native\Native.cs" />
-    <Compile Include="GTA.Native\NativeHashes.cs" />
-    <Compile Include="GTA.Native\PedHash.cs" />
-    <Compile Include="GTA.Native\VehicleHash.cs" />
-    <Compile Include="GTA.Native\WeaponComponent.cs" />
-    <Compile Include="GTA.Native\WeaponHash.cs" />
-    <Compile Include="GTA.NaturalMotion\Euphoria.cs" />
-    <Compile Include="GTA.NaturalMotion\EuphoriaBase.cs" />
-    <Compile Include="GTA.NaturalMotion\EuphoriaHelpers.cs" />
-    <Compile Include="GTA\Audio.cs" />
-    <Compile Include="GTA\AudioFlag.cs" />
-    <Compile Include="GTA\Blip.cs" />
-    <Compile Include="GTA\BlipColor.cs" />
-    <Compile Include="GTA\BlipSprite.cs" />
-    <Compile Include="GTA\Camera.cs" />
-    <Compile Include="GTA\CameraShake.cs" />
-    <Compile Include="GTA\Control.cs" />
-    <Compile Include="GTA\Entities\Entity.cs" />
-    <Compile Include="GTA\Entities\Model.cs" />
-    <Compile Include="GTA\Entities\Peds\AnimationFlags.cs" />
-    <Compile Include="GTA\Entities\Peds\Bone.cs" />
-    <Compile Include="GTA\Entities\Peds\DrivingStyle.cs" />
-    <Compile Include="GTA\Entities\Peds\FiringPattern.cs" />
-    <Compile Include="GTA\Entities\Peds\FormationType.cs" />
-    <Compile Include="GTA\Entities\Peds\Gender.cs" />
-    <Compile Include="GTA\Entities\Peds\HelmetType.cs" />
-    <Compile Include="GTA\Entities\Peds\LeaveVehicleFlags.cs" />
-    <Compile Include="GTA\Entities\Peds\Ped.cs" />
-    <Compile Include="GTA\Entities\Peds\PedGroup.cs" />
-    <Compile Include="GTA\Entities\Peds\Relationship.cs" />
-    <Compile Include="GTA\Entities\Peds\Tasks.cs" />
-    <Compile Include="GTA\Entities\Peds\TaskSequence.cs" />
-    <Compile Include="GTA\Entities\Prop.cs" />
-    <Compile Include="GTA\Entities\Vehicles\CargobobHook.cs" />
-    <Compile Include="GTA\Entities\Vehicles\NumberPlateMounting.cs" />
-    <Compile Include="GTA\Entities\Vehicles\NumberPlateType.cs" />
-    <Compile Include="GTA\Entities\Vehicles\Vehicle.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleClass.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleColor.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleDoor.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleLandingGear.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleLockStatus.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleMod.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleNeonLight.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleRoofState.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleSeat.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleToggleMod.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWheelType.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWindow.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWindowTint.cs" />
-    <Compile Include="GTA\ExplosionType.cs" />
-    <Compile Include="GTA\Font.cs" />
-    <Compile Include="GTA\ForceType.cs" />
-    <Compile Include="GTA\Game.cs" />
-    <Compile Include="GTA\GameplayCamera.cs" />
-    <Compile Include="GTA\GameVersion.cs" />
-    <Compile Include="GTA\Global.cs" />
-    <Compile Include="GTA\GlobalCollection.cs" />
-    <Compile Include="GTA\Handleable.cs" />
-    <Compile Include="GTA\InputMode.cs" />
-    <Compile Include="GTA\IntersectOptions.cs" />
-    <Compile Include="GTA\Language.cs" />
-    <Compile Include="GTA\MarkerType.cs" />
-    <Compile Include="GTA\Menu.cs" />
-    <Compile Include="GTA\MenuBase.cs" />
-    <Compile Include="GTA\MenuButton.cs" />
-    <Compile Include="GTA\MenuEnumScroller.cs" />
-    <Compile Include="GTA\MenuItem.cs" />
-    <Compile Include="GTA\MenuItemDoubleValueArgs.cs" />
-    <Compile Include="GTA\MenuItemIndexArgs.cs" />
-    <Compile Include="GTA\MenuLabel.cs" />
-    <Compile Include="GTA\MenuNumericScroller.cs" />
-    <Compile Include="GTA\MenuToggle.cs" />
-    <Compile Include="GTA\MessageBox.cs" />
-    <Compile Include="GTA\ParachuteTint.cs" />
-    <Compile Include="GTA\Pickup.cs" />
-    <Compile Include="GTA\PickupType.cs" />
-    <Compile Include="GTA\Player.cs" />
-    <Compile Include="GTA\RadioStation.cs" />
-    <Compile Include="GTA\RaycastResult.cs" />
-    <Compile Include="GTA\RequireScript.cs" />
-    <Compile Include="GTA\Rope.cs" />
-    <Compile Include="GTA\RopeType.cs" />
-    <Compile Include="GTA\Scaleform.cs" />
-    <Compile Include="GTA\ScaleformArgumentTXD.cs" />
-    <Compile Include="GTA\Script.cs" />
-    <Compile Include="GTA\ScriptSettings.cs" />
-    <Compile Include="GTA\SelectedIndexChangedArgs.cs" />
-    <Compile Include="GTA\UIContainer.cs" />
-    <Compile Include="GTA\UIElement.cs" />
-    <Compile Include="GTA\UIRectangle.cs" />
-    <Compile Include="GTA\UISprite.cs" />
-    <Compile Include="GTA\UIText.cs" />
-    <Compile Include="GTA\Viewport.cs" />
-    <Compile Include="GTA\Weapons\DlcWeaponData.cs" />
-    <Compile Include="GTA\Weapons\Weapon.cs" />
-    <Compile Include="GTA\Weapons\WeaponAsset.cs" />
-    <Compile Include="GTA\Weapons\WeaponCollection.cs" />
-    <Compile Include="GTA\Weapons\WeaponGroup.cs" />
-    <Compile Include="GTA\Weapons\WeaponTint.cs" />
-    <Compile Include="GTA\Weather.cs" />
-    <Compile Include="GTA\WindowTitle.cs" />
-    <Compile Include="GTA\World.cs" />
-    <Compile Include="GTA\ZoneID.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <CppCompile Include="GTA\UI.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="Properties\AssemblyInfo.rc" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="GTA\HudComponent.h" />
-    <None Include="GTA\Notification.h" />
-    <None Include="GTA\UI.h" />
-  </ItemGroup>
-  <!-- Import Cpp targets -->
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.WindowsSDK.props" Condition="Exists('$(VCTargetsPath)\Microsoft.Cpp.WindowsSDK.props')" />
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Common.props" />
-  <!-- Import CSharp targets-->
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- Overwrite core build logic to support a mixed C++/CLI and C# code base -->
-  <UsingTask TaskName="CL" AssemblyFile="$(VCTargetsPath)\Microsoft.Build.CppTasks.Common.dll" />
-  <UsingTask TaskName="RC" AssemblyFile="$(VCTargetsPath)\Microsoft.Build.CppTasks.Common.dll" />
-  <UsingTask TaskName="Link" AssemblyFile="$(VCTargetsPath)\Microsoft.Build.CppTasks.Common.dll" />
-  <Target
-    Name="CoreCompile"
-    Inputs="@(Compile);@(CppCompile);$(ReferencePathWithRefAssemblies)"
-    Outputs="@(IntermediateAssembly);$(IntermediateOutputPath)$(TargetName).cpp.netmodule;$(IntermediateOutputPath)$(TargetName).csharp.netmodule"
-    DependsOnTargets="$(CoreCompileDependsOn)">
-    <!-- Keep track of the generated intermediate files so that they are properly cleaned on rebuilds -->
-    <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)$(TargetName).cpp.netmodule;" />
-      <FileWrites Include="$(IntermediateOutputPath)$(TargetName).csharp.netmodule" />
-    </ItemGroup>
-    <PropertyGroup>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <GenerateDebugInformation Condition="'$(DebugType)' == 'none'">false</GenerateDebugInformation>
-      <GenerateDebugInformation Condition="'$(DebugType)' == 'full'">DebugFull</GenerateDebugInformation>
-    </PropertyGroup>
-    <!-- First build all C++/CLI files -->
-    <CL
-      Sources="@(CppCompile)"
-      AdditionalUsingDirectories="$(TargetFrameworkDirectory);$(OutputPath)"
-      CompileAsManaged="true"
-      ForcedUsingFiles="@(ReferencePathWithRefAssemblies);ScriptHookVDotNet.asi"
-      ObjectFileName="$(IntermediateOutputPath)$(TargetName).cpp.netmodule"
-      SuppressStartupBanner="true"
-      ToolExe="cl.exe"
-      ToolPath="$(VCToolsInstallDir)bin\HostX64\x64" />
-    <!-- After that build all the C# files -->
-    <CSC
-      Sources="@(Compile)"
-      AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
-      BaseAddress="$(BaseAddress)"
-      DebugType="$(DebugType)"
-      DefineConstants="$(DefineConstants)"
-      DisabledWarnings="$(NoWarn)"
-      DocumentationFile="@(DocFileItem)"
-      EmitDebugInformation="$(DebugSymbols)"
-      EnvironmentVariables="$(CscEnvironment)"
-      FileAlignment="$(FileAlignment)"
-      HighEntropyVA="$(HighEntropyVA)"
-      LangVersion="$(LangVersion)"
-      NoStandardLib="$(NoCompilerStandardLib)"
-      Optimize="$(Optimize)"
-      OutputAssembly="$(IntermediateOutputPath)$(TargetName).csharp.netmodule"
-      PdbFile="$(PdbFile)"
-      References="@(ReferencePathWithRefAssemblies)"
-      TargetType="Module"
-      Utf8Output="$(Utf8Output)"
-      WarningLevel="$(WarningLevel)"
-      WarningsAsErrors="$(WarningsAsErrors)"
-      WarningsNotAsErrors="$(WarningsNotAsErrors)"
-      ToolExe="$(CscToolExe)"
-      ToolPath="$(CscToolPath)" />
-    <!-- Compile version resource -->
-    <RC
-      Source="@(ResourceCompile)"
-      ResourceOutputFileName="$(IntermediateOutputPath)$(TargetName).res"
-      SuppressStartupBanner="true"
-      ToolExe="rc.exe"
-      ToolPath="$(WindowsSdkDir)bin\$(WindowsTargetPlatformVersion)\x64" />
-    <!-- Finally link the two modules together into a single assembly -->
-    <Link
-      Sources="$(IntermediateOutputPath)$(TargetName).*.netmodule;$(IntermediateOutputPath)$(TargetName).res"
-      AdditionalLibraryDirectories="$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(OutputPath)"
-      GenerateDebugInformation="$(GenerateDebugInformation)"
-      LinkDLL="true"
-      LinkTimeCodeGeneration="UseLinkTimeCodeGeneration"
-      OutputFile="@(IntermediateAssembly)"
-      RandomizedBaseAddress="$(HighEntropyVA)"
-      SuppressStartupBanner="true"
-      TargetMachine="Machine$(PlatformTarget)"
-      ToolExe="link.exe"
-      ToolPath="$(VCToolsInstallDir)bin\HostX64\x64" />
-  </Target>
+	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+	<PropertyGroup>
+		<Platform>AnyCPU</Platform>
+		<Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+		<ProjectGuid>{019193A7-50C0-444A-84CA-777595E702CD}</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>GTA</RootNamespace>
+		<AssemblyName>ScriptHookVDotNet2</AssemblyName>
+		<TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+		<FileAlignment>512</FileAlignment>
+		<WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+		<OutputPath>..\..\bin\Debug\</OutputPath>
+		<BaseIntermediateOutputPath>..\..\intermediate\ScriptHookVDotNet2\</BaseIntermediateOutputPath>
+		<DocumentationFile>..\..\bin\Debug\ScriptHookVDotNet2.xml</DocumentationFile>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<Optimize>false</Optimize>
+		<NoWarn>1591</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<LangVersion>latest</LangVersion>
+		<ErrorReport>prompt</ErrorReport>
+		<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+		<OutputPath>..\..\bin\Release\</OutputPath>
+		<BaseIntermediateOutputPath>..\..\intermediate\ScriptHookVDotNet2\</BaseIntermediateOutputPath>
+		<DocumentationFile>..\..\bin\Release\ScriptHookVDotNet2.xml</DocumentationFile>
+		<DefineConstants>TRACE</DefineConstants>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<Optimize>true</Optimize>
+		<NoWarn>1591</NoWarn>
+		<DebugType>none</DebugType>
+		<LangVersion>latest</LangVersion>
+		<ErrorReport>prompt</ErrorReport>
+		<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="System" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Windows.Forms" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\ScriptHookVDotNet.vcxproj">
+			<Name>ScriptHookVDotNet</Name>
+			<Project>{b2933d8f-f922-40bd-bb70-18622a81ab8f}</Project>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<!-- Add custom Build Action to Visual Studio Properties -->
+		<AvailableItemName Include="CppCompile">
+			<Targets>CppCompile</Targets>
+		</AvailableItemName>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="GTA.Math\Matrix.cs" />
+		<Compile Include="GTA.Math\Quaternion.cs" />
+		<Compile Include="GTA.Math\Vector2.cs" />
+		<Compile Include="GTA.Math\Vector3.cs" />
+		<Compile Include="GTA.Native\Native.cs" />
+		<Compile Include="GTA.Native\NativeHashes.cs" />
+		<Compile Include="GTA.Native\PedHash.cs" />
+		<Compile Include="GTA.Native\VehicleHash.cs" />
+		<Compile Include="GTA.Native\WeaponComponent.cs" />
+		<Compile Include="GTA.Native\WeaponHash.cs" />
+		<Compile Include="GTA.NaturalMotion\Euphoria.cs" />
+		<Compile Include="GTA.NaturalMotion\EuphoriaBase.cs" />
+		<Compile Include="GTA.NaturalMotion\EuphoriaHelpers.cs" />
+		<Compile Include="GTA\Audio.cs" />
+		<Compile Include="GTA\AudioFlag.cs" />
+		<Compile Include="GTA\Blip.cs" />
+		<Compile Include="GTA\BlipColor.cs" />
+		<Compile Include="GTA\BlipSprite.cs" />
+		<Compile Include="GTA\Camera.cs" />
+		<Compile Include="GTA\CameraShake.cs" />
+		<Compile Include="GTA\Control.cs" />
+		<Compile Include="GTA\Entities\Entity.cs" />
+		<Compile Include="GTA\Entities\Model.cs" />
+		<Compile Include="GTA\Entities\Peds\AnimationFlags.cs" />
+		<Compile Include="GTA\Entities\Peds\Bone.cs" />
+		<Compile Include="GTA\Entities\Peds\DrivingStyle.cs" />
+		<Compile Include="GTA\Entities\Peds\FiringPattern.cs" />
+		<Compile Include="GTA\Entities\Peds\FormationType.cs" />
+		<Compile Include="GTA\Entities\Peds\Gender.cs" />
+		<Compile Include="GTA\Entities\Peds\HelmetType.cs" />
+		<Compile Include="GTA\Entities\Peds\LeaveVehicleFlags.cs" />
+		<Compile Include="GTA\Entities\Peds\Ped.cs" />
+		<Compile Include="GTA\Entities\Peds\PedGroup.cs" />
+		<Compile Include="GTA\Entities\Peds\Relationship.cs" />
+		<Compile Include="GTA\Entities\Peds\Tasks.cs" />
+		<Compile Include="GTA\Entities\Peds\TaskSequence.cs" />
+		<Compile Include="GTA\Entities\Prop.cs" />
+		<Compile Include="GTA\Entities\Vehicles\CargobobHook.cs" />
+		<Compile Include="GTA\Entities\Vehicles\NumberPlateMounting.cs" />
+		<Compile Include="GTA\Entities\Vehicles\NumberPlateType.cs" />
+		<Compile Include="GTA\Entities\Vehicles\Vehicle.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleClass.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleColor.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleDoor.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleLandingGear.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleLockStatus.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleMod.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleNeonLight.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleRoofState.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleSeat.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleToggleMod.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWheelType.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWindow.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWindowTint.cs" />
+		<Compile Include="GTA\ExplosionType.cs" />
+		<Compile Include="GTA\Font.cs" />
+		<Compile Include="GTA\ForceType.cs" />
+		<Compile Include="GTA\Game.cs" />
+		<Compile Include="GTA\GameplayCamera.cs" />
+		<Compile Include="GTA\GameVersion.cs" />
+		<Compile Include="GTA\Global.cs" />
+		<Compile Include="GTA\GlobalCollection.cs" />
+		<Compile Include="GTA\Handleable.cs" />
+		<Compile Include="GTA\InputMode.cs" />
+		<Compile Include="GTA\IntersectOptions.cs" />
+		<Compile Include="GTA\Language.cs" />
+		<Compile Include="GTA\MarkerType.cs" />
+		<Compile Include="GTA\Menu.cs" />
+		<Compile Include="GTA\MenuBase.cs" />
+		<Compile Include="GTA\MenuButton.cs" />
+		<Compile Include="GTA\MenuEnumScroller.cs" />
+		<Compile Include="GTA\MenuItem.cs" />
+		<Compile Include="GTA\MenuItemDoubleValueArgs.cs" />
+		<Compile Include="GTA\MenuItemIndexArgs.cs" />
+		<Compile Include="GTA\MenuLabel.cs" />
+		<Compile Include="GTA\MenuNumericScroller.cs" />
+		<Compile Include="GTA\MenuToggle.cs" />
+		<Compile Include="GTA\MessageBox.cs" />
+		<Compile Include="GTA\ParachuteTint.cs" />
+		<Compile Include="GTA\Pickup.cs" />
+		<Compile Include="GTA\PickupType.cs" />
+		<Compile Include="GTA\Player.cs" />
+		<Compile Include="GTA\RadioStation.cs" />
+		<Compile Include="GTA\RaycastResult.cs" />
+		<Compile Include="GTA\RequireScript.cs" />
+		<Compile Include="GTA\Rope.cs" />
+		<Compile Include="GTA\RopeType.cs" />
+		<Compile Include="GTA\Scaleform.cs" />
+		<Compile Include="GTA\ScaleformArgumentTXD.cs" />
+		<Compile Include="GTA\Script.cs" />
+		<Compile Include="GTA\ScriptSettings.cs" />
+		<Compile Include="GTA\SelectedIndexChangedArgs.cs" />
+		<Compile Include="GTA\UIContainer.cs" />
+		<Compile Include="GTA\UIElement.cs" />
+		<Compile Include="GTA\UIRectangle.cs" />
+		<Compile Include="GTA\UISprite.cs" />
+		<Compile Include="GTA\UIText.cs" />
+		<Compile Include="GTA\Viewport.cs" />
+		<Compile Include="GTA\Weapons\DlcWeaponData.cs" />
+		<Compile Include="GTA\Weapons\Weapon.cs" />
+		<Compile Include="GTA\Weapons\WeaponAsset.cs" />
+		<Compile Include="GTA\Weapons\WeaponCollection.cs" />
+		<Compile Include="GTA\Weapons\WeaponGroup.cs" />
+		<Compile Include="GTA\Weapons\WeaponTint.cs" />
+		<Compile Include="GTA\Weather.cs" />
+		<Compile Include="GTA\WindowTitle.cs" />
+		<Compile Include="GTA\World.cs" />
+		<Compile Include="GTA\ZoneID.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<CppCompile Include="GTA\UI.cpp" />
+	</ItemGroup>
+	<ItemGroup>
+		<ResourceCompile Include="Properties\AssemblyInfo.rc" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="GTA\HudComponent.h" />
+		<None Include="GTA\Notification.h" />
+		<None Include="GTA\UI.h" />
+	</ItemGroup>
+	<!-- Import Cpp targets -->
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.WindowsSDK.props" Condition="Exists('$(VCTargetsPath)\Microsoft.Cpp.WindowsSDK.props')" />
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Common.props" />
+	<!-- Import CSharp targets-->
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+	<!-- Overwrite core build logic to support a mixed C++/CLI and C# code base -->
+	<UsingTask TaskName="CL" AssemblyFile="$(VCTargetsPath)\Microsoft.Build.CppTasks.Common.dll" />
+	<UsingTask TaskName="RC" AssemblyFile="$(VCTargetsPath)\Microsoft.Build.CppTasks.Common.dll" />
+	<UsingTask TaskName="Link" AssemblyFile="$(VCTargetsPath)\Microsoft.Build.CppTasks.Common.dll" />
+	<Target Name="CoreCompile" Inputs="@(Compile);@(CppCompile);$(ReferencePathWithRefAssemblies)" Outputs="@(IntermediateAssembly);$(IntermediateOutputPath)$(TargetName).cpp.netmodule;$(IntermediateOutputPath)$(TargetName).csharp.netmodule" DependsOnTargets="$(CoreCompileDependsOn)">
+		<!-- Keep track of the generated intermediate files so that they are properly cleaned on rebuilds -->
+		<ItemGroup>
+			<FileWrites Include="$(IntermediateOutputPath)$(TargetName).cpp.netmodule;" />
+			<FileWrites Include="$(IntermediateOutputPath)$(TargetName).csharp.netmodule" />
+		</ItemGroup>
+		<PropertyGroup>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<GenerateDebugInformation Condition="'$(DebugType)' == 'none'">false</GenerateDebugInformation>
+			<GenerateDebugInformation Condition="'$(DebugType)' == 'full'">DebugFull</GenerateDebugInformation>
+		</PropertyGroup>
+		<!-- First build all C++/CLI files -->
+		<CL Sources="@(CppCompile)" AdditionalUsingDirectories="$(TargetFrameworkDirectory);$(OutputPath)" CompileAsManaged="true" ForcedUsingFiles="@(ReferencePathWithRefAssemblies);ScriptHookVDotNet.asi" ObjectFileName="$(IntermediateOutputPath)$(TargetName).cpp.netmodule" SuppressStartupBanner="true" ToolExe="cl.exe" ToolPath="$(VCToolsInstallDir)bin\HostX64\x64" />
+		<!-- After that build all the C# files -->
+		<CSC Sources="@(Compile)" AllowUnsafeBlocks="$(AllowUnsafeBlocks)" BaseAddress="$(BaseAddress)" DebugType="$(DebugType)" DefineConstants="$(DefineConstants)" DisabledWarnings="$(NoWarn)" DocumentationFile="@(DocFileItem)" EmitDebugInformation="$(DebugSymbols)" EnvironmentVariables="$(CscEnvironment)" FileAlignment="$(FileAlignment)" HighEntropyVA="$(HighEntropyVA)" LangVersion="$(LangVersion)" NoStandardLib="$(NoCompilerStandardLib)" Optimize="$(Optimize)" OutputAssembly="$(IntermediateOutputPath)$(TargetName).csharp.netmodule" PdbFile="$(PdbFile)" References="@(ReferencePathWithRefAssemblies)" TargetType="Module" Utf8Output="$(Utf8Output)" WarningLevel="$(WarningLevel)" WarningsAsErrors="$(WarningsAsErrors)" WarningsNotAsErrors="$(WarningsNotAsErrors)" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" />
+		<!-- Compile version resource -->
+		<RC Source="@(ResourceCompile)" ResourceOutputFileName="$(IntermediateOutputPath)$(TargetName).res" SuppressStartupBanner="true" ToolExe="rc.exe" ToolPath="$(WindowsSdkDir)bin\$(WindowsTargetPlatformVersion)\x64" />
+		<!-- Finally link the two modules together into a single assembly -->
+		<Link Sources="$(IntermediateOutputPath)$(TargetName).*.netmodule;$(IntermediateOutputPath)$(TargetName).res" AdditionalLibraryDirectories="$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(OutputPath)" GenerateDebugInformation="$(GenerateDebugInformation)" LinkDLL="true" LinkTimeCodeGeneration="UseLinkTimeCodeGeneration" OutputFile="@(IntermediateAssembly)" RandomizedBaseAddress="$(HighEntropyVA)" SuppressStartupBanner="true" TargetMachine="Machinex64" ToolExe="link.exe" ToolPath="$(VCToolsInstallDir)bin\HostX64\x64" />
+	</Target>
 </Project>

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -61,6 +61,16 @@ namespace GTA
 		public bool HasDonkHydraulics => Game.Version >= GameVersion.v1_0_505_2_Steam && SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, NativeMemory.VehicleFlag2.HasLowriderDonkHydraulics);
 		public bool HasParachute => Game.Version >= GameVersion.v1_0_505_2_Steam && Function.Call<bool>(Hash._GET_VEHICLE_HAS_PARACHUTE, Handle);
 		public bool HasRocketBoost => Game.Version >= GameVersion.v1_0_944_2_Steam && Function.Call<bool>(Hash._GET_HAS_ROCKET_BOOST, Handle);
+		public bool IsRocketBoostActive
+		{
+			get => Function.Call<bool>((Hash)0x3D34E80EED4AE3BE, Handle);
+			set => Function.Call((Hash)0x81E1552E35DC3839, Handle, value);
+		}
+		public bool IsParachuteActive
+		{
+			get => Function.Call<bool>((Hash)0x3DE51E9C80B116CF, Handle);
+			set => Function.Call((Hash)0x0BFFB028B3DD0A97, Handle, value);
+		}
 
 
 		public float DirtLevel

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -1396,6 +1396,11 @@ namespace GTA
 		/// </value>
 		public bool IsLeftIndicatorLightOn
 		{
+			get => NativeMemory.ReadByte(MemoryAddress + NativeMemory.IsInteriorLightOnOffset) switch
+			{
+				1 or 3 => true,
+				_ => false
+			};
 			set => Function.Call(Hash.SET_VEHICLE_INDICATOR_LIGHTS, Handle, true, value);
 		}
 
@@ -1407,6 +1412,11 @@ namespace GTA
 		/// </value>
 		public bool IsRightIndicatorLightOn
 		{
+			get => NativeMemory.ReadByte(MemoryAddress + NativeMemory.IsInteriorLightOnOffset) switch
+			{
+				2 or 3 => true,
+				_ => false
+			};
 			set => Function.Call(Hash.SET_VEHICLE_INDICATOR_LIGHTS, Handle, false, value);
 		}
 

--- a/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
+++ b/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
@@ -1,218 +1,216 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">x64</Platform>
-    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
-    <ProjectGuid>{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>GTA</RootNamespace>
-    <AssemblyName>ScriptHookVDotNet3</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <OutputPath>..\..\bin\Debug\</OutputPath>
-    <BaseIntermediateOutputPath>..\..\intermediate\ScriptHookVDotNet3\</BaseIntermediateOutputPath>
-    <DocumentationFile>..\..\bin\Debug\ScriptHookVDotNet3.xml</DocumentationFile>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>false</Optimize>
-    <NoWarn>1591</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>latest</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>..\..\bin\Release\</OutputPath>
-    <BaseIntermediateOutputPath>..\..\intermediate\ScriptHookVDotNet3\</BaseIntermediateOutputPath>
-    <DocumentationFile>..\..\bin\Release\ScriptHookVDotNet3.xml</DocumentationFile>
-    <DefineConstants>TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <NoWarn>1591</NoWarn>
-    <DebugType>none</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>latest</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\ScriptHookVDotNet.vcxproj">
-      <Name>ScriptHookVDotNet</Name>
-      <Project>{b2933d8f-f922-40bd-bb70-18622a81ab8f}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="GTA.Math\Matrix.cs" />
-    <Compile Include="GTA.Math\Quaternion.cs" />
-    <Compile Include="GTA.Math\Vector2.cs" />
-    <Compile Include="GTA.Math\Vector3.cs" />
-    <Compile Include="GTA.Native\Native.cs" />
-    <Compile Include="GTA.Native\NativeHashes.cs" />
-    <Compile Include="GTA.NaturalMotion\Euphoria.cs" />
-    <Compile Include="GTA.NaturalMotion\EuphoriaBase.cs" />
-    <Compile Include="GTA.NaturalMotion\EuphoriaHelpers.cs" />
-    <Compile Include="GTA.UI\Alignment.cs" />
-    <Compile Include="GTA.UI\ContainerElement.cs" />
-    <Compile Include="GTA.UI\CursorSprite.cs" />
-    <Compile Include="GTA.UI\CustomSprite.cs" />
-    <Compile Include="GTA.UI\Font.cs" />
-    <Compile Include="GTA.UI\Hud.cs" />
-    <Compile Include="GTA.UI\HudComponent.cs" />
-    <Compile Include="GTA.UI\IElement.cs" />
-    <Compile Include="GTA.UI\ISpriteElement.cs" />
-    <Compile Include="GTA.UI\LoadingPrompt.cs" />
-    <Compile Include="GTA.UI\LoadingSpinnerType.cs" />
-    <Compile Include="GTA.UI\Notification.cs" />
-    <Compile Include="GTA.UI\NotificationIcon.cs" />
-    <Compile Include="GTA.UI\Screen.cs" />
-    <Compile Include="GTA.UI\ScreenEffects.cs" />
-    <Compile Include="GTA.UI\Sprite.cs" />
-    <Compile Include="GTA.UI\TextElement.cs" />
-    <Compile Include="GTA\Audio.cs" />
-    <Compile Include="GTA\AudioFlags.cs" />
-    <Compile Include="GTA\Blip.cs" />
-    <Compile Include="GTA\BlipCategoryType.cs" />
-    <Compile Include="GTA\BlipColor.cs" />
-    <Compile Include="GTA\BlipDisplayType.cs" />
-    <Compile Include="GTA\BlipSprite.cs" />
-    <Compile Include="GTA\Button.cs" />
-    <Compile Include="GTA\Camera.cs" />
-    <Compile Include="GTA\CameraShake.cs" />
-    <Compile Include="GTA\Checkpoint.cs" />
-    <Compile Include="GTA\CheckpointCustomIcon.cs" />
-    <Compile Include="GTA\CheckpointCustomIconStyle.cs" />
-    <Compile Include="GTA\CheckpointIcon.cs" />
-    <Compile Include="GTA\Entities\AnimatedBuilding.cs" />
-    <Compile Include="GTA\Entities\InteriorInstance.cs" />
-    <Compile Include="GTA\Entities\EntityPopulationType.cs" />
-    <Compile Include="GTA\Entities\Building.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleType.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWheelBoneId.cs" />
-    <Compile Include="GTA\DrawBoxFlags.cs" />
-    <Compile Include="GTA\PlayerTargetingMode.cs" />
-    <Compile Include="GTA\Control.cs" />
-    <Compile Include="GTA\Entities\Entity.cs" />
-    <Compile Include="GTA\Entities\EntityBone.cs" />
-    <Compile Include="GTA\Entities\EntityBoneCollection.cs" />
-    <Compile Include="GTA\Entities\EntityDamageRecord.cs" />
-    <Compile Include="GTA\Entities\EntityType.cs" />
-    <Compile Include="GTA\Entities\Model.cs" />
-    <Compile Include="GTA\Entities\Peds\AnimationFlags.cs" />
-    <Compile Include="GTA\Entities\Peds\Bone.cs" />
-    <Compile Include="GTA\Entities\Peds\DrivingStyle.cs" />
-    <Compile Include="GTA\Entities\Peds\EnterVehicleFlags.cs" />
-    <Compile Include="GTA\Entities\Peds\FiringPattern.cs" />
-    <Compile Include="GTA\Entities\Peds\Formation.cs" />
-    <Compile Include="GTA\Entities\Peds\Gender.cs" />
-    <Compile Include="GTA\Entities\Peds\Helmet.cs" />
-    <Compile Include="GTA\Entities\Peds\LeaveVehicleFlags.cs" />
-    <Compile Include="GTA\Entities\Peds\ParachuteLandingType.cs" />
-    <Compile Include="GTA\Entities\Peds\ParachuteState.cs" />
-    <Compile Include="GTA\Entities\Peds\Ped.cs" />
-    <Compile Include="GTA\Entities\Peds\PedBone.cs" />
-    <Compile Include="GTA\Entities\Peds\PedBoneCollection.cs" />
-    <Compile Include="GTA\Entities\Peds\PedComponent.cs" />
-    <Compile Include="GTA\Entities\Peds\PedComponentType.cs" />
-    <Compile Include="GTA\Entities\Peds\PedGroup.cs" />
-    <Compile Include="GTA\Entities\Peds\PedHash.cs" />
-    <Compile Include="GTA\Entities\Peds\PedProp.cs" />
-    <Compile Include="GTA\Entities\Peds\PedPropType.cs" />
-    <Compile Include="GTA\Entities\Peds\IPedVariation.cs" />
-    <Compile Include="GTA\Entities\Peds\RagdollType.cs" />
-    <Compile Include="GTA\Entities\Peds\Relationship.cs" />
-    <Compile Include="GTA\Entities\Peds\RelationshipGroup.cs" />
-    <Compile Include="GTA\Entities\Peds\SpeechModifier.cs" />
-    <Compile Include="GTA\Entities\Peds\Style.cs" />
-    <Compile Include="GTA\Entities\Peds\TaskInvoker.cs" />
-    <Compile Include="GTA\Entities\Peds\TaskSequence.cs" />
-    <Compile Include="GTA\Entities\Peds\VehicleDrivingFlags.cs" />
-    <Compile Include="GTA\Entities\Projectile.cs" />
-    <Compile Include="GTA\Entities\Prop.cs" />
-    <Compile Include="GTA\Entities\Vehicles\CargobobHook.cs" />
-    <Compile Include="GTA\Entities\Vehicles\HandlingData.cs" />
-    <Compile Include="GTA\Entities\Vehicles\LicensePlateStyle.cs" />
-    <Compile Include="GTA\Entities\Vehicles\LicensePlateType.cs" />
-    <Compile Include="GTA\Entities\Vehicles\Vehicle.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleClass.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleColor.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleDoor.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleDoorCollection.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleDoorIndex.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleHash.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleLandingGearState.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleLockStatus.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleMod.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleModCollection.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleModType.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleNeonLight.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleRoofState.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleSeat.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleToggleMod.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleToggleModType.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWheel.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWheelCollection.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWheelType.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWindow.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWindowCollection.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWindowIndex.cs" />
-    <Compile Include="GTA\Entities\Vehicles\VehicleWindowTint.cs" />
-    <Compile Include="GTA\ExplosionType.cs" />
-    <Compile Include="GTA\ForceType.cs" />
-    <Compile Include="GTA\Game.cs" />
-    <Compile Include="GTA\GameplayCamera.cs" />
-    <Compile Include="GTA\GameVersion.cs" />
-    <Compile Include="GTA\InputMethod.cs" />
-    <Compile Include="GTA\IntersectFlags.cs" />
-    <Compile Include="GTA\InvertAxisFlags.cs" />
-    <Compile Include="GTA\Language.cs" />
-    <Compile Include="GTA\MarkerType.cs" />
-    <Compile Include="GTA\MaterialHash.cs" />
-    <Compile Include="GTA\MeasurementSystem.cs" />
-    <Compile Include="GTA\ParachuteTint.cs" />
-    <Compile Include="GTA\Particles\ParticleEffect.cs" />
-    <Compile Include="GTA\Particles\ParticleEffectAsset.cs" />
-    <Compile Include="GTA\Pickup.cs" />
-    <Compile Include="GTA\PickupType.cs" />
-    <Compile Include="GTA\Player.cs" />
-    <Compile Include="GTA\PoolObject.cs" />
-    <Compile Include="GTA\InteriorProxy.cs" />
-    <Compile Include="GTA\RadioStation.cs" />
-    <Compile Include="GTA\Entities\EntityDamageRecordCollection.cs" />
-    <Compile Include="GTA\RaycastResult.cs" />
-    <Compile Include="GTA\GameVersionNotSupportedException.cs" />
-    <Compile Include="GTA\RequireScript.cs" />
-    <Compile Include="GTA\Rope.cs" />
-    <Compile Include="GTA\RopeType.cs" />
-    <Compile Include="GTA\Scaleform.cs" />
-    <Compile Include="GTA\ScaleformArgumentTXD.cs" />
-    <Compile Include="GTA\Script.cs" />
-    <Compile Include="GTA\ScriptAttributes.cs" />
-    <Compile Include="GTA\ScriptSettings.cs" />
-    <Compile Include="GTA\Weapons\WeaponAttachmentPoint.cs" />
-    <Compile Include="GTA\Weapons\DlcWeaponData.cs" />
-    <Compile Include="GTA\Weapons\Weapon.cs" />
-    <Compile Include="GTA\Weapons\WeaponAsset.cs" />
-    <Compile Include="GTA\Weapons\WeaponCollection.cs" />
-    <Compile Include="GTA\Weapons\WeaponComponent.cs" />
-    <Compile Include="GTA\Weapons\WeaponComponentCollection.cs" />
-    <Compile Include="GTA\Weapons\WeaponComponentHash.cs" />
-    <Compile Include="GTA\Weapons\WeaponGroup.cs" />
-    <Compile Include="GTA\Weapons\WeaponHash.cs" />
-    <Compile Include="GTA\Weapons\WeaponTint.cs" />
-    <Compile Include="GTA\Weather.cs" />
-    <Compile Include="GTA\WindowTitle.cs" />
-    <Compile Include="GTA\World.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+	<PropertyGroup>
+		<Platform>AnyCPU</Platform>
+		<Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+		<ProjectGuid>{D68E6CB7-FC70-41C9-BD53-D79552B37F0E}</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>GTA</RootNamespace>
+		<AssemblyName>ScriptHookVDotNet3</AssemblyName>
+		<TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+		<FileAlignment>512</FileAlignment>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+		<OutputPath>..\..\bin\Debug\</OutputPath>
+		<BaseIntermediateOutputPath>..\..\intermediate\ScriptHookVDotNet3\</BaseIntermediateOutputPath>
+		<DocumentationFile>..\..\bin\Debug\ScriptHookVDotNet3.xml</DocumentationFile>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<Optimize>false</Optimize>
+		<NoWarn>1591</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<LangVersion>latest</LangVersion>
+		<ErrorReport>prompt</ErrorReport>
+		<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+		<OutputPath>..\..\bin\Release\</OutputPath>
+		<BaseIntermediateOutputPath>..\..\intermediate\ScriptHookVDotNet3\</BaseIntermediateOutputPath>
+		<DocumentationFile>..\..\bin\Release\ScriptHookVDotNet3.xml</DocumentationFile>
+		<DefineConstants>TRACE</DefineConstants>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<Optimize>true</Optimize>
+		<NoWarn>1591</NoWarn>
+		<DebugType>none</DebugType>
+		<LangVersion>latest</LangVersion>
+		<ErrorReport>prompt</ErrorReport>
+		<CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="System" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Windows.Forms" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\ScriptHookVDotNet.vcxproj">
+			<Name>ScriptHookVDotNet</Name>
+			<Project>{b2933d8f-f922-40bd-bb70-18622a81ab8f}</Project>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="GTA.Math\Matrix.cs" />
+		<Compile Include="GTA.Math\Quaternion.cs" />
+		<Compile Include="GTA.Math\Vector2.cs" />
+		<Compile Include="GTA.Math\Vector3.cs" />
+		<Compile Include="GTA.Native\Native.cs" />
+		<Compile Include="GTA.Native\NativeHashes.cs" />
+		<Compile Include="GTA.NaturalMotion\Euphoria.cs" />
+		<Compile Include="GTA.NaturalMotion\EuphoriaBase.cs" />
+		<Compile Include="GTA.NaturalMotion\EuphoriaHelpers.cs" />
+		<Compile Include="GTA.UI\Alignment.cs" />
+		<Compile Include="GTA.UI\ContainerElement.cs" />
+		<Compile Include="GTA.UI\CursorSprite.cs" />
+		<Compile Include="GTA.UI\CustomSprite.cs" />
+		<Compile Include="GTA.UI\Font.cs" />
+		<Compile Include="GTA.UI\Hud.cs" />
+		<Compile Include="GTA.UI\HudComponent.cs" />
+		<Compile Include="GTA.UI\IElement.cs" />
+		<Compile Include="GTA.UI\ISpriteElement.cs" />
+		<Compile Include="GTA.UI\LoadingPrompt.cs" />
+		<Compile Include="GTA.UI\LoadingSpinnerType.cs" />
+		<Compile Include="GTA.UI\Notification.cs" />
+		<Compile Include="GTA.UI\NotificationIcon.cs" />
+		<Compile Include="GTA.UI\Screen.cs" />
+		<Compile Include="GTA.UI\ScreenEffects.cs" />
+		<Compile Include="GTA.UI\Sprite.cs" />
+		<Compile Include="GTA.UI\TextElement.cs" />
+		<Compile Include="GTA\Audio.cs" />
+		<Compile Include="GTA\AudioFlags.cs" />
+		<Compile Include="GTA\Blip.cs" />
+		<Compile Include="GTA\BlipCategoryType.cs" />
+		<Compile Include="GTA\BlipColor.cs" />
+		<Compile Include="GTA\BlipDisplayType.cs" />
+		<Compile Include="GTA\BlipSprite.cs" />
+		<Compile Include="GTA\Button.cs" />
+		<Compile Include="GTA\Camera.cs" />
+		<Compile Include="GTA\CameraShake.cs" />
+		<Compile Include="GTA\Checkpoint.cs" />
+		<Compile Include="GTA\CheckpointCustomIcon.cs" />
+		<Compile Include="GTA\CheckpointCustomIconStyle.cs" />
+		<Compile Include="GTA\CheckpointIcon.cs" />
+		<Compile Include="GTA\Entities\AnimatedBuilding.cs" />
+		<Compile Include="GTA\Entities\InteriorInstance.cs" />
+		<Compile Include="GTA\Entities\EntityPopulationType.cs" />
+		<Compile Include="GTA\Entities\Building.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleType.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWheelBoneId.cs" />
+		<Compile Include="GTA\DrawBoxFlags.cs" />
+		<Compile Include="GTA\PlayerTargetingMode.cs" />
+		<Compile Include="GTA\Control.cs" />
+		<Compile Include="GTA\Entities\Entity.cs" />
+		<Compile Include="GTA\Entities\EntityBone.cs" />
+		<Compile Include="GTA\Entities\EntityBoneCollection.cs" />
+		<Compile Include="GTA\Entities\EntityDamageRecord.cs" />
+		<Compile Include="GTA\Entities\EntityType.cs" />
+		<Compile Include="GTA\Entities\Model.cs" />
+		<Compile Include="GTA\Entities\Peds\AnimationFlags.cs" />
+		<Compile Include="GTA\Entities\Peds\Bone.cs" />
+		<Compile Include="GTA\Entities\Peds\DrivingStyle.cs" />
+		<Compile Include="GTA\Entities\Peds\EnterVehicleFlags.cs" />
+		<Compile Include="GTA\Entities\Peds\FiringPattern.cs" />
+		<Compile Include="GTA\Entities\Peds\Formation.cs" />
+		<Compile Include="GTA\Entities\Peds\Gender.cs" />
+		<Compile Include="GTA\Entities\Peds\Helmet.cs" />
+		<Compile Include="GTA\Entities\Peds\LeaveVehicleFlags.cs" />
+		<Compile Include="GTA\Entities\Peds\ParachuteLandingType.cs" />
+		<Compile Include="GTA\Entities\Peds\ParachuteState.cs" />
+		<Compile Include="GTA\Entities\Peds\Ped.cs" />
+		<Compile Include="GTA\Entities\Peds\PedBone.cs" />
+		<Compile Include="GTA\Entities\Peds\PedBoneCollection.cs" />
+		<Compile Include="GTA\Entities\Peds\PedComponent.cs" />
+		<Compile Include="GTA\Entities\Peds\PedComponentType.cs" />
+		<Compile Include="GTA\Entities\Peds\PedGroup.cs" />
+		<Compile Include="GTA\Entities\Peds\PedHash.cs" />
+		<Compile Include="GTA\Entities\Peds\PedProp.cs" />
+		<Compile Include="GTA\Entities\Peds\PedPropType.cs" />
+		<Compile Include="GTA\Entities\Peds\IPedVariation.cs" />
+		<Compile Include="GTA\Entities\Peds\RagdollType.cs" />
+		<Compile Include="GTA\Entities\Peds\Relationship.cs" />
+		<Compile Include="GTA\Entities\Peds\RelationshipGroup.cs" />
+		<Compile Include="GTA\Entities\Peds\SpeechModifier.cs" />
+		<Compile Include="GTA\Entities\Peds\Style.cs" />
+		<Compile Include="GTA\Entities\Peds\TaskInvoker.cs" />
+		<Compile Include="GTA\Entities\Peds\TaskSequence.cs" />
+		<Compile Include="GTA\Entities\Peds\VehicleDrivingFlags.cs" />
+		<Compile Include="GTA\Entities\Projectile.cs" />
+		<Compile Include="GTA\Entities\Prop.cs" />
+		<Compile Include="GTA\Entities\Vehicles\CargobobHook.cs" />
+		<Compile Include="GTA\Entities\Vehicles\HandlingData.cs" />
+		<Compile Include="GTA\Entities\Vehicles\LicensePlateStyle.cs" />
+		<Compile Include="GTA\Entities\Vehicles\LicensePlateType.cs" />
+		<Compile Include="GTA\Entities\Vehicles\Vehicle.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleClass.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleColor.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleDoor.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleDoorCollection.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleDoorIndex.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleHash.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleLandingGearState.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleLockStatus.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleMod.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleModCollection.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleModType.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleNeonLight.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleRoofState.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleSeat.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleToggleMod.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleToggleModType.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWheel.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWheelCollection.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWheelType.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWindow.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWindowCollection.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWindowIndex.cs" />
+		<Compile Include="GTA\Entities\Vehicles\VehicleWindowTint.cs" />
+		<Compile Include="GTA\ExplosionType.cs" />
+		<Compile Include="GTA\ForceType.cs" />
+		<Compile Include="GTA\Game.cs" />
+		<Compile Include="GTA\GameplayCamera.cs" />
+		<Compile Include="GTA\GameVersion.cs" />
+		<Compile Include="GTA\InputMethod.cs" />
+		<Compile Include="GTA\IntersectFlags.cs" />
+		<Compile Include="GTA\InvertAxisFlags.cs" />
+		<Compile Include="GTA\Language.cs" />
+		<Compile Include="GTA\MarkerType.cs" />
+		<Compile Include="GTA\MaterialHash.cs" />
+		<Compile Include="GTA\MeasurementSystem.cs" />
+		<Compile Include="GTA\ParachuteTint.cs" />
+		<Compile Include="GTA\Particles\ParticleEffect.cs" />
+		<Compile Include="GTA\Particles\ParticleEffectAsset.cs" />
+		<Compile Include="GTA\Pickup.cs" />
+		<Compile Include="GTA\PickupType.cs" />
+		<Compile Include="GTA\Player.cs" />
+		<Compile Include="GTA\PoolObject.cs" />
+		<Compile Include="GTA\InteriorProxy.cs" />
+		<Compile Include="GTA\RadioStation.cs" />
+		<Compile Include="GTA\Entities\EntityDamageRecordCollection.cs" />
+		<Compile Include="GTA\RaycastResult.cs" />
+		<Compile Include="GTA\GameVersionNotSupportedException.cs" />
+		<Compile Include="GTA\RequireScript.cs" />
+		<Compile Include="GTA\Rope.cs" />
+		<Compile Include="GTA\RopeType.cs" />
+		<Compile Include="GTA\Scaleform.cs" />
+		<Compile Include="GTA\ScaleformArgumentTXD.cs" />
+		<Compile Include="GTA\Script.cs" />
+		<Compile Include="GTA\ScriptAttributes.cs" />
+		<Compile Include="GTA\ScriptSettings.cs" />
+		<Compile Include="GTA\Weapons\WeaponAttachmentPoint.cs" />
+		<Compile Include="GTA\Weapons\DlcWeaponData.cs" />
+		<Compile Include="GTA\Weapons\Weapon.cs" />
+		<Compile Include="GTA\Weapons\WeaponAsset.cs" />
+		<Compile Include="GTA\Weapons\WeaponCollection.cs" />
+		<Compile Include="GTA\Weapons\WeaponComponent.cs" />
+		<Compile Include="GTA\Weapons\WeaponComponentCollection.cs" />
+		<Compile Include="GTA\Weapons\WeaponComponentHash.cs" />
+		<Compile Include="GTA\Weapons\WeaponGroup.cs" />
+		<Compile Include="GTA\Weapons\WeaponHash.cs" />
+		<Compile Include="GTA\Weapons\WeaponTint.cs" />
+		<Compile Include="GTA\Weather.cs" />
+		<Compile Include="GTA\WindowTitle.cs" />
+		<Compile Include="GTA\World.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+	</ItemGroup>
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
- Add getter for vehicle indicator
- Add `Vehicle.IsRocketBoostActive` and `Vehicle.IsParachuteActive`
- Change platform of scripting api to AnyCPU
- Add `Tick` and `KeyEvent` to `ScriptDomain` and made `DoTick` and `DoKeyEvent` public, there're two major benifits:
1. Significant performance improvment when calling native in the handler, since it's invoked from main thread.
2. Modders can load another `ScriptDomain` and use the events to [bridge it to the primary one](https://github.com/RAGECOOP/RAGECOOP-V/blob/resource-breaking-changes/RageCoop.Client/Scripting/ResourceDomain.cs)
 
 Waiting and yielding won't be avalible in the handler, but this can be considered as a compromise for #1012, allowing performant native calling while preserving existing scripting functionality.