### PR TITLE
Fix Ped.CanBeKnockedOffBike

### DIFF
--- a/source/scripting_v2/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/Ped.cs
@@ -331,7 +331,7 @@ namespace GTA
 
 		public bool CanBeKnockedOffBike
 		{
-			set => Function.Call(Hash.SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE, Handle, value);
+			set => Function.Call(Hash.SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE, Handle, !value);
 		}
 
 		public bool CanFlyThroughWindscreen

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -576,7 +576,7 @@ namespace GTA
 
 		public bool CanBeKnockedOffBike
 		{
-			set => Function.Call(Hash.SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE, Handle, value);
+			set => Function.Call(Hash.SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE, Handle, !value);
 		}
 
 		public bool CanFlyThroughWindscreen


### PR DESCRIPTION
This fixes Ped.CanBeKnockedOffBike by inverting the value passed to that native. The underlying native in this function uses an enum rather than a bool, but the first two values in the enum are '0' for the default ped behavior of being able to be knocked off, and '1' for a ped never being able to be knocked off. Thus, by inverting the bool passed to this function, we can achieve the intended behavior without further changes.