### PR TITLE
Add new Projectile.FromHandle() method

### DIFF
--- a/source/scripting_v3/GTA/Entities/Projectile.cs
+++ b/source/scripting_v3/GTA/Entities/Projectile.cs
@@ -83,5 +83,20 @@ namespace GTA
 
 			SHVDN.NativeMemory.ExplodeProjectile(address);
 		}
+
+		/// <summary>
+		/// Get a <see cref="Projectile"/> instance by its handle
+		/// </summary>
+		/// <param name="handle"></param>
+		/// <returns>Null if not found or the entity is not a <see cref="Prop"/>, otherwise, a <see cref="Projectile"/></returns>
+		public new static Projectile FromHandle(int handle)
+		{
+			var memoryAddress = NativeMemory.GetEntityAddress(handle);
+
+			if (memoryAddress == IntPtr.Zero || NativeMemory.ReadByte(memoryAddress + 0x28) != 5)
+				return null;
+
+			return new Projectile(handle);
+		}
 	}
 }


### PR DESCRIPTION
Since we can't cast object from base to derived class, and the constructor isn't publicly accessible either, there's no way to get a projectile by it's handle. So I added the `Projectile.FromHandle` method which hides `Entity.FromHandle`  and returns a projectile instance instead. 