### PR TITLE
Fix NativeMemory static constructor crash

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1138,10 +1138,10 @@ namespace SHVDN
 			return (*data & (1 << bit)) != 0;
 		}
 
+		static byte[] _strBufferForStringToCoTaskMemUTF8 = new byte[100];
 		public static readonly IntPtr String = StringToCoTaskMemUTF8("STRING");
 		public static readonly IntPtr NullString = StringToCoTaskMemUTF8(string.Empty);
 		public static readonly IntPtr CellEmailBcon = StringToCoTaskMemUTF8("CELL_EMAIL_BCON");
-		static byte[] _strBufferForStringToCoTaskMemUTF8 = new byte[100];
 
 		public static string PtrToStringUTF8(IntPtr ptr)
 		{


### PR DESCRIPTION
A fix to e61fbb05aaa36706f959f3984c3d63fdb5fa8746 , it somehow causes the static constructor to throw a NullReferenceException due to `_strBufferForStringToCoTaskMemUTF8` field has not been initialized yet. Sorry for the inconvenience.