### PR TITLE
Add missing INPUT_VEH_FLY_BOOST enum to fix control enum returns

### DIFF
--- a/source/scripting_v2/GTA/Control.cs
+++ b/source/scripting_v2/GTA/Control.cs
@@ -359,6 +359,7 @@ namespace GTA
 		ReplaySnapmaticPhoto,
 		VehicleCarJump,
 		VehicleRocketBoost,
+		VehicleFlyBoost,
 		VehicleParachute,
 		VehicleBikeWings,
 		VehicleFlyBombBay,

--- a/source/scripting_v3/GTA/Control.cs
+++ b/source/scripting_v3/GTA/Control.cs
@@ -359,6 +359,7 @@ namespace GTA
 		ReplaySnapmaticPhoto,
 		VehicleCarJump,
 		VehicleRocketBoost,
+		VehicleFlyBoost,
 		VehicleParachute,
 		VehicleBikeWings,
 		VehicleFlyBombBay,


### PR DESCRIPTION
Currently, attempting to set a control above Control.VehicleRocketBoost will result in the returned integer being off by one digit. As an example, setting Control.QuadLocoReverse (which should be 358) actually sets INPUT_VEH_TRANSFORM (357). This PR adds in the missing INPUT_VEH_FLY_BOOST enum as Control.VehicleFlyBoost to correct for this.

SEE: https://docs.fivem.net/docs/game-references/controls