### PR TITLE
Convert all delegate to function pointer syntax

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -2,7 +2,6 @@
 // Copyright (C) 2015 crosire & contributors
 // License: https://github.com/crosire/scripthookvdotnet#license
 //
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -25,54 +24,50 @@ namespace SHVDN
 		/// Creates a texture. Texture deletion is performed automatically when game reloads scripts.
 		/// Can be called only in the same thread as natives.
 		/// </summary>
-		/// <param name="filename"></param>
+		/// <param name = "filename"></param>
 		/// <returns>Internal texture ID.</returns>
 		[DllImport("ScriptHookV.dll", ExactSpelling = true, EntryPoint = "?createTexture@@YAHPEBD@Z")]
 		public static extern int CreateTexture([MarshalAs(UnmanagedType.LPStr)] string filename);
-
 		/// <summary>
 		/// Draws a texture on screen. Can be called only in the same thread as natives.
 		/// </summary>
-		/// <param name="id">Texture ID returned by <see cref="CreateTexture(string)"/>.</param>
-		/// <param name="instance">The instance index. Each texture can have up to 64 different instances on screen at a time.</param>
-		/// <param name="level">Texture instance with low levels draw first.</param>
-		/// <param name="time">How long in milliseconds the texture instance should stay on screen.</param>
-		/// <param name="sizeX">Width in screen space [0,1].</param>
-		/// <param name="sizeY">Height in screen space [0,1].</param>
-		/// <param name="centerX">Center position in texture space [0,1].</param>
-		/// <param name="centerY">Center position in texture space [0,1].</param>
-		/// <param name="posX">Position in screen space [0,1].</param>
-		/// <param name="posY">Position in screen space [0,1].</param>
-		/// <param name="rotation">Normalized rotation [0,1].</param>
-		/// <param name="scaleFactor">Screen aspect ratio, used for size correction.</param>
-		/// <param name="colorR">Red tint.</param>
-		/// <param name="colorG">Green tint.</param>
-		/// <param name="colorB">Blue tint.</param>
-		/// <param name="colorA">Alpha value.</param>
+		/// <param name = "id">Texture ID returned by <see cref = "CreateTexture(string)"/>.</param>
+		/// <param name = "instance">The instance index. Each texture can have up to 64 different instances on screen at a time.</param>
+		/// <param name = "level">Texture instance with low levels draw first.</param>
+		/// <param name = "time">How long in milliseconds the texture instance should stay on screen.</param>
+		/// <param name = "sizeX">Width in screen space [0,1].</param>
+		/// <param name = "sizeY">Height in screen space [0,1].</param>
+		/// <param name = "centerX">Center position in texture space [0,1].</param>
+		/// <param name = "centerY">Center position in texture space [0,1].</param>
+		/// <param name = "posX">Position in screen space [0,1].</param>
+		/// <param name = "posY">Position in screen space [0,1].</param>
+		/// <param name = "rotation">Normalized rotation [0,1].</param>
+		/// <param name = "scaleFactor">Screen aspect ratio, used for size correction.</param>
+		/// <param name = "colorR">Red tint.</param>
+		/// <param name = "colorG">Green tint.</param>
+		/// <param name = "colorB">Blue tint.</param>
+		/// <param name = "colorA">Alpha value.</param>
 		[DllImport("ScriptHookV.dll", ExactSpelling = true, EntryPoint = "?drawTexture@@YAXHHHHMMMMMMMMMMMM@Z")]
 		public static extern void DrawTexture(int id, int instance, int level, int time, float sizeX, float sizeY, float centerX, float centerY, float posX, float posY, float rotation, float scaleFactor, float colorR, float colorG, float colorB, float colorA);
-
 		/// <summary>
 		/// Gets the game version enumeration value as specified by ScriptHookV.
 		/// </summary>
 		[DllImport("ScriptHookV.dll", ExactSpelling = true, EntryPoint = "?getGameVersion@@YA?AW4eGameVersion@@XZ")]
 		public static extern int GetGameVersion();
-
 		/// <summary>
 		/// Returns pointer to a global variable. IDs may differ between game versions.
 		/// </summary>
-		/// <param name="index">The variable ID to query.</param>
-		/// <returns>Pointer to the variable, or <see cref="IntPtr.Zero"/> if it does not exist.</returns>
+		/// <param name = "index">The variable ID to query.</param>
+		/// <returns>Pointer to the variable, or <see cref = "IntPtr.Zero"/> if it does not exist.</returns>
 		[DllImport("ScriptHookV.dll", ExactSpelling = true, EntryPoint = "?getGlobalPtr@@YAPEA_KH@Z")]
 		public static extern IntPtr GetGlobalPtr(int index);
 		#endregion
-
 		/// <summary>
 		/// Searches the address space of the current process for a memory pattern.
 		/// </summary>
-		/// <param name="pattern">The pattern.</param>
-		/// <param name="mask">The pattern mask.</param>
-		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
+		/// <param name = "pattern">The pattern.</param>
+		/// <param name = "mask">The pattern mask.</param>
+		/// <returns>The address of a region matching the pattern or <see langword="null"/> if none was found.</returns>
 		public static unsafe byte* FindPattern(string pattern, string mask)
 		{
 			ProcessModule module = Process.GetCurrentProcess().MainModule;
@@ -82,35 +77,31 @@ namespace SHVDN
 		/// <summary>
 		/// Searches the specific address space of the current process for a memory pattern.
 		/// </summary>
-		/// <param name="pattern">The pattern.</param>
-		/// <param name="mask">The pattern mask.</param>
-		/// <param name="startAddress">The address to start searching at.</param>
-		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
+		/// <param name = "pattern">The pattern.</param>
+		/// <param name = "mask">The pattern mask.</param>
+		/// <param name = "startAddress">The address to start searching at.</param>
+		/// <returns>The address of a region matching the pattern or <see langword="null"/> if none was found.</returns>
 		public static unsafe byte* FindPattern(string pattern, string mask, IntPtr startAddress)
 		{
 			ProcessModule module = Process.GetCurrentProcess().MainModule;
-
 			if ((ulong)startAddress.ToInt64() < (ulong)module.BaseAddress.ToInt64())
 				return null;
-
 			ulong size = (ulong)module.ModuleMemorySize - ((ulong)startAddress - (ulong)module.BaseAddress);
-
 			return FindPattern(pattern, mask, startAddress, size);
 		}
 
 		/// <summary>
 		/// Searches the specific address space of the current process for a memory pattern.
 		/// </summary>
-		/// <param name="pattern">The pattern.</param>
-		/// <param name="mask">The pattern mask.</param>
-		/// <param name="startAddress">The address to start searching at.</param>
-		/// <param name="size">The size where the pattern search will be performed from <paramref name="startAddress"/>.</param>
-		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
+		/// <param name = "pattern">The pattern.</param>
+		/// <param name = "mask">The pattern mask.</param>
+		/// <param name = "startAddress">The address to start searching at.</param>
+		/// <param name = "size">The size where the pattern search will be performed from <paramref name = "startAddress"/>.</param>
+		/// <returns>The address of a region matching the pattern or <see langword="null"/> if none was found.</returns>
 		public static unsafe byte* FindPattern(string pattern, string mask, IntPtr startAddress, ulong size)
 		{
 			ulong address = (ulong)startAddress.ToInt64();
 			ulong endAddress = address + size;
-
 			for (; address < endAddress; address++)
 			{
 				for (int i = 0; i < pattern.Length; i++)
@@ -132,73 +123,51 @@ namespace SHVDN
 		{
 			byte* address;
 			IntPtr startAddressToSearch;
-
 			// Get relative address and add it to the instruction address.
 			address = FindPattern("\x74\x21\x48\x8B\x48\x20\x48\x85\xC9\x74\x18\x48\x8B\xD6\xE8", "xxxxxxxxxxxxxxx") - 10;
-			GetPtfxAddressFunc = GetDelegateForFunctionPointer<GetHandleAddressFuncDelegate>(
-				new IntPtr(*(int*)(address) + address + 4));
-
+			GetPtfxAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(new IntPtr(*(int*)(address) + address + 4));
 			address = FindPattern("\xE8\x00\x00\x00\x00\x48\x8B\xD8\x48\x85\xC0\x74\x2E\x48\x83\x3D", "x????xxxxxxxxxxx");
-			GetEntityAddressFunc = GetDelegateForFunctionPointer<GetHandleAddressFuncDelegate>(
-				new IntPtr(*(int*)(address + 1) + address + 5));
-
+			GetEntityAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(new IntPtr(*(int*)(address + 1) + address + 5));
 			address = FindPattern("\xB2\x01\xE8\x00\x00\x00\x00\x48\x85\xC0\x74\x1C\x8A\x88", "xxx????xxxxxxx");
-			GetPlayerAddressFunc = GetDelegateForFunctionPointer<GetHandleAddressFuncDelegate>(
-				new IntPtr(*(int*)(address + 3) + address + 7));
-
+			GetPlayerAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(new IntPtr(*(int*)(address + 3) + address + 7));
 			address = FindPattern("\x48\xF7\xF9\x49\x8B\x48\x08\x48\x63\xD0\xC1\xE0\x08\x0F\xB6\x1C\x11\x03\xD8", "xxxxxxxxxxxxxxxxxxx");
-			AddEntityToPoolFunc = GetDelegateForFunctionPointer<AddEntityToPoolFuncDelegate>(
-				new IntPtr(address - 0x68));
-
+			AddEntityToPoolFunc = (delegate* unmanaged[Stdcall]<ulong, int>)(new IntPtr(address - 0x68));
 			address = FindPattern("\x48\x8B\xDA\xE8\x00\x00\x00\x00\xF3\x0F\x10\x44\x24", "xxxx????xxxxx");
-			EntityPosFunc = GetDelegateForFunctionPointer<EntityPosFuncDelegate>(
-				new IntPtr((address - 6)));
-
+			EntityPosFunc = (delegate* unmanaged[Stdcall]<ulong, float*, ulong>)(new IntPtr((address - 6)));
 			address = FindPattern("\x0F\x85\x00\x00\x00\x00\x48\x8B\x4B\x20\xE8\x00\x00\x00\x00\x48\x8B\xC8", "xx????xxxxx????xxx");
-			EntityModel1Func = GetDelegateForFunctionPointer<EntityModel1FuncDelegate>(
-				new IntPtr((*(int*)address + 11) + address + 15));
-
+			EntityModel1Func = (delegate* unmanaged[Stdcall]<ulong, ulong>)(new IntPtr((*(int*)address + 11) + address + 15));
 			address = FindPattern("\x45\x33\xC9\x3B\x05", "xxxxx");
-			EntityModel2Func = GetDelegateForFunctionPointer<EntityModel2FuncDelegate>(
-				new IntPtr(address - 0x46));
-
+			EntityModel2Func = (delegate* unmanaged[Stdcall]<ulong, ulong>)(new IntPtr(address - 0x46));
 			// Find handling data functions
 			address = FindPattern("\x0F\x84\x00\x00\x00\x00\x8B\x8B\x00\x00\x00\x00\xE8\x00\x00\x00\x00\xBA\x09\x00\x00\x00", "xx????xx????x????xxxxx");
-			GetHandlingDataByIndex = GetDelegateForFunctionPointer<GetHandlingDataByIndexDelegate>(
-				new IntPtr(*(int*)(address + 13) + address + 17));
+			GetHandlingDataByIndex = (delegate* unmanaged[Stdcall]<int, ulong>)(new IntPtr(*(int*)(address + 13) + address + 17));
 			handlingIndexOffsetInModelInfo = *(int*)(address + 8);
-
 			address = FindPattern("\xE8\x00\x00\x00\x00\x48\x85\xC0\x75\x5A\xB2\x01", "x????xxxxxxx");
-			GetHandlingDataByHash = GetDelegateForFunctionPointer<GetHandlingDataByHashDelegate>(
-				new IntPtr(*(int*)(address + 1) + address + 5));
-
+			GetHandlingDataByHash = (delegate* unmanaged[Stdcall]<IntPtr, ulong>)(new IntPtr(*(int*)(address + 1) + address + 5));
 			// Find entity pools and interior proxy pool
 			address = FindPattern("\x48\x8B\x05\x00\x00\x00\x00\x41\x0F\xBF\xC8\x0F\xBF\x40\x10", "xxx????xxxxxxxx");
 			PedPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
-
 			address = FindPattern("\x48\x8B\x05\x00\x00\x00\x00\x8B\x78\x10\x85\xFF", "xxx????xxxxx");
 			ObjectPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
-
 			address = FindPattern("\x4C\x8B\x0D\x00\x00\x00\x00\x44\x8B\xC1\x49\x8B\x41\x08", "xxx????xxxxxxx");
 			EntityPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
-
 			address = FindPattern("\x48\x8B\x05\x00\x00\x00\x00\xF3\x0F\x59\xF6\x48\x8B\x08", "xxx????xxxxxxx");
 			VehiclePoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
-
 			address = FindPattern("\x4C\x8B\x05\x00\x00\x00\x00\x40\x8A\xF2\x8B\xE9", "xxx????xxxxx");
 			PickupObjectPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
-
 			address = FindPattern("\x83\x38\xFF\x74\x27\xD1\xEA\xF6\xC2\x01\x74\x20", "xxxxxxxxxxxx");
 			if (address != null)
 			{
 				BuildingPoolAddress = (ulong*)(*(int*)(address + 47) + address + 51);
 				AnimatedBuildingPoolAddress = (ulong*)(*(int*)(address + 15) + address + 19);
 			}
+
 			address = FindPattern("\x83\xBB\x80\x01\x00\x00\x01\x75\x12", "xxxxxxxxx");
 			if (address != null)
 			{
 				InteriorInstPoolAddress = (ulong*)(*(int*)(address + 23) + address + 27);
 			}
+
 			address = FindPattern("\x0F\x85\xA3\x00\x00\x00\x8B\x52\x0C\x48\x8B\x0D\x00\x00\x00\x00", "xxxxxxxxxxxx????");
 			if (address != null)
 			{
@@ -207,29 +176,21 @@ namespace SHVDN
 
 			// Find euphoria functions
 			address = FindPattern("\x40\x53\x48\x83\xEC\x20\x83\x61\x0C\x00\x44\x89\x41\x08\x49\x63\xC0", "xxxxxxxxxxxxxxxxx");
-			InitMessageMemoryFunc = GetDelegateForFunctionPointer<InitMessageMemoryDelegate>(new IntPtr(address));
-
+			InitMessageMemoryFunc = (delegate* unmanaged[Stdcall]<ulong, ulong, int, ulong>)(new IntPtr(address));
 			address = FindPattern("\x41\x83\xFA\xFF\x74\x4A\x48\x85\xD2\x74\x19", "xxxxxxxxxxx") - 0xE;
-			SendMessageToPedFunc = GetDelegateForFunctionPointer<SendMessageToPedDelegate>(new IntPtr(address));
-
+			SendMessageToPedFunc = (delegate* unmanaged[Stdcall]<ulong, IntPtr, ulong, void>)(new IntPtr(address));
 			address = FindPattern("\x48\x89\x5C\x24\x00\x57\x48\x83\xEC\x20\x48\x8B\xD9\x48\x63\x49\x0C\x41\x8B\xF8", "xxxx?xxxxxxxxxxxxxxx");
-			SetNmIntAddress = GetDelegateForFunctionPointer<SetNmIntAddressDelegate>(new IntPtr(address));
-
+			SetNmIntAddress = (delegate* unmanaged[Stdcall]<ulong, IntPtr, int, byte>)(new IntPtr(address));
 			address = FindPattern("\x48\x89\x5C\x24\x00\x57\x48\x83\xEC\x20\x48\x8B\xD9\x48\x63\x49\x0C\x41\x8A\xF8", "xxxx?xxxxxxxxxxxxxxx");
-			SetNmBoolAddress = GetDelegateForFunctionPointer<SetNmBoolAddressDelegate>(new IntPtr(address));
-
+			SetNmBoolAddress = (delegate* unmanaged[Stdcall]<ulong, IntPtr, bool, byte>)(new IntPtr(address));
 			address = FindPattern("\x40\x53\x48\x83\xEC\x30\x48\x8B\xD9\x48\x63\x49\x0C", "xxxxxxxxxxxxx");
-			SetNmFloatAddress = GetDelegateForFunctionPointer<SetNmFloatAddressDelegate>(new IntPtr(address));
-
+			SetNmFloatAddress = (delegate* unmanaged[Stdcall]<ulong, IntPtr, float, byte>)(new IntPtr(address));
 			address = FindPattern("\x57\x48\x83\xEC\x20\x48\x8B\xD9\x48\x63\x49\x0C\x49\x8B\xE8", "xxxxxxxxxxxxxxx") - 15;
-			SetNmStringAddress = GetDelegateForFunctionPointer<SetNmStringAddressDelegate>(new IntPtr(address));
-
+			SetNmStringAddress = (delegate* unmanaged[Stdcall]<ulong, IntPtr, IntPtr, byte>)(new IntPtr(address));
 			address = FindPattern("\x40\x53\x48\x83\xEC\x40\x48\x8B\xD9\x48\x63\x49\x0C", "xxxxxxxxxxxxx");
-			SetNmVector3Address = GetDelegateForFunctionPointer<SetNmVector3AddressDelegate>(new IntPtr(address));
-
+			SetNmVector3Address = (delegate* unmanaged[Stdcall]<ulong, IntPtr, float, float, float, byte>)(new IntPtr(address));
 			address = FindPattern("\x83\x79\x10\xFF\x7E\x1D\x48\x63\x41\x10", "xxxxxxxxxx");
-			GetActiveTaskFunc = GetDelegateForFunctionPointer<GetActiveTaskFuncDelegate>(new IntPtr(address));
-
+			GetActiveTaskFunc = (delegate* unmanaged[Stdcall]<ulong, CTask*>)(new IntPtr(address));
 			address = FindPattern("\x75\xEF\x48\x8B\x5C\x24\x30\xB8\x00\x00\x00\x00", "xxxxxxxx????");
 			if (address != null)
 			{
@@ -246,14 +207,11 @@ namespace SHVDN
 
 			address = FindPattern("\x84\xC0\x74\x34\x48\x8D\x0D\x00\x00\x00\x00\x48\x8B\xD3", "xxxxxxx????xxx");
 			GetLabelTextByHashAddress = (ulong)(*(int*)(address + 7) + address + 11);
-
 			address = FindPattern("\x48\x89\x5C\x24\x08\x48\x89\x6C\x24\x18\x89\x54\x24\x10\x56\x57\x41\x56\x48\x83\xEC\x20", "xxxxxxxxxxxxxxxxxxxxxx");
-			GetLabelTextByHashFunc = GetDelegateForFunctionPointer<GetLabelTextByHashFuncDelegate>(new IntPtr(address));
-
+			GetLabelTextByHashFunc = (delegate* unmanaged[Stdcall]<ulong, int, ulong>)(new IntPtr(address));
 			address = FindPattern("\x8A\x4C\x24\x60\x8B\x50\x10\x44\x8A\xCE", "xxxxxxxxxx");
 			CheckpointPoolAddress = (ulong*)(*(int*)(address + 17) + address + 21);
-			GetCGameScriptHandlerAddressFunc = GetDelegateForFunctionPointer<GetCGameScriptHandlerAddressDelegate>(new IntPtr(*(int*)(address - 19) + address - 15));
-
+			GetCGameScriptHandlerAddressFunc = (delegate* unmanaged[Stdcall]<ulong>)(new IntPtr(*(int*)(address - 19) + address - 15));
 			address = FindPattern("\x4C\x8D\x05\x00\x00\x00\x00\x0F\xB7\xC1", "xxx????xxx");
 			RadarBlipPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
 			address = FindPattern("\xFF\xC6\x49\x83\xC6\x08\x3B\x35\x00\x00\x00\x00\x7C\x9B", "xxxxxxxx????xx");
@@ -264,10 +222,8 @@ namespace SHVDN
 			NorthRadarBlipHandleAddress = (int*)(*(int*)(address + 10) + address + 14);
 			address = FindPattern("\x41\xB8\x06\x00\x00\x00\x8B\xD0\x89\x05\x00\x00\x00\x00\x41\x8D\x48\xFD", "xxxxxxxxxx????xxxx");
 			CenterRadarBlipHandleAddress = (int*)(*(int*)(address + 10) + address + 14);
-
 			address = FindPattern("\x33\xDB\xE8\x00\x00\x00\x00\x48\x85\xC0\x74\x07\x48\x8B\x40\x20\x8B\x58\x18", "xxx????xxxxxxxxxxxx");
-			GetLocalPlayerPedAddressFunc = GetDelegateForFunctionPointer<GetLocalPlayerPedAddressFuncDelegate>(new IntPtr(*(int*)(address + 3) + address + 7));
-
+			GetLocalPlayerPedAddressFunc = (delegate* unmanaged[Stdcall]<ulong>)(new IntPtr(*(int*)(address + 3) + address + 7));
 			address = FindPattern("\x4C\x8D\x05\x00\x00\x00\x00\x74\x07\xB8\x00\x00\x00\x00\xEB\x2D\x33\xC0", "xxx????xxx????xxxx");
 			waypointInfoArrayStartAddress = (ulong*)(*(int*)(address + 3) + address + 7);
 			if (waypointInfoArrayStartAddress != null)
@@ -280,12 +236,13 @@ namespace SHVDN
 			address = FindPattern("\x48\x8D\x4C\x24\x20\x41\xB8\x02\x00\x00\x00\xE8\x00\x00\x00\x00\xF3", "xxxxxxxxxxxx????x");
 			if (address != null)
 			{
-				GetRotationFromMatrixFunc = GetDelegateForFunctionPointer<GetRotationFromMatrixDelegate>(new IntPtr(*(int*)(address + 12) + address + 16));
+				GetRotationFromMatrixFunc = (delegate* unmanaged[Stdcall]<float*, ulong, int, float*>)(new IntPtr(*(int*)(address + 12) + address + 16));
 			}
+
 			address = FindPattern("\xF3\x0F\x11\x4D\x38\xF3\x0F\x11\x45\x3C\xE8\x00\x00\x00\x00", "xxxxxxxxxxx????");
 			if (address != null)
 			{
-				GetQuaternionFromMatrixFunc = GetDelegateForFunctionPointer<GetQuaternionFromMatrixDelegate>(new IntPtr(*(int*)(address + 11) + address + 15));
+				GetQuaternionFromMatrixFunc = (delegate* unmanaged[Stdcall]<float*, ulong, int>)(new IntPtr(*(int*)(address + 11) + address + 15));
 			}
 
 			address = FindPattern("\x48\x8B\x42\x20\x48\x85\xC0\x74\x09\xF3\x0F\x10\x80", "xxxxxxxxxxxxx");
@@ -308,7 +265,6 @@ namespace SHVDN
 				startAddressToSearch = new IntPtr(address);
 				address = FindPattern("\x48\x63\x51\x00\x48\x85\xD2", "xxx?xxx", startAddressToSearch);
 				elementCountOfCAttackerArrayOfEntityOffset = (uint)(*(sbyte*)(address + 3));
-
 				startAddressToSearch = new IntPtr(address);
 				address = FindPattern("\x48\x83\xC1\x00\x48\x3B\xC2\x7C\xEF", "xxx?xxxxx", startAddressToSearch);
 				// the element size might be 0x10 in older builds (the size is 0x18 at least in b1604 and b2372)
@@ -316,42 +272,33 @@ namespace SHVDN
 			}
 
 			address = FindPattern("\x48\x8B\x0B\x33\xD2\xE8\x00\x00\x00\x00\x89\x03", "xxxxxx????xx");
-			GetHashKeyFunc = GetDelegateForFunctionPointer<GetHashKeyDelegate>(new IntPtr(*(int*)(address + 6) + address + 10));
-
+			GetHashKeyFunc = (delegate* unmanaged[Stdcall]<IntPtr, uint, uint>)(new IntPtr(*(int*)(address + 6) + address + 10));
 			address = FindPattern("\x74\x11\x8B\xD1\x48\x8D\x0D\x00\x00\x00\x00\x45\x33\xC0", "xxxxxxx????xxx");
 			cursorSpriteAddr = (int*)(*(int*)(address - 4) + address);
-
 			address = FindPattern("\x48\x63\xC1\x48\x8D\x0D\x00\x00\x00\x00\xF3\x0F\x10\x04\x81\xF3\x0F\x11\x05\x00\x00\x00\x00", "xxxxxx????xxxxxxxxx????");
 			readWorldGravityAddress = (float*)(*(int*)(address + 19) + address + 23);
 			writeWorldGravityAddress = (float*)(*(int*)(address + 6) + address + 10);
-
 			address = FindPattern("\xF3\x0F\x11\x05\x00\x00\x00\x00\xF3\x0F\x10\x08\x0F\x2F\xC8\x73\x03\x0F\x28\xC1\x48\x83\xC0\x04\x49\x2B", "xxxx????xxxxxxxxxxxxxxxxxx");
 			var timeScaleArrayAddress = (float*)(*(int*)(address + 4) + address + 8);
 			if (timeScaleArrayAddress != null)
 				// SET_TIME_SCALE changes the 2nd element, so obtain the address of it
 				timeScaleAddress = timeScaleArrayAddress + 1;
-
 			address = FindPattern("\x66\x0F\x6E\x05\x00\x00\x00\x00\x0F\x57\xF6", "xxxx????xxx");
 			millisecondsPerGameMinuteAddress = (int*)(*(int*)(address + 4) + address + 8);
-
 			address = FindPattern("\x75\x2D\x44\x38\x3D\x00\x00\x00\x00\x75\x24", "xxxxx????xx");
 			isClockPausedAddress = (bool*)(*(int*)(address + 5) + address + 9);
-
 			// Find camera objects
 			address = FindPattern("\x48\x8B\xC8\xEB\x02\x33\xC9\x48\x85\xC9\x74\x26", "xxxxxxxxxxxx") - 9;
 			CameraPoolAddress = (ulong*)(*(int*)(address) + address + 4);
 			address = FindPattern("\x48\x8B\xC7\xF3\x0F\x10\x0D", "xxxxxxx") - 0x1D;
 			address = address + *(int*)(address) + 4;
 			GameplayCameraAddress = (ulong*)(*(int*)(address + 3) + address + 7);
-
 			// Find model hash table
 			address = FindPattern("\x3C\x05\x75\x16\x8B\x81\x00\x00\x00\x00", "xxxxxx????");
 			if (address != null)
 				VehicleTypeOffsetInModelInfo = *(int*)(address + 6);
-
 			address = FindPattern("\x66\x81\xF9\x00\x00\x74\x10\x4D\x85\xC0", "xxx??xxxxx") - 0x21;
 			uint vehicleClassOffset = *(uint*)(address + 0x31);
-
 			address = address + *(int*)(address) + 4;
 			modelNum1 = *(UInt32*)(*(int*)(address + 0x52) + address + 0x56);
 			modelNum2 = *(UInt64*)(*(int*)(address + 0x63) + address + 0x67);
@@ -359,30 +306,22 @@ namespace SHVDN
 			modelNum4 = *(UInt64*)(*(int*)(address + 0x81) + address + 0x85);
 			modelHashTable = *(UInt64*)(*(int*)(address + 0x24) + address + 0x28);
 			modelHashEntries = *(UInt16*)(address + *(int*)(address + 3) + 7);
-
 			address = FindPattern("\x33\xD2\x00\x8B\xD0\x00\x2B\x05\x00\x00\x00\x00\xC1\xE6\x10", "xx?xx?xx????xxx");
 			modelInfoArrayPtr = (ulong*)(*(int*)(address + 8) + address + 12);
-
 			address = FindPattern("\x8B\x54\x00\x00\x00\x8D\x0D\x00\x00\x00\x00\xE8\x00\x00\x00\x00\x8A\xC3", "xx???xx????x????xx");
 			cStreamingAddr = (ulong*)(*(int*)(address + 7) + address + 11);
-
 			address = FindPattern("\x48\x8B\x05\x00\x00\x00\x00\x41\x8B\x1E", "xxx????xxx");
 			weaponAndAmmoInfoArrayPtr = (RageAtArrayPtr*)(*(int*)(address + 3) + address + 7);
-
 			address = FindPattern("\x48\x85\xC0\x74\x08\x8B\x90\x00\x00\x00\x00\xEB\x02", "xxxxxxx????xx");
 			weaponInfoHumanNameHashOffset = *(int*)(address + 7);
-
 			address = FindPattern("\x8B\x05\x00\x00\x00\x00\x44\x8B\xD3\x8D\x48\xFF", "xx????xxxxxx");
 			if (address != null)
 			{
 				weaponComponentArrayCountAddr = (uint*)(*(int*)(address + 2) + address + 6);
-
 				address = FindPattern("\x46\x8D\x04\x11\x48\x8D\x15\x00\x00\x00\x00\x41\xD1\xF8", "xxxxxxx????xxx", new IntPtr(address));
 				offsetForCWeaponComponentArrayAddr = (ulong)(address + 7);
-
 				address = FindPattern("\x74\x10\x49\x8B\xC9\xE8\x00\x00\x00\x00", "xxxxxx????", new IntPtr(address));
 				var findAttachPointFuncAddr = new IntPtr((long)(*(int*)(address + 6) + address + 10));
-
 				address = FindPattern("\x4C\x8D\x81\x00\x00\x00\x00", "xxx????", findAttachPointFuncAddr);
 				weaponAttachPointsStartOffset = *(int*)(address + 3);
 				address = FindPattern("\x4D\x63\x98\x00\x00\x00\x00", "xxx????", new IntPtr(address));
@@ -420,6 +359,7 @@ namespace SHVDN
 			{
 				FuelLevelOffset = *(int*)(address + 8);
 			}
+
 			address = FindPattern("\x74\x2D\x0F\x57\xC0\x0F\x2F\x83\x00\x00\x00\x00", "xxxxxxxx????");
 			if (address != null)
 			{
@@ -456,9 +396,7 @@ namespace SHVDN
 
 			// use the former pattern if the version is 1.0.1604.0 or newer
 			var gameVersion = GetGameVersion();
-			address = gameVersion >= 46 ?
-						FindPattern("\xF3\x0F\x10\x9F\xD4\x08\x00\x00\x0F\x2F\xDF\x73\x0A", "xxxx????xxxxx") :
-						FindPattern("\xF3\x0F\x10\x8F\x68\x08\x00\x00\x88\x4D\x8C\x0F\x2F\xCF", "xxxx????xxx???");
+			address = gameVersion >= 46 ? FindPattern("\xF3\x0F\x10\x9F\xD4\x08\x00\x00\x0F\x2F\xDF\x73\x0A", "xxxx????xxxxx") : FindPattern("\xF3\x0F\x10\x8F\x68\x08\x00\x00\x88\x4D\x8C\x0F\x2F\xCF", "xxxx????xxx???");
 			if (address != null)
 			{
 				TurboOffset = *(int*)(address + 4);
@@ -560,14 +498,11 @@ namespace SHVDN
 				string patternForHeliHealthOffsets = "\x48\x85\xC0\x74\x18\x8B\x88\x00\x00\x00\x00\x83\xE9\x08\x83\xF9\x01\x77\x0A\xF3\x0F\x10\x80\x00\x00\x00\x00";
 				string maskForHeliHealthOffsets = "xxxxxxx????xxxxxxxxxxxx????";
 				startAddressToSearch = Process.GetCurrentProcess().MainModule.BaseAddress;
-
 				int[] heliHealthOffsets = new int[3];
-
 				// the pattern will match 3 times
 				for (int i = 0; i < 3; i++)
 				{
 					address = FindPattern(patternForHeliHealthOffsets, maskForHeliHealthOffsets, startAddressToSearch);
-
 					if (address != null)
 					{
 						heliHealthOffsets[i] = *(int*)(address + 23);
@@ -640,7 +575,7 @@ namespace SHVDN
 			address = FindPattern("\x74\x21\x8B\xD7\x48\x8B\xCB\xE8\x00\x00\x00\x00\x48\x8B\xC8\xE8\x00\x00\x00\x00", "xxxxxxxx????xxxx????");
 			if (address != null)
 			{
-				FixVehicleWheelFunc = GetDelegateForFunctionPointer<FixVehicleWheelDelegate>(new IntPtr(*(int*)(address + 16) + address + 20));
+				FixVehicleWheelFunc = (delegate* unmanaged[Stdcall]<IntPtr, void>)(new IntPtr(*(int*)(address + 16) + address + 20));
 				address = FindPattern("\x80\xA1\x00\x00\x00\x00\xFD", "xx????x", new IntPtr(address + 20));
 				ShouldShowOnlyVehicleTiresWithPositiveHealthOffset = *(int*)(address + 2);
 			}
@@ -648,18 +583,18 @@ namespace SHVDN
 			address = FindPattern("\x4C\x8B\x81\x28\x01\x00\x00\x0F\x29\x70\xE8\x0F\x29\x78\xD8", "xxxxxxxxxxxxxxx");
 			if (address != null)
 			{
-				PunctureVehicleTireNewFunc = GetDelegateForFunctionPointer<PunctureVehicleTireNewDelegate>(new IntPtr((long)(address - 0x10)));
+				PunctureVehicleTireNewFunc = (delegate* unmanaged[Stdcall]<IntPtr, ulong, float, ulong, ulong, int, byte, bool, void>)(new IntPtr((long)(address - 0x10)));
 				address = FindPattern("\x48\x83\xEC\x50\x48\x8B\x81\x00\x00\x00\x00\x48\x8B\xF1\xF6\x80", "xxxxxxx????xxxxx");
-				BurstVehicleTireOnRimNewFunc = GetDelegateForFunctionPointer<BurstVehicleTireOnRimNewDelegate>(new IntPtr((long)(address - 0xB)));
+				BurstVehicleTireOnRimNewFunc = (delegate* unmanaged[Stdcall]<IntPtr, void>)(new IntPtr((long)(address - 0xB)));
 			}
 			else
 			{
 				address = FindPattern("\x41\xF6\x81\x00\x00\x00\x00\x20\x0F\x29\x70\xE8\x0F\x29\x78\xD8\x49\x8B\xF9", "xxx????xxxxxxxxxxxx");
 				if (address != null)
 				{
-					PunctureVehicleTireOldFunc = GetDelegateForFunctionPointer<PunctureVehicleTireOldDelegate>(new IntPtr((long)(address - 0x14)));
+					PunctureVehicleTireOldFunc = (delegate* unmanaged[Stdcall]<IntPtr, ulong, float, IntPtr, ulong, ulong, int, byte, bool, void>)(new IntPtr((long)(address - 0x14)));
 					address = FindPattern("\x48\x83\xEC\x50\xF6\x82\x00\x00\x00\x00\x20\x48\x8B\xF2\x48\x8B\xE9", "xxxxxx????xxxxxxx");
-					BurstVehicleTireOnRimOldFunc = GetDelegateForFunctionPointer<BurstVehicleTireOnRimOldDelegate>(new IntPtr((long)(address - 0x10)));
+					BurstVehicleTireOnRimOldFunc = (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, void>)(new IntPtr((long)(address - 0x10)));
 				}
 			}
 
@@ -701,6 +636,7 @@ namespace SHVDN
 				PedIsInVehicleOffset = *(int*)(address + 12);
 				PedLastVehicleOffset = *(int*)(address + 0x1A);
 			}
+
 			address = FindPattern("\x24\x3F\x0F\xB6\xC0\x66\x89\x87\x00\x00\x00\x00", "xxxxxxxx????");
 			if (address != null)
 			{
@@ -769,39 +705,45 @@ namespace SHVDN
 			{
 				ProjectilePoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
 			}
+
 			// Find address of the projectile count, just in case the max number of projectile changes from 50
 			address = FindPattern("\x44\x8B\x0D\x00\x00\x00\x00\x33\xDB\x45\x8A\xF8", "xxx????xxxxx");
 			if (address != null)
 			{
 				ProjectileCountAddress = (int*)(*(int*)(address + 3) + address + 7);
 			}
+
 			address = FindPattern("\x48\x85\xED\x74\x09\x48\x39\xA9\x00\x00\x00\x00\x75\x2D", "xxxxxxxx????xx");
 			if (address != null)
 			{
 				ProjectileOwnerOffset = *(int*)(address + 8);
 			}
+
 			address = FindPattern("\x45\x85\xF6\x74\x0D\x48\x8B\x81\x00\x00\x00\x00\x44\x39\x70\x10", "xxxxxxxx????xxxx");
 			if (address != null)
 			{
 				ProjectileAmmoInfoOffset = *(int*)(address + 8);
 			}
+
 			address = FindPattern("\x39\x70\x10\x75\x17\x40\x84\xED\x74\x09\x33\xD2\xE8", "xxxxxxxxxxxxx");
 			if (address != null)
 			{
-				ExplodeProjectileFunc = GetDelegateForFunctionPointer<ExplodeProjectileDelegate>(new IntPtr(*(int*)(address + 13) + address + 17));
+				ExplodeProjectileFunc = (delegate* unmanaged[Stdcall]<IntPtr, int, void>)(new IntPtr(*(int*)(address + 13) + address + 17));
 			}
 
 			address = FindPattern("\x0F\xBE\x5E\x06\x48\x8B\xCF\xFF\x50\x00\x8B\xD3\x48\x8B\xC8\xE8\x00\x00\x00\x00\x8B\x4E\x00", "xxxxxxxxx?xxxxxx????xx?");
 			if (address != null)
 			{
 				getFragInstVFuncOffset = *(sbyte*)(address + 9);
-				detachFragmentPartByIndexFunc = GetDelegateForFunctionPointer<DetachFragmentPartByIndexDelegate>(new IntPtr(*(int*)(address + 16) + address + 20));
+				detachFragmentPartByIndexFunc = (delegate* unmanaged[Stdcall]<FragInst*, int, FragInst*>)(new IntPtr(*(int*)(address + 16) + address + 20));
 			}
+
 			address = FindPattern("\x00\x8B\x0D\x00\x00\x00\x00\x00\x83\x64\x00\x00\x00\x00\x0F\xB7\xD1\x00\x33\xC9\xE8", "?xx?????xx????xxx?xxx");
 			if (address != null)
 			{
 				phSimulatorInstPtr = (ulong**)(*(int*)(address + 3) + address + 7);
 			}
+
 			address = FindPattern("\x00\x63\x00\x00\x00\x00\x00\x3B\x00\x00\x00\x00\x00\x0F\x8D\x00\x00\x00\x00\x00\x8B\xC8", "?x?????x?????xx?????xx");
 			if (address != null)
 			{
@@ -816,28 +758,17 @@ namespace SHVDN
 				InteriorInstPtrInInteriorProxyOffset = (int)*(byte*)(address + 49);
 			}
 
-
 			// Generate vehicle model list
 			var vehicleHashesGroupedByClass = new List<int>[0x20];
 			for (int i = 0; i < 0x20; i++)
 				vehicleHashesGroupedByClass[i] = new List<int>();
-
 			var vehicleHashesGroupedByType = new List<int>[0x10];
 			for (int i = 0; i < 0x10; i++)
 				vehicleHashesGroupedByType[i] = new List<int>();
-
 			var weaponObjectHashes = new List<int>();
 			var pedHashes = new List<int>();
-
 			// The game will crash when it load these vehicles because of the stub vehicle models
-			var stubVehicles = new HashSet<uint> {
-				0xA71D0D4F, /* astron2 */
-				0x170341C2, /* cyclone2 */
-				0x5C54030C, /* arbitergt */
-				0x39085F47, /* ignus2 */
-				0x438F6593, /* s95 */
-			};
-
+			var stubVehicles = new HashSet<uint> { 0xA71D0D4F, /* astron2 */ 0x170341C2, /* cyclone2 */ 0x5C54030C, /* arbitergt */ 0x39085F47, /* ignus2 */ 0x438F6593, /* s95 */ };
 			for (int i = 0; i < modelHashEntries; i++)
 			{
 				for (HashNode* cur = ((HashNode**)modelHashTable)[i]; cur != null; cur = cur->next)
@@ -862,14 +793,12 @@ namespace SHVDN
 										if (stubVehicles.Contains((uint)cur->hash))
 											continue;
 										vehicleHashesGroupedByClass[*(byte*)(addr2 + vehicleClassOffset) & 0x1F].Add(cur->hash);
-
 										// Normalize the value to vehicle type range for b944 or later versions if current game version is earlier than b944.
 										// The values for CAmphibiousAutomobile and CAmphibiousQuadBike were inserted between those for CSubmarineCar and CHeli in b944.
 										int vehicleTypeInt = *(int*)((byte*)addr2 + VehicleTypeOffsetInModelInfo);
 										if (gameVersion < 28 && vehicleTypeInt >= 6)
 											vehicleTypeInt += 2;
 										vehicleHashesGroupedByType[vehicleTypeInt].Add(cur->hash);
-
 										break;
 									case ModelInfoClassType.Ped:
 										pedHashes.Add(cur->hash);
@@ -885,15 +814,12 @@ namespace SHVDN
 			for (int i = 0; i < 0x20; i++)
 				vehicleResult[i] = Array.AsReadOnly(vehicleHashesGroupedByClass[i].ToArray());
 			VehicleModels = Array.AsReadOnly(vehicleResult);
-
 			vehicleResult = new ReadOnlyCollection<int>[0x10];
 			for (int i = 0; i < 0x10; i++)
 				vehicleResult[i] = Array.AsReadOnly(vehicleHashesGroupedByType[i].ToArray());
 			VehicleModelsGroupedByType = Array.AsReadOnly(vehicleResult);
-
 			WeaponModels = Array.AsReadOnly(weaponObjectHashes.ToArray());
 			PedModels = Array.AsReadOnly(pedHashes.ToArray());
-
 			#region -- Enable All DLC Vehicles --
 			// no need to patch the global variable in v1.0.573.1 or older builds
 			if (gameVersion <= 15)
@@ -903,17 +829,14 @@ namespace SHVDN
 
 			address = FindPattern("\x48\x03\x15\x00\x00\x00\x00\x4C\x23\xC2\x49\x8B\x08", "xxx????xxxxxx");
 			var yscScriptTable = (YscScriptTable*)(address + *(int*)(address + 3) + 7);
-
 			// find the shop_controller script
 			YscScriptTableItem* shopControllerItem = yscScriptTable->FindScript(0x39DA738B);
-
 			if (shopControllerItem == null || !shopControllerItem->IsLoaded())
 			{
 				return;
 			}
 
 			YscScriptHeader* shopControllerHeader = shopControllerItem->header;
-
 			string enableCarsGlobalPattern;
 			if (gameVersion >= 80)
 			{
@@ -928,16 +851,15 @@ namespace SHVDN
 			{
 				enableCarsGlobalPattern = "\x2D\x00\x00\x00\x00\x2C\x01\x00\x00\x56\x04\x00\x6E\x2E\x00\x01\x5F\x00\x00\x00\x00\x04\x00\x6E\x2E\x00\x01";
 			}
+
 			var enableCarsGlobalMask = gameVersion >= 46 ? "x??xxxx??xxxxx?xx????xxxx?x" : "xx??xxxxxx?xx????xxxx?x";
 			var enableCarsGlobalOffset = gameVersion >= 46 ? 17 : 13;
-
 			for (int i = 0; i < shopControllerHeader->CodePageCount(); i++)
 			{
 				int size = shopControllerHeader->GetCodePageSize(i);
 				if (size > 0)
 				{
 					address = FindPattern(enableCarsGlobalPattern, enableCarsGlobalMask, shopControllerHeader->GetCodePageAddress(i), (ulong)size);
-
 					if (address != null)
 					{
 						int globalindex = *(int*)(address + enableCarsGlobalOffset) & 0xFFFFFF;
@@ -949,73 +871,80 @@ namespace SHVDN
 		}
 
 		/// <summary>
-		/// Reads a single 8-bit value from the specified <paramref name="address"/>.
+		/// Reads a single 8-bit value from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
+		/// <param name = "address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static byte ReadByte(IntPtr address)
 		{
 			return *(byte*)address.ToPointer();
 		}
+
 		/// <summary>
-		/// Reads a single 16-bit value from the specified <paramref name="address"/>.
+		/// Reads a single 16-bit value from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
+		/// <param name = "address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static Int16 ReadInt16(IntPtr address)
 		{
 			return *(short*)address.ToPointer();
 		}
+
 		/// <summary>
-		/// Reads a single 32-bit value from the specified <paramref name="address"/>.
+		/// Reads a single 32-bit value from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
+		/// <param name = "address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static Int32 ReadInt32(IntPtr address)
 		{
 			return *(int*)address.ToPointer();
 		}
+
 		/// <summary>
-		/// Reads a single floating-point value from the specified <paramref name="address"/>.
+		/// Reads a single floating-point value from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
+		/// <param name = "address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static float ReadFloat(IntPtr address)
 		{
 			return *(float*)address.ToPointer();
 		}
+
 		/// <summary>
-		/// Reads a null-terminated UTF-8 string from the specified <paramref name="address"/>.
+		/// Reads a null-terminated UTF-8 string from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
+		/// <param name = "address">The memory address to access.</param>
 		/// <returns>The string at the address.</returns>
 		public static String ReadString(IntPtr address)
 		{
 			return PtrToStringUTF8(address);
 		}
+
 		/// <summary>
-		/// Reads a single 64-bit value from the specified <paramref name="address"/>.
+		/// Reads a single 64-bit value from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
+		/// <param name = "address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static IntPtr ReadAddress(IntPtr address)
 		{
 			return new IntPtr(*(void**)(address.ToPointer()));
 		}
+
 		/// <summary>
-		/// Reads a 4x4 floating-point matrix from the specified <paramref name="address"/>.
+		/// Reads a 4x4 floating-point matrix from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
+		/// <param name = "address">The memory address to access.</param>
 		/// <returns>All elements of the matrix in row major arrangement.</returns>
 		public static float[] ReadMatrix(IntPtr address)
 		{
 			var data = (float*)address.ToPointer();
 			return new float[16] { data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15] };
 		}
+
 		/// <summary>
-		/// Reads a 3-component floating-point vector from the specified <paramref name="address"/>.
+		/// Reads a 3-component floating-point vector from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
+		/// <param name = "address">The memory address to access.</param>
 		/// <returns>All elements of the vector.</returns>
 		public static float[] ReadVector3(IntPtr address)
 		{
@@ -1024,61 +953,66 @@ namespace SHVDN
 		}
 
 		/// <summary>
-		/// Writes a single 8-bit value to the specified <paramref name="address"/>.
+		/// Writes a single 8-bit value to the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="value">The value to write.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "value">The value to write.</param>
 		public static void WriteByte(IntPtr address, byte value)
 		{
 			var data = (byte*)address.ToPointer();
 			*data = value;
 		}
+
 		/// <summary>
-		/// Writes a single 16-bit value to the specified <paramref name="address"/>.
+		/// Writes a single 16-bit value to the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="value">The value to write.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "value">The value to write.</param>
 		public static void WriteInt16(IntPtr address, Int16 value)
 		{
 			var data = (short*)address.ToPointer();
 			*data = value;
 		}
+
 		/// <summary>
-		/// Writes a single 32-bit value to the specified <paramref name="address"/>.
+		/// Writes a single 32-bit value to the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="value">The value to write.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "value">The value to write.</param>
 		public static void WriteInt32(IntPtr address, Int32 value)
 		{
 			var data = (int*)address.ToPointer();
 			*data = value;
 		}
+
 		/// <summary>
-		/// Writes a single floating-point value to the specified <paramref name="address"/>.
+		/// Writes a single floating-point value to the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="value">The value to write.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "value">The value to write.</param>
 		public static void WriteFloat(IntPtr address, float value)
 		{
 			var data = (float*)address.ToPointer();
 			*data = value;
 		}
+
 		/// <summary>
-		/// Writes a 4x4 floating-point matrix to the specified <paramref name="address"/>.
+		/// Writes a 4x4 floating-point matrix to the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="value">The elements of the matrix in row major arrangement to write.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "value">The elements of the matrix in row major arrangement to write.</param>
 		public static void WriteMatrix(IntPtr address, float[] value)
 		{
 			var data = (float*)(address.ToPointer());
 			for (int i = 0; i < value.Length; i++)
 				data[i] = value[i];
 		}
+
 		/// <summary>
-		/// Writes a 3-component floating-point to the specified <paramref name="address"/>.
+		/// Writes a 3-component floating-point to the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="value">The vector components to write.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "value">The vector components to write.</param>
 		public static void WriteVector3(IntPtr address, float[] value)
 		{
 			var data = (float*)address.ToPointer();
@@ -1086,11 +1020,12 @@ namespace SHVDN
 			data[1] = value[1];
 			data[2] = value[2];
 		}
+
 		/// <summary>
-		/// Writes a single 64-bit value from the specified <paramref name="address"/>.
+		/// Writes a single 64-bit value from the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="value">The value to write.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "value">The value to write.</param>
 		public static void WriteAddress(IntPtr address, IntPtr value)
 		{
 			var data = (long*)address.ToPointer();
@@ -1098,42 +1033,41 @@ namespace SHVDN
 		}
 
 		/// <summary>
-		/// Sets a single bit in the 32-bit value at the specified <paramref name="address"/>.
+		/// Sets a single bit in the 32-bit value at the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="bit">The bit index to change.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "bit">The bit index to change.</param>
 		public static void SetBit(IntPtr address, int bit)
 		{
 			if (bit < 0 || bit > 31)
 				throw new ArgumentOutOfRangeException(nameof(bit), "The bit index has to be between 0 and 31");
-
 			var data = (int*)address.ToPointer();
 			*data |= (1 << bit);
 		}
+
 		/// <summary>
-		/// Clears a single bit in the 32-bit value at the specified <paramref name="address"/>.
+		/// Clears a single bit in the 32-bit value at the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="bit">The bit index to change.</param>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "bit">The bit index to change.</param>
 		public static void ClearBit(IntPtr address, int bit)
 		{
 			if (bit < 0 || bit > 31)
 				throw new ArgumentOutOfRangeException(nameof(bit), "The bit index has to be between 0 and 31");
-
 			var data = (int*)address.ToPointer();
 			*data &= ~(1 << bit);
 		}
+
 		/// <summary>
-		/// Checks a single bit in the 32-bit value at the specified <paramref name="address"/>.
+		/// Checks a single bit in the 32-bit value at the specified <paramref name = "address"/>.
 		/// </summary>
-		/// <param name="address">The memory address to access.</param>
-		/// <param name="bit">The bit index to check.</param>
-		/// <returns><see langword="true" /> if the bit is set, <see langword="false" /> if it is unset.</returns>
+		/// <param name = "address">The memory address to access.</param>
+		/// <param name = "bit">The bit index to check.</param>
+		/// <returns><see langword="true"/> if the bit is set, <see langword="false"/> if it is unset.</returns>
 		public static bool IsBitSet(IntPtr address, int bit)
 		{
 			if (bit < 0 || bit > 31)
 				throw new ArgumentOutOfRangeException(nameof(bit), "The bit index has to be between 0 and 31");
-
 			var data = (int*)address.ToPointer();
 			return (*data & (1 << bit)) != 0;
 		}
@@ -1142,38 +1076,33 @@ namespace SHVDN
 		public static readonly IntPtr String = StringToCoTaskMemUTF8("STRING");
 		public static readonly IntPtr NullString = StringToCoTaskMemUTF8(string.Empty);
 		public static readonly IntPtr CellEmailBcon = StringToCoTaskMemUTF8("CELL_EMAIL_BCON");
-
 		public static string PtrToStringUTF8(IntPtr ptr)
 		{
 			if (ptr == IntPtr.Zero)
 				return string.Empty;
-
 			var data = (byte*)ptr.ToPointer();
-
 			// Calculate length of null-terminated string
 			int len = 0;
 			while (data[len] != 0)
 				++len;
-
 			return PtrToStringUTF8(ptr, len);
 		}
+
 		public static string PtrToStringUTF8(IntPtr ptr, int len)
 		{
 			if (len < 0)
 				throw new ArgumentException(null, nameof(len));
-
 			if (ptr == IntPtr.Zero)
 				return null;
 			if (len == 0)
 				return string.Empty;
-
 			return Encoding.UTF8.GetString((byte*)ptr.ToPointer(), len);
 		}
+
 		public static IntPtr StringToCoTaskMemUTF8(string s)
 		{
 			if (s == null)
 				return IntPtr.Zero;
-
 			int byteCountUtf8 = Encoding.UTF8.GetByteCount(s);
 			if (byteCountUtf8 > _strBufferForStringToCoTaskMemUTF8.Length)
 			{
@@ -1184,16 +1113,13 @@ namespace SHVDN
 			IntPtr dest = AllocCoTaskMem(byteCountUtf8 + 1);
 			if (dest == IntPtr.Zero)
 				throw new OutOfMemoryException();
-
 			Copy(_strBufferForStringToCoTaskMemUTF8, 0, dest, byteCountUtf8);
 			// Add null-terminator to end
 			((byte*)dest.ToPointer())[byteCountUtf8] = 0;
-
 			return dest;
 		}
 
 		#region -- RAGE classes --
-
 		[StructLayout(LayoutKind.Explicit, Size = 0xC)]
 		struct RageAtArrayPtr
 		{
@@ -1203,7 +1129,6 @@ namespace SHVDN
 			internal ushort size;
 			[FieldOffset(0xA)]
 			internal ushort capacity;
-
 			internal ulong GetElementAddress(int i)
 			{
 				return data[i];
@@ -1211,12 +1136,9 @@ namespace SHVDN
 		}
 
 		#endregion
-
 		#region -- Cameras --
-
 		static ulong* CameraPoolAddress;
 		static ulong* GameplayCameraAddress;
-
 		public static IntPtr GetCameraAddress(int handle)
 		{
 			uint index = (uint)(handle >> 8);
@@ -1225,21 +1147,16 @@ namespace SHVDN
 			{
 				return new IntPtr(*(long*)poolAddr + (index * *(uint*)(poolAddr + 20)));
 			}
-			return IntPtr.Zero;
 
+			return IntPtr.Zero;
 		}
+
 		public static IntPtr GetGameplayCameraAddress()
 		{
 			return new IntPtr((long)*GameplayCameraAddress);
 		}
 
-		#endregion
-
-		#region -- Game Data --
-
-		delegate uint GetHashKeyDelegate(IntPtr stringPtr, uint initialHash);
-		static GetHashKeyDelegate GetHashKeyFunc;
-
+		static delegate* unmanaged[Stdcall]<IntPtr, uint, uint> GetHashKeyFunc;
 		public static uint GetHashKey(string key)
 		{
 			IntPtr keyPtr = ScriptDomain.CurrentDomain.PinString(key);
@@ -1247,9 +1164,7 @@ namespace SHVDN
 		}
 
 		static ulong GetLabelTextByHashAddress;
-		delegate ulong GetLabelTextByHashFuncDelegate(ulong address, int labelHash);
-		static GetLabelTextByHashFuncDelegate GetLabelTextByHashFunc;
-
+		static delegate* unmanaged[Stdcall]<ulong, int, ulong> GetLabelTextByHashFunc;
 		public static string GetGXTEntryByHash(int entryLabelHash)
 		{
 			var entryText = (char*)GetLabelTextByHashFunc(GetLabelTextByHashAddress, entryLabelHash);
@@ -1257,9 +1172,7 @@ namespace SHVDN
 		}
 
 		#endregion
-
 		#region -- YSC Script Data --
-
 		[StructLayout(LayoutKind.Explicit)]
 		struct YscScriptHeader
 		{
@@ -1277,15 +1190,16 @@ namespace SHVDN
 			internal long* nativeOffset;
 			[FieldOffset(0x58)]
 			internal int nameHash;
-
 			internal int CodePageCount()
 			{
 				return (codeLength + 0x3FFF) >> 14;
 			}
+
 			internal int GetCodePageSize(int page)
 			{
 				return (page < 0 || page >= CodePageCount() ? 0 : (page == CodePageCount() - 1) ? codeLength & 0x3FFF : 0x4000);
 			}
+
 			internal IntPtr GetCodePageAddress(int page)
 			{
 				return new IntPtr(codeBlocksOffset[page]);
@@ -1299,7 +1213,6 @@ namespace SHVDN
 			internal YscScriptHeader* header;
 			[FieldOffset(0xC)]
 			internal int hash;
-
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			internal bool IsLoaded()
 			{
@@ -1314,13 +1227,13 @@ namespace SHVDN
 			internal YscScriptTableItem* TablePtr;
 			[FieldOffset(0x18)]
 			internal uint count;
-
 			internal YscScriptTableItem* FindScript(int hash)
 			{
 				if (TablePtr == null)
 				{
 					return null; //table initialisation hasnt happened yet
 				}
+
 				for (int i = 0; i < count; i++)
 				{
 					if (TablePtr[i].hash == hash)
@@ -1328,56 +1241,66 @@ namespace SHVDN
 						return &TablePtr[i];
 					}
 				}
+
 				return null;
 			}
 		}
 
-
 		#endregion
-
 		#region -- World Data --
-
 		static int* cursorSpriteAddr;
-
 		public static int CursorSprite
 		{
-			get { return *cursorSpriteAddr; }
+			get
+			{
+				return *cursorSpriteAddr;
+			}
 		}
 
 		static float* timeScaleAddress;
-
 		public static float TimeScale
 		{
-			get { return *timeScaleAddress; }
+			get
+			{
+				return *timeScaleAddress;
+			}
 		}
 
 		static int* millisecondsPerGameMinuteAddress;
-
 		public static int MillisecondsPerGameMinute
 		{
-			set { *millisecondsPerGameMinuteAddress = value; }
+			set
+			{
+				*millisecondsPerGameMinuteAddress = value;
+			}
 		}
 
 		static bool* isClockPausedAddress;
-
 		public static bool IsClockPaused
 		{
-			get { return *isClockPausedAddress; }
+			get
+			{
+				return *isClockPausedAddress;
+			}
 		}
 
 		static float* readWorldGravityAddress;
 		static float* writeWorldGravityAddress;
-
 		public static float WorldGravity
 		{
-			get { return *readWorldGravityAddress; }
-			set { *writeWorldGravityAddress = value; }
+			get
+			{
+				return *readWorldGravityAddress;
+			}
+
+			set
+			{
+				*writeWorldGravityAddress = value;
+			}
 		}
 
 		#endregion
-
 		#region -- Skeleton Data --
-
 		static CrSkeleton* GetCrSkeletonOfEntityHandle(int handle) => GetCrSkeletonOfEntity(new IntPtr((long)GetEntityAddressFunc(handle)));
 		static CrSkeleton* GetCrSkeletonOfEntity(IntPtr entityAddress)
 		{
@@ -1400,15 +1323,14 @@ namespace SHVDN
 				}
 			}
 		}
+
 		static CrSkeleton* GetEntityCrSkeletonOfFragInst(FragInst* fragInst)
 		{
 			var fragCacheEntry = fragInst->fragCacheEntry;
 			var gtaFragType = fragInst->gtaFragType;
-
 			// Check if either pointer is null just like native functions that take a bone index argument
 			if (fragCacheEntry == null || gtaFragType == null)
 				return null;
-
 			return fragCacheEntry->crSkeleton;
 		}
 
@@ -1417,15 +1339,14 @@ namespace SHVDN
 			var crSkeleton = GetCrSkeletonOfEntityHandle(handle);
 			return crSkeleton != null ? crSkeleton->boneCount : 0;
 		}
+
 		public static IntPtr GetEntityBonePoseAddress(int handle, int boneIndex)
 		{
 			if ((boneIndex & 0x80000000) != 0) // boneIndex cant be negative
 				return IntPtr.Zero;
-
 			var crSkeletonData = GetCrSkeletonOfEntityHandle(handle);
 			if (crSkeletonData == null)
 				return IntPtr.Zero;
-
 			if (boneIndex < crSkeletonData->boneCount)
 			{
 				return crSkeletonData->GetBonePoseMatrixAddress(boneIndex);
@@ -1433,15 +1354,14 @@ namespace SHVDN
 
 			return IntPtr.Zero;
 		}
+
 		public static IntPtr GetEntityBoneMatrixAddress(int handle, int boneIndex)
 		{
 			if ((boneIndex & 0x80000000) != 0) // boneIndex cant be negative
 				return IntPtr.Zero;
-
 			var crSkeletonData = GetCrSkeletonOfEntityHandle(handle);
 			if (crSkeletonData == null)
 				return IntPtr.Zero;
-
 			if (boneIndex < crSkeletonData->boneCount)
 			{
 				return crSkeletonData->GetBoneMatrixAddress(boneIndex);
@@ -1450,62 +1370,44 @@ namespace SHVDN
 			return IntPtr.Zero;
 		}
 
-		#endregion
-
-		#region -- CEntity Functions --
-
-		public delegate float* GetRotationFromMatrixDelegate(float* returnRotationArrayAddress, ulong matrixAddress, int rotationOrder);
-		public delegate int GetQuaternionFromMatrixDelegate(float* returnQuaternionArrayAddress, ulong matrixAddress);
-		static GetRotationFromMatrixDelegate GetRotationFromMatrixFunc;
-		static GetQuaternionFromMatrixDelegate GetQuaternionFromMatrixFunc;
-
+		static delegate* unmanaged[Stdcall]<float*, ulong, int, float*> GetRotationFromMatrixFunc;
+		static delegate* unmanaged[Stdcall]<float*, ulong, int> GetQuaternionFromMatrixFunc;
 		public static void GetRotationFromMatrix(float* returnRotationArray, IntPtr matrixAddress, int rotationOrder = 2)
 		{
 			GetRotationFromMatrixFunc(returnRotationArray, (ulong)matrixAddress.ToInt64(), rotationOrder);
-
 			const float RAD_2_DEG = 57.2957763671875f; // 0x42652EE0 in hex. Exactly the same value as the GET_ENTITY_ROTATION multiplies the rotation values in radian by.
 			returnRotationArray[0] *= RAD_2_DEG;
 			returnRotationArray[1] *= RAD_2_DEG;
 			returnRotationArray[2] *= RAD_2_DEG;
 		}
+
 		public static void GetQuaternionFromMatrix(float* returnRotationArray, IntPtr matrixAddress)
 		{
 			GetQuaternionFromMatrixFunc(returnRotationArray, (ulong)matrixAddress.ToInt64());
 		}
 
 		#endregion
-
 		#region -- CPhysical Offsets --
-
 		public static int EntityMaxHealthOffset { get; }
+
 		public static int SetAngularVelocityVFuncOfEntityOffset { get; }
+
 		public static int GetAngularVelocityVFuncOfEntityOffset { get; }
 
 		public static uint cAttackerArrayOfEntityOffset { get; }
+
 		public static uint elementCountOfCAttackerArrayOfEntityOffset { get; }
+
 		public static uint elementSizeOfCAttackerArrayOfEntity { get; }
-
-		#endregion
-
-		#region -- CPhysical Functions --
-
-		public delegate void SetEntityAngularVelocityDelegate(IntPtr entityAddress, float* angularVelocity);
-		// return value will be the address of the temporary 4 float storage
-		public delegate float* GetEntityAngularVelocityDelegate(IntPtr entityAddress);
-
-		// Only 2 virtural functions are present (one for peds and objects and one for vehicles)
-		static Dictionary<ulong, SetEntityAngularVelocityDelegate> setEntityAngularVelocityVFuncCache = new Dictionary<ulong, SetEntityAngularVelocityDelegate>(2);
-		static Dictionary<ulong, GetEntityAngularVelocityDelegate> getEntityAngularVelocityVFuncCache = new Dictionary<ulong, GetEntityAngularVelocityDelegate>(2);
 
 		internal class SetEntityAngularVelocityTask : IScriptTask
 		{
 			#region Fields
 			IntPtr entityAddress;
-			SetEntityAngularVelocityDelegate setAngularVelocityDelegate;
+			delegate* unmanaged[Stdcall]<IntPtr, float*, void> setAngularVelocityDelegate;
 			float x, y, z;
 			#endregion
-
-			internal SetEntityAngularVelocityTask(IntPtr entityAddress, SetEntityAngularVelocityDelegate vFuncDelegate, float x, float y, float z)
+			internal SetEntityAngularVelocityTask(IntPtr entityAddress, delegate* unmanaged[Stdcall]<IntPtr, float*, void> vFuncDelegate, float x, float y, float z)
 			{
 				this.entityAddress = entityAddress;
 				this.setAngularVelocityDelegate = vFuncDelegate;
@@ -1520,7 +1422,6 @@ namespace SHVDN
 				angularVelocity[0] = x;
 				angularVelocity[1] = y;
 				angularVelocity[2] = z;
-
 				setAngularVelocityDelegate(entityAddress, angularVelocity);
 			}
 		}
@@ -1528,54 +1429,20 @@ namespace SHVDN
 		public static float* GetEntityAngularVelocity(IntPtr entityAddress)
 		{
 			var vFuncAddr = *(ulong*)(*(ulong*)entityAddress.ToPointer() + (uint)GetAngularVelocityVFuncOfEntityOffset);
-			var getEntityAngularVelocity = CreateGetEntityAngularVelocityDelegateIfNotCreated(vFuncAddr);
-
+			var getEntityAngularVelocity = (delegate* unmanaged[Stdcall]<IntPtr, float*>)(vFuncAddr);
 			return getEntityAngularVelocity(entityAddress);
 		}
 
 		public static void SetEntityAngularVelocity(IntPtr entityAddress, float x, float y, float z)
 		{
 			var vFuncAddr = *(ulong*)(*(ulong*)entityAddress.ToPointer() + (uint)SetAngularVelocityVFuncOfEntityOffset);
-			var setEntityAngularVelocityDelegate = CreateSetEntityAngularVelocityDelegateIfNotCreated(vFuncAddr);
-
+			var setEntityAngularVelocityDelegate = (delegate* unmanaged[Stdcall]<IntPtr, float*, void>)(vFuncAddr);
 			var task = new SetEntityAngularVelocityTask(entityAddress, setEntityAngularVelocityDelegate, x, y, z);
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
 		}
 
-		static SetEntityAngularVelocityDelegate CreateSetEntityAngularVelocityDelegateIfNotCreated(ulong virtualFuncAddr)
-		{
-			if (setEntityAngularVelocityVFuncCache.TryGetValue(virtualFuncAddr, out var outDelegate))
-			{
-				return outDelegate;
-			}
-			else
-			{
-				var newDelegate = GetDelegateForFunctionPointer<SetEntityAngularVelocityDelegate>(new IntPtr((long)virtualFuncAddr));
-				setEntityAngularVelocityVFuncCache.Add(virtualFuncAddr, newDelegate);
-
-				return newDelegate;
-			}
-		}
-
-		static GetEntityAngularVelocityDelegate CreateGetEntityAngularVelocityDelegateIfNotCreated(ulong virtualFuncAddr)
-		{
-			if (getEntityAngularVelocityVFuncCache.TryGetValue(virtualFuncAddr, out var outDelegate))
-			{
-				return outDelegate;
-			}
-			else
-			{
-				var newDelegate = GetDelegateForFunctionPointer<GetEntityAngularVelocityDelegate>(new IntPtr((long)virtualFuncAddr));
-				getEntityAngularVelocityVFuncCache.Add(virtualFuncAddr, newDelegate);
-
-				return newDelegate;
-			}
-		}
-
 		#endregion
-
 		#region -- CPhysical Data --
-
 		// the size is at least 0x10 in all game versions
 		[StructLayout(LayoutKind.Explicit, Size = 0x10)]
 		struct CAttacker
@@ -1590,57 +1457,42 @@ namespace SHVDN
 
 		public static bool IsIndexOfEntityDamageRecordValid(IntPtr entityAddress, uint index)
 		{
-			if (index < 0 ||
-				cAttackerArrayOfEntityOffset == 0 ||
-				elementCountOfCAttackerArrayOfEntityOffset == 0 ||
-				elementSizeOfCAttackerArrayOfEntity == 0)
+			if (index < 0 || cAttackerArrayOfEntityOffset == 0 || elementCountOfCAttackerArrayOfEntityOffset == 0 || elementSizeOfCAttackerArrayOfEntity == 0)
 				return false;
-
 			ulong entityCAttackerArrayAddress = *(ulong*)(entityAddress + (int)cAttackerArrayOfEntityOffset).ToPointer();
-
 			if (entityCAttackerArrayAddress == 0)
 				return false;
-
 			var entryCount = *(int*)(entityCAttackerArrayAddress + elementCountOfCAttackerArrayOfEntityOffset);
-
 			return index < entryCount;
 		}
+
 		static (int attackerHandle, int weaponHash, int gameTime) GetEntityDamageRecordEntryAtIndexInternal(ulong cAttackerArrayAddress, uint index)
 		{
 			var cAttacker = (CAttacker*)(cAttackerArrayAddress + index * elementSizeOfCAttackerArrayOfEntity);
-
 			var attackerEntityAddress = cAttacker->attackerEntityAddress;
 			var weaponHash = cAttacker->weaponHash;
 			var gameTime = cAttacker->gameTime;
 			var attackerHandle = attackerEntityAddress != 0 ? GetEntityHandleFromAddress(new IntPtr((long)attackerEntityAddress)) : 0;
-
 			return (attackerHandle, weaponHash, gameTime);
 		}
+
 		public static (int attackerHandle, int weaponHash, int gameTime) GetEntityDamageRecordEntryAtIndex(IntPtr entityAddress, uint index)
 		{
 			ulong entityCAttackerArrayAddress = *(ulong*)(entityAddress + (int)cAttackerArrayOfEntityOffset).ToPointer();
-
 			if (entityCAttackerArrayAddress == 0)
 				return default((int attackerHandle, int weaponHash, int gameTime));
-
 			return GetEntityDamageRecordEntryAtIndexInternal(entityCAttackerArrayAddress, index);
 		}
 
 		public static (int attackerHandle, int weaponHash, int gameTime)[] GetEntityDamageRecordEntries(IntPtr entityAddress)
 		{
-			if (cAttackerArrayOfEntityOffset == 0 ||
-				elementCountOfCAttackerArrayOfEntityOffset == 0 ||
-				elementSizeOfCAttackerArrayOfEntity == 0)
+			if (cAttackerArrayOfEntityOffset == 0 || elementCountOfCAttackerArrayOfEntityOffset == 0 || elementSizeOfCAttackerArrayOfEntity == 0)
 				return Array.Empty<(int handle, int weaponHash, int gameTime)>();
-
 			ulong entityCAttackerArrayAddress = *(ulong*)(entityAddress + (int)cAttackerArrayOfEntityOffset).ToPointer();
-
 			if (entityCAttackerArrayAddress == 0)
 				return Array.Empty<(int attackerHandle, int weaponHash, int gameTime)>();
-
 			var returnEntrySize = *(int*)(entityCAttackerArrayAddress + elementCountOfCAttackerArrayOfEntityOffset);
 			var returnEntries = returnEntrySize != 0 ? new (int attackerHandle, int weaponHash, int gameTime)[returnEntrySize] : Array.Empty<(int attackerHandle, int weaponHash, int gameTime)>();
-
 			for (uint i = 0; i < returnEntries.Length; i++)
 			{
 				returnEntries[i] = GetEntityDamageRecordEntryAtIndexInternal(entityCAttackerArrayAddress, i);
@@ -1650,15 +1502,13 @@ namespace SHVDN
 		}
 
 		#endregion
-
 		#region -- CPed Data --
-
 		/// <summary>
 		/// <para>Gets the last vehicle the ped used or is using.</para>
 		/// <para>
 		/// This method exists because there are no reliable ways with native functions.
 		/// The native <c>GET_VEHICLE_PED_IS_IN</c> returns the last vehicle the ped used when not in vehicle (though the 2nd parameter name is supposed to be <c>ConsiderEnteringAsInVehicle</c> as a leaked header suggests),
-        /// but returns <c>0</c> when the ped is going to a door of some vehicle or opening one.
+		/// but returns <c>0</c> when the ped is going to a door of some vehicle or opening one.
 		/// Also, the native returns the vehicle's handle the ped is getting in when ped is getting in it, which is different from the last vehicle this method returns and the native <c>RESET_PED_LAST_VEHICLE</c> changes.
 		/// </para>
 		/// </summary>
@@ -1666,7 +1516,6 @@ namespace SHVDN
 		{
 			if (PedLastVehicleOffset == 0)
 				return 0;
-
 			var lastVehicleAddress = new IntPtr(*(long*)(pedAddress + PedLastVehicleOffset));
 			return lastVehicleAddress != IntPtr.Zero ? GetEntityHandleFromAddress(lastVehicleAddress) : 0;
 		}
@@ -1681,47 +1530,56 @@ namespace SHVDN
 		{
 			if (PedIsInVehicleOffset == 0 || PedLastVehicleOffset == 0)
 				return 0;
-
 			var bitFlags = *(uint*)(pedAddress + PedIsInVehicleOffset);
 			bool isPedInVehicle = ((bitFlags & (1 << 0x1E)) != 0);
 			if (!isPedInVehicle)
 				return 0;
-
 			var lastVehicleAddress = new IntPtr(*(long*)(pedAddress + PedLastVehicleOffset));
 			return lastVehicleAddress != IntPtr.Zero ? GetEntityHandleFromAddress(lastVehicleAddress) : 0;
 		}
 
 		#endregion
-
 		#region -- Vehicle Offsets --
-
 		public static int NextGearOffset { get; }
+
 		public static int GearOffset { get; }
+
 		public static int HighGearOffset { get; }
 
 		public static int CurrentRPMOffset { get; }
+
 		public static int ClutchOffset { get; }
+
 		public static int AccelerationOffset { get; }
 
 		public static int TurboOffset { get; }
 
 		public static int FuelLevelOffset { get; }
+
 		public static int OilLevelOffset { get; }
 
 		public static int VehicleTypeOffsetInCVehicle { get; }
 
 		public static int WheelPtrArrayOffset { get; }
+
 		public static int WheelCountOffset { get; }
+
 		public static int WheelBoneIdToPtrArrayIndexOffset { get; }
+
 		public static int WheelSpeedOffset { get; }
+
 		public static int CanWheelBreakOffset { get; }
 
 		public static int SteeringAngleOffset { get; }
+
 		public static int SteeringScaleOffset { get; }
+
 		public static int ThrottlePowerOffset { get; }
+
 		public static int BrakePowerOffset { get; }
 
 		public static int EngineTemperatureOffset { get; }
+
 		public static int EnginePowerMultiplierOffset { get; }
 
 		public static int DisablePretendOccupantOffset { get; }
@@ -1731,6 +1589,7 @@ namespace SHVDN
 		public static int VehicleLightsMultiplierOffset { get; }
 
 		public static int IsInteriorLightOnOffset { get; }
+
 		public static int IsEngineStartingOffset { get; }
 
 		public static int IsWantedOffset { get; }
@@ -1738,6 +1597,7 @@ namespace SHVDN
 		public static int IsHeadlightDamagedOffset { get; }
 
 		public static int PreviouslyOwnedByPlayerOffset { get; }
+
 		public static int NeedsToBeHotwiredOffset { get; }
 
 		public static int AlarmTimeOffset { get; }
@@ -1749,29 +1609,20 @@ namespace SHVDN
 		public static int HeliBladesSpeedOffset { get; }
 
 		public static int HeliMainRotorHealthOffset { get; }
+
 		public static int HeliTailRotorHealthOffset { get; }
+
 		public static int HeliTailBoomHealthOffset { get; }
 
 		public static int HandlingDataOffset { get; }
 
 		public static int FirstVehicleFlagsOffset { get; }
 
-		#endregion
-
-		#region -- Vehicle Wheel Data --
-
-		delegate void FixVehicleWheelDelegate(IntPtr wheelAddress);
-		delegate void PunctureVehicleTireNewDelegate(IntPtr wheelPtr, ulong unkPtr, float damage, ulong unkIntReturnPtrParam, ulong unkFloatReturnPtrParam, int unkIntParam, byte unkByteParam, [MarshalAs(UnmanagedType.I1)] bool someBoolFlagForMultiplayer);
-		delegate void PunctureVehicleTireOldDelegate(IntPtr wheelPtr, ulong unkPtr, float damage, IntPtr vehiclePtr, ulong unkIntReturnPtrParam, ulong unkFloatReturnPtrParam, int unkIntParam, byte unkByteParam, [MarshalAs(UnmanagedType.I1)] bool someBoolFlagForMultiplayer);
-		delegate void BurstVehicleTireOnRimNewDelegate(IntPtr wheelPtr);
-		delegate void BurstVehicleTireOnRimOldDelegate(IntPtr wheelPtr, IntPtr vehiclePtr);
-
-		static FixVehicleWheelDelegate FixVehicleWheelFunc;
-		static PunctureVehicleTireNewDelegate PunctureVehicleTireNewFunc;
-		static PunctureVehicleTireOldDelegate PunctureVehicleTireOldFunc;
-		static BurstVehicleTireOnRimNewDelegate BurstVehicleTireOnRimNewFunc;
-		static BurstVehicleTireOnRimOldDelegate BurstVehicleTireOnRimOldFunc;
-
+		static delegate* unmanaged[Stdcall]<IntPtr, void> FixVehicleWheelFunc;
+		static delegate* unmanaged[Stdcall]<IntPtr, ulong, float, ulong, ulong, int, byte, bool, void> PunctureVehicleTireNewFunc;
+		static delegate* unmanaged[Stdcall]<IntPtr, ulong, float, IntPtr, ulong, ulong, int, byte, bool, void> PunctureVehicleTireOldFunc;
+		static delegate* unmanaged[Stdcall]<IntPtr, void> BurstVehicleTireOnRimNewFunc;
+		static delegate* unmanaged[Stdcall]<IntPtr, IntPtr, void> BurstVehicleTireOnRimOldFunc;
 		public static int VehicleWheelSteeringLimitMultiplierOffset { get; }
 
 		public static int VehicleWheelTemperatureOffset { get; }
@@ -1790,14 +1641,11 @@ namespace SHVDN
 		public static int ShouldShowOnlyVehicleTiresWithPositiveHealthOffset { get; }
 
 		public static void FixVehicleWheel(IntPtr wheelAddress) => FixVehicleWheelFunc(wheelAddress);
-
 		public static IntPtr GetVehicleWheelAddressByIndexOfWheelArray(IntPtr vehicleAddress, int index)
 		{
 			var vehicleWheelArrayAddr = *(ulong**)(vehicleAddress + SHVDN.NativeMemory.WheelPtrArrayOffset);
-
 			if (vehicleWheelArrayAddr == null)
 				return IntPtr.Zero;
-
 			return new IntPtr((long)*(vehicleWheelArrayAddr + index));
 		}
 
@@ -1805,28 +1653,23 @@ namespace SHVDN
 		{
 			if (VehicleWheelTouchingFlagsOffset == 0)
 				return false;
-
 			var wheelTouchingFlag = *(uint*)(wheelAddress + VehicleWheelTouchingFlagsOffset).ToPointer();
 			if ((wheelTouchingFlag & 1) != 0)
 				return true;
-
 			#region Slower Check
 			if (((wheelTouchingFlag >> 1) & 1) == 0)
 				return false;
-
 			var phCollider = *(ulong*)(*(ulong*)(vehicleAddress + 0x50).ToPointer() + 0x50);
 			if (phCollider == 0)
 				return true;
 			var unkStructAddr = *(ulong*)(phCollider + 0x18);
 			if (unkStructAddr == 0)
 				return false;
-
 			return (*(uint*)(unkStructAddr + 0x14) & 0xFFFFFFFD) == 0;
 			#endregion
 		}
 
 		static bool VehicleWheelHasVehiclePtr() => PunctureVehicleTireNewFunc != null;
-
 		public static void PunctureTire(IntPtr wheelAddress, float damage, IntPtr vehicleAddress)
 		{
 			var task = new VehicleWheelPunctureTask(wheelAddress, vehicleAddress, false, damage);
@@ -1849,7 +1692,6 @@ namespace SHVDN
 			bool burstWheelCompletely;
 			float damage;
 			#endregion
-
 			internal VehicleWheelPunctureTask(IntPtr wheelAddress, IntPtr vehicleAddress, bool burstWheelCompletely, float damage = 1000f)
 			{
 				this.wheelAddress = wheelAddress;
@@ -1862,7 +1704,6 @@ namespace SHVDN
 			{
 				int outValInt;
 				float outValFloat;
-
 				if (VehicleWheelHasVehiclePtr())
 				{
 					PunctureVehicleTireNewFunc(wheelAddress, 0, damage, (ulong)&outValInt, (ulong)&outValFloat, 3, 0, true);
@@ -1879,9 +1720,7 @@ namespace SHVDN
 		}
 
 		#endregion
-
 		#region -- Ped Offsets --
-
 		public static int SweatOffset { get; }
 
 		// the same offset as the offset for SET_PED_CAN_BE_TARGETTED
@@ -1892,29 +1731,40 @@ namespace SHVDN
 		public static int ArmorOffset { get; }
 
 		public static int InjuryHealthThresholdOffset { get; }
+
 		public static int FatalInjuryHealthThresholdOffset { get; }
 
 		public static int PedIsInVehicleOffset { get; }
+
 		public static int PedLastVehicleOffset { get; }
+
 		public static int SeatIndexOffset { get; }
 
 		public static int PedSourceOfDeathOffset { get; }
+
 		public static int PedCauseOfDeathOffset { get; }
+
 		public static int PedTimeOfDeathOffset { get; }
 
 		#region -- Ped Intelligence Offsets --
-
 		public static int PedIntelligenceOffset { get; }
 
 		public static int FiringPatternOffset { get; }
 
 		public static int SeeingRangeOffset { get; }
+
 		public static int HearingRangeOffset { get; }
+
 		public static int VisualFieldMinAngleOffset { get; }
+
 		public static int VisualFieldMaxAngleOffset { get; }
+
 		public static int VisualFieldMinElevationAngleOffset { get; }
+
 		public static int VisualFieldMaxElevationAngleOffset { get; }
+
 		public static int VisualFieldPeripheralRangeOffset { get; }
+
 		public static int VisualFieldCenterAngleOffset { get; }
 
 		static int CTaskTreePedOffset { get; }
@@ -1924,11 +1774,8 @@ namespace SHVDN
 		static int CEventStackOffset { get; }
 
 		#endregion
-
 		#endregion
-
 		#region -- Model Info --
-
 		[StructLayout(LayoutKind.Sequential)]
 		struct HashNode
 		{
@@ -1948,6 +1795,7 @@ namespace SHVDN
 			Vehicle = 5,
 			Ped = 6
 		}
+
 		enum VehicleStructClassType
 		{
 			None = -1,
@@ -1967,6 +1815,7 @@ namespace SHVDN
 			Train = 0xE,
 			Submarine = 0xF
 		}
+
 		[Flags]
 		public enum VehicleFlag1 : ulong
 		{
@@ -1980,6 +1829,7 @@ namespace SHVDN
 			IsOffroadVehicle = 0x1000000000000,
 			IsBus = 0x400000000000000,
 		}
+
 		[Flags]
 		public enum VehicleFlag2 : ulong
 		{
@@ -2020,14 +1870,12 @@ namespace SHVDN
 		static ulong* modelInfoArrayPtr;
 		static ulong* cStreamingAddr;
 		static ulong* pedPersonalitiesArrayAddr;
-
 		static IntPtr FindCModelInfo(int modelHash)
 		{
 			for (HashNode* cur = ((HashNode**)modelHashTable)[(uint)(modelHash) % modelHashEntries]; cur != null; cur = cur->next)
 			{
 				if (cur->hash != modelHash)
 					continue;
-
 				ushort data = cur->data;
 				bool bitTest = ((*(int*)(modelNum2 + (ulong)(4 * data >> 5))) & (1 << (data & 0x1F))) != 0;
 				if (data < modelNum1 && bitTest)
@@ -2043,6 +1891,7 @@ namespace SHVDN
 
 			return IntPtr.Zero;
 		}
+
 		static ModelInfoClassType GetModelInfoClass(IntPtr address)
 		{
 			if (address != IntPtr.Zero)
@@ -2052,31 +1901,30 @@ namespace SHVDN
 
 			return ModelInfoClassType.Invalid;
 		}
+
 		static VehicleStructClassType GetVehicleStructClass(IntPtr modelInfoAddress)
 		{
 			if (GetModelInfoClass(modelInfoAddress) == ModelInfoClassType.Vehicle)
 			{
 				int typeInt = (*(int*)((byte*)modelInfoAddress.ToPointer() + VehicleTypeOffsetInModelInfo));
-
 				// Normalize the value to vehicle type range for b944 or later versions if current game version is earlier than b944.
 				// The values for CAmphibiousAutomobile and CAmphibiousQuadBike were inserted between those for CSubmarineCar and CHeli in b944.
 				if (GetGameVersion() < 28 && typeInt >= 6)
 					typeInt += 2;
-
 				return (VehicleStructClassType)typeInt;
 			}
 
 			return VehicleStructClassType.None;
 		}
+
 		public static int GetVehicleType(int modelHash)
 		{
 			var modelInfo = FindCModelInfo(modelHash);
-
 			if (modelInfo == IntPtr.Zero)
 				return -1;
-
 			return (int)GetVehicleStructClass(modelInfo);
 		}
+
 		static IntPtr GetModelInfo(IntPtr entityAddress)
 		{
 			if (entityAddress != IntPtr.Zero)
@@ -2086,6 +1934,7 @@ namespace SHVDN
 
 			return IntPtr.Zero;
 		}
+
 		static int GetModelHashFromFwArcheType(IntPtr fwArcheTypeAddress)
 		{
 			if (fwArcheTypeAddress != IntPtr.Zero)
@@ -2095,6 +1944,7 @@ namespace SHVDN
 
 			return 0;
 		}
+
 		public static int GetModelHashFromEntity(IntPtr entityAddress)
 		{
 			if (entityAddress != IntPtr.Zero)
@@ -2113,72 +1963,74 @@ namespace SHVDN
 		{
 			if (modelInfoArrayPtr == null || index < 0)
 				return IntPtr.Zero;
-
 			ulong modelInfoArrayFirstElemPtr = *modelInfoArrayPtr;
-
 			return new IntPtr(*(long*)(modelInfoArrayFirstElemPtr + index * 0x8));
 		}
+
 		public static List<int> GetLoadedAppropriateVehicleHashes()
 		{
 			return GetLoadedHashesOfModelList(0x2D00);
 		}
+
 		public static List<int> GetLoadedAppropriatePedHashes()
 		{
 			return GetLoadedHashesOfModelList(0x4504);
 		}
+
 		internal static List<int> GetLoadedHashesOfModelList(int startOffsetOfCStreaming)
 		{
 			if (modelInfoArrayPtr == null || cStreamingAddr == null)
 				return new List<int>();
-
 			var resultList = new List<int>();
-
 			const int MAX_MODEL_LIST_ELEMENT_COUNT = 256;
 			var modelSet = (CModelList*)((ulong)cStreamingAddr + (uint)startOffsetOfCStreaming);
 			for (uint i = 0; i < MAX_MODEL_LIST_ELEMENT_COUNT; i++)
 			{
 				uint indexOfModelInfo = modelSet->modelMemberIndices[i];
-
 				if (indexOfModelInfo == 0xFFFF)
 					break;
-
 				resultList.Add(GetModelHashFromFwArcheType(GetModelInfoByIndex(indexOfModelInfo)));
 			}
 
 			return resultList;
 		}
 
-
 		public static bool IsModelAPed(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetModelInfoClass(modelInfo) == ModelInfoClassType.Ped;
 		}
+
 		public static bool IsModelABlimp(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Blimp;
 		}
+
 		public static bool IsModelAMotorcycle(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Bike;
 		}
+
 		public static bool IsModelASubmarine(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Submarine;
 		}
+
 		public static bool IsModelASubmarineCar(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.SubmarineCar;
 		}
+
 		public static bool IsModelATrailer(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Trailer;
 		}
+
 		public static bool IsModelAMlo(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
@@ -2188,7 +2040,6 @@ namespace SHVDN
 		public static string GetVehicleMakeName(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
-
 			if (GetModelInfoClass(modelInfo) == ModelInfoClassType.Vehicle)
 			{
 				return PtrToStringUTF8(modelInfo + vehicleMakeNameOffsetInModelInfo);
@@ -2203,9 +2054,7 @@ namespace SHVDN
 		{
 			if (FirstVehicleFlagsOffset == 0)
 				return false;
-
 			IntPtr modelInfo = FindCModelInfo(modelHash);
-
 			if (GetModelInfoClass(modelInfo) == ModelInfoClassType.Vehicle)
 			{
 				var modelFlags = *(ulong*)(modelInfo + FirstVehicleFlagsOffset + flagOffset).ToPointer();
@@ -2216,25 +2065,24 @@ namespace SHVDN
 		}
 
 		public static ReadOnlyCollection<int> WeaponModels { get; }
+
 		public static ReadOnlyCollection<ReadOnlyCollection<int>> VehicleModels { get; }
+
 		public static ReadOnlyCollection<ReadOnlyCollection<int>> VehicleModelsGroupedByType { get; }
+
 		public static ReadOnlyCollection<int> PedModels { get; }
 
-		delegate ulong GetHandlingDataByHashDelegate(IntPtr hashAddress);
-		delegate ulong GetHandlingDataByIndexDelegate(int index);
-
-		static GetHandlingDataByHashDelegate GetHandlingDataByHash;
-		static GetHandlingDataByIndexDelegate GetHandlingDataByIndex;
-
+		static delegate* unmanaged[Stdcall]<IntPtr, ulong> GetHandlingDataByHash;
+		static delegate* unmanaged[Stdcall]<int, ulong> GetHandlingDataByIndex;
 		public static IntPtr GetHandlingDataByModelHash(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			if (GetModelInfoClass(modelInfo) != ModelInfoClassType.Vehicle)
 				return IntPtr.Zero;
-
 			int handlingIndex = *(int*)(modelInfo + handlingIndexOffsetInModelInfo).ToPointer();
 			return new IntPtr((long)GetHandlingDataByIndex(handlingIndex));
 		}
+
 		public static IntPtr GetHandlingDataByHandlingNameHash(int handlingNameHash)
 		{
 			return new IntPtr((long)GetHandlingDataByHash(new IntPtr(&handlingNameHash)));
@@ -2242,71 +2090,58 @@ namespace SHVDN
 
 		private static PedPersonality* GetPedPersonalityElementAddress(IntPtr modelInfoAddress)
 		{
-			if (modelInfoAddress == IntPtr.Zero ||
-				pedPersonalitiesArrayAddr == null ||
-				pedPersonalityIndexOffsetInModelInfo == 0 ||
-				*(ulong*)pedPersonalitiesArrayAddr == 0)
+			if (modelInfoAddress == IntPtr.Zero || pedPersonalitiesArrayAddr == null || pedPersonalityIndexOffsetInModelInfo == 0 || *(ulong*)pedPersonalitiesArrayAddr == 0)
 				return null;
-
 			if (GetModelInfoClass(modelInfoAddress) != ModelInfoClassType.Ped)
 				return null;
-
 			// This values is not likely to be changed in further updates
 			const int PED_PERSONALITY_ELEMENT_SIZE = 0xB8;
-
 			var indexOfPedPersonality = *(ushort*)(modelInfoAddress + pedPersonalityIndexOffsetInModelInfo).ToPointer();
 			return (PedPersonality*)(*(ulong*)pedPersonalitiesArrayAddr + (uint)(indexOfPedPersonality * PED_PERSONALITY_ELEMENT_SIZE));
 		}
+
 		public static bool IsModelAMalePed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
-
 			if (pedPersonalityAddress == null)
 				return false;
-
 			return pedPersonalityAddress->isMale;
 		}
+
 		public static bool IsModelAFemalePed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
-
 			if (pedPersonalityAddress == null)
 				return false;
-
 			return !pedPersonalityAddress->isMale;
 		}
+
 		public static bool IsModelHumanPed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
-
 			if (pedPersonalityAddress == null)
 				return false;
-
 			return pedPersonalityAddress->isHuman;
 		}
+
 		public static bool IsModelAnAnimalPed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
-
 			if (pedPersonalityAddress == null)
 				return false;
-
 			return !pedPersonalityAddress->isHuman;
 		}
+
 		public static bool IsModelAGangPed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
-
 			if (pedPersonalityAddress == null)
 				return false;
-
 			return pedPersonalityAddress->isGang;
 		}
 
 		#endregion
-
 		#region -- Entity Pools --
-
 		[StructLayout(LayoutKind.Explicit)]
 		struct EntityPool
 		{
@@ -2314,7 +2149,6 @@ namespace SHVDN
 			internal uint num1;
 			[FieldOffset(0x20)]
 			internal uint num2;
-
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			internal bool IsFull()
 			{
@@ -2333,7 +2167,6 @@ namespace SHVDN
 			internal uint* bitArray;
 			[FieldOffset(0x60)]
 			internal uint itemCount;
-
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			internal bool IsValid(uint i)
 			{
@@ -2360,7 +2193,6 @@ namespace SHVDN
 			public uint itemSize;
 			[FieldOffset(0x20)]
 			public ushort itemCount;
-
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			public bool IsValid(uint index)
 			{
@@ -2398,11 +2230,9 @@ namespace SHVDN
 			{
 				if (address < poolStartAddress || address >= poolStartAddress + size * itemSize)
 					return 0;
-
 				var offset = address - poolStartAddress;
 				if (offset % itemSize != 0)
 					return 0;
-
 				var indexOfPool = (uint)(offset / itemSize);
 				return (int)((indexOfPool << 8) + GetCounter(indexOfPool));
 			}
@@ -2438,21 +2268,13 @@ namespace SHVDN
 		static ulong* AnimatedBuildingPoolAddress;
 		static ulong* InteriorInstPoolAddress;
 		static ulong* InteriorProxyPoolAddress;
-
 		static ulong* ProjectilePoolAddress;
 		static int* ProjectileCountAddress;
-
-		delegate ulong EntityPosFuncDelegate(ulong address, float* position);
-		delegate ulong EntityModel1FuncDelegate(ulong address);
-		delegate ulong EntityModel2FuncDelegate(ulong address);
-		delegate int AddEntityToPoolFuncDelegate(ulong address);
-
 		// if the entity is a ped and they are in a vehicle, the vehicle position will be returned instead (just like GET_ENTITY_COORDS does)
-		static EntityPosFuncDelegate EntityPosFunc;
-		static EntityModel1FuncDelegate EntityModel1Func;
-		static EntityModel2FuncDelegate EntityModel2Func;
-		static AddEntityToPoolFuncDelegate AddEntityToPoolFunc;
-
+		static delegate* unmanaged[Stdcall]<ulong, float*, ulong> EntityPosFunc;
+		static delegate* unmanaged[Stdcall]<ulong, ulong> EntityModel1Func;
+		static delegate* unmanaged[Stdcall]<ulong, ulong> EntityModel2Func;
+		static delegate* unmanaged[Stdcall]<ulong, int> AddEntityToPoolFunc;
 		internal class EntityPoolTask : IScriptTask
 		{
 			#region Fields
@@ -2463,7 +2285,6 @@ namespace SHVDN
 			internal int[] modelHashes;
 			internal float radiusSquared;
 			internal float[] position;
-
 			// We should avoid wasting (temp) arrays many times by casually using List, but ArrayPool is not available in .NET Framework. So prepare resource pools manually
 			static int[] _vehicleHandleBuffer;
 			static int[] _pedHandleBuffer;
@@ -2471,7 +2292,6 @@ namespace SHVDN
 			static int[] _pickupObjectHandleBuffer;
 			static int[] _projectileHandleBuffer = new int[50];
 			#endregion
-
 			internal enum Type
 			{
 				Ped = 1,
@@ -2491,16 +2311,13 @@ namespace SHVDN
 			{
 				if (address == 0)
 					return false;
-
 				if (doPosCheck)
 				{
 					float* position = stackalloc float[4];
-
 					NativeMemory.EntityPosFunc(address, position);
 					float x = this.position[0] - position[0];
 					float y = this.position[1] - position[1];
 					float z = this.position[2] - position[2];
-
 					float distanceSquared = (x * x) + (y * y) + (z * z);
 					if (distanceSquared > radiusSquared)
 						return false;
@@ -2519,13 +2336,11 @@ namespace SHVDN
 			int CopyCPhysicalHandlesFromArrayGenericPool(GenericPool* pool, ref int[] handleBuffer)
 			{
 				int returnEntityCount = 0;
-
 				uint entityCountInPool = pool->itemCount;
 				if (handleBuffer == null)
 					handleBuffer = new int[(int)entityCountInPool * 2];
 				else if (entityCountInPool > handleBuffer.Length)
 					handleBuffer = new int[CalculateAppropriateExtendedArrayLength(handleBuffer, (int)entityCountInPool)];
-
 				uint poolSize = pool->size;
 				for (uint i = 0; i < poolSize; i++)
 				{
@@ -2544,27 +2359,22 @@ namespace SHVDN
 			{
 				if (*NativeMemory.EntityPoolAddress == 0)
 					return;
-
 				EntityPool* entityPool = (EntityPool*)(*NativeMemory.EntityPoolAddress);
-
 				#region Store Entity Handles to Buffer Arrays
 				int vehicleCountStored = 0;
 				if (HasFlagFast(poolType, Type.Vehicle) && *NativeMemory.VehiclePoolAddress != 0)
 				{
 					VehiclePool* vehiclePool = *(VehiclePool**)(*NativeMemory.VehiclePoolAddress);
-
 					uint vehicleCountInPool = vehiclePool->itemCount;
 					if (_vehicleHandleBuffer == null)
 						_vehicleHandleBuffer = new int[(int)vehicleCountInPool * 2];
 					else if (_vehicleHandleBuffer == null || vehicleCountInPool > _vehicleHandleBuffer.Length)
 						_vehicleHandleBuffer = new int[CalculateAppropriateExtendedArrayLength(_vehicleHandleBuffer, (int)vehicleCountInPool)];
-
 					uint poolSize = vehiclePool->size;
 					for (uint i = 0; i < poolSize; i++)
 					{
 						if (entityPool->IsFull())
 							break;
-
 						if (vehiclePool->IsValid(i))
 						{
 							ulong address = vehiclePool->GetAddress(i);
@@ -2601,63 +2411,60 @@ namespace SHVDN
 					int projectilesLeft = NativeMemory.GetProjectileCount();
 					int projectileCapacity = NativeMemory.GetProjectileCapacity();
 					ulong* projectilePoolAddress = NativeMemory.ProjectilePoolAddress;
-
 					int projectileCountInPool = projectilesLeft;
 					if (_projectileHandleBuffer == null)
 						_projectileHandleBuffer = new int[(int)projectileCountInPool * 2];
 					else if (projectileCountInPool > _projectileHandleBuffer.Length)
 						_projectileHandleBuffer = new int[CalculateAppropriateExtendedArrayLength(_projectileHandleBuffer, (int)projectileCountInPool)];
-
 					for (uint i = 0; (projectilesLeft > 0 && i < projectileCapacity); i++)
 					{
 						ulong entityAddress = (ulong)ReadAddress(new IntPtr(projectilePoolAddress + i)).ToInt64();
-
 						if (entityAddress == 0)
 							continue;
-
 						projectilesLeft--;
-
 						if (CheckEntity(entityAddress))
 							AddElementAndReallocateIfLengthIsNotLongEnough(ref _projectileHandleBuffer, projectileCountStored++, NativeMemory.AddEntityToPoolFunc(entityAddress));
 					}
 				}
-				#endregion
 
+				#endregion
 				#region Copy Entity Handles to a New Result Array
 				int totalEntityCount = vehicleCountStored + pedCountStored + objectCountStored + pickupCountStored + projectileCountStored;
 				if (totalEntityCount == 0)
 					return;
-
 				handles = new int[totalEntityCount];
 				int currentStartIndexToCopy = 0;
-
 				if (vehicleCountStored != 0)
 				{
 					Array.Copy(_vehicleHandleBuffer, 0, handles, currentStartIndexToCopy, vehicleCountStored);
 					currentStartIndexToCopy += vehicleCountStored;
 				}
+
 				if (pedCountStored != 0)
 				{
 					Array.Copy(_pedHandleBuffer, 0, handles, currentStartIndexToCopy, pedCountStored);
 					currentStartIndexToCopy += pedCountStored;
 				}
+
 				if (objectCountStored != 0)
 				{
 					Array.Copy(_objectHandleBuffer, 0, handles, currentStartIndexToCopy, objectCountStored);
 					currentStartIndexToCopy += objectCountStored;
 				}
+
 				if (pickupCountStored != 0)
 				{
 					Array.Copy(_pickupObjectHandleBuffer, 0, handles, currentStartIndexToCopy, pickupCountStored);
 					currentStartIndexToCopy += pickupCountStored;
 				}
+
 				if (projectileCountStored != 0)
 				{
 					Array.Copy(_projectileHandleBuffer, 0, handles, currentStartIndexToCopy, projectileCountStored);
 					currentStartIndexToCopy += projectileCountStored;
 				}
-				#endregion
 
+				#endregion
 				// Enum.HasFlag causes the boxing in .NET Framework and much slower than manually comparing enum flags with bitwise AND
 				bool HasFlagFast(Type poolTypeValue, Type flag) => (poolTypeValue & flag) == flag;
 			}
@@ -2669,7 +2476,6 @@ namespace SHVDN
 			internal ulong entityAddress;
 			internal int returnEntityHandle;
 			#endregion
-
 			internal GetEntityHandleTask(IntPtr entityAddress)
 			{
 				this.entityAddress = (ulong)entityAddress.ToInt64();
@@ -2688,8 +2494,10 @@ namespace SHVDN
 				VehiclePool* pool = *(VehiclePool**)(*VehiclePoolAddress);
 				return (int)pool->itemCount;
 			}
+
 			return 0;
 		}
+
 		public static int GetPedCount() => PedPoolAddress != null ? GetGenericPoolCount(*PedPoolAddress) : 0;
 		public static int GetObjectCount() => ObjectPoolAddress != null ? GetGenericPoolCount(*ObjectPoolAddress) : 0;
 		public static int GetPickupObjectCount() => PickupObjectPoolAddress != null ? GetGenericPoolCount(*PickupObjectPoolAddress) : 0;
@@ -2711,8 +2519,10 @@ namespace SHVDN
 				VehiclePool* pool = *(VehiclePool**)(*VehiclePoolAddress);
 				return (int)pool->size;
 			}
+
 			return 0;
 		}
+
 		public static int GetPedCapacity() => PedPoolAddress != null ? GetGenericPoolCapacity(*PedPoolAddress) : 0;
 		public static int GetObjectCapacity() => ObjectPoolAddress != null ? GetGenericPoolCapacity(*ObjectPoolAddress) : 0;
 		public static int GetPickupObjectCapacity() => PickupObjectPoolAddress != null ? GetGenericPoolCapacity(*PickupObjectPoolAddress) : 0;
@@ -2733,11 +2543,10 @@ namespace SHVDN
 			var task = new EntityPoolTask(EntityPoolTask.Type.Ped);
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
+
 		public static int[] GetPedHandles(float[] position, float radius, int[] modelHashes = null)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Ped);
@@ -2746,9 +2555,7 @@ namespace SHVDN
 			task.doPosCheck = true;
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
 
@@ -2757,11 +2564,10 @@ namespace SHVDN
 			var task = new EntityPoolTask(EntityPoolTask.Type.Object);
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
+
 		public static int[] GetPropHandles(float[] position, float radius, int[] modelHashes = null)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Object);
@@ -2770,29 +2576,24 @@ namespace SHVDN
 			task.doPosCheck = true;
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
 
 		public static int[] GetEntityHandles()
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Ped | EntityPoolTask.Type.Object | EntityPoolTask.Type.Vehicle);
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
+
 		public static int[] GetEntityHandles(float[] position, float radius)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Ped | EntityPoolTask.Type.Object | EntityPoolTask.Type.Vehicle);
 			task.position = position;
 			task.radiusSquared = radius * radius;
 			task.doPosCheck = true;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
 
@@ -2801,11 +2602,10 @@ namespace SHVDN
 			var task = new EntityPoolTask(EntityPoolTask.Type.Vehicle);
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
+
 		public static int[] GetVehicleHandles(float[] position, float radius, int[] modelHashes = null)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Vehicle);
@@ -2814,48 +2614,41 @@ namespace SHVDN
 			task.doPosCheck = true;
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
 
 		public static int[] GetPickupObjectHandles()
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.PickupObject);
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
+
 		public static int[] GetPickupObjectHandles(float[] position, float radius)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.PickupObject);
 			task.position = position;
 			task.radiusSquared = radius * radius;
 			task.doPosCheck = true;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
+
 		public static int[] GetProjectileHandles()
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Projectile);
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
+
 		public static int[] GetProjectileHandles(float[] position, float radius)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Projectile);
 			task.position = position;
 			task.radiusSquared = radius * radius;
 			task.doPosCheck = true;
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.handles;
 		}
 
@@ -2863,7 +2656,6 @@ namespace SHVDN
 		{
 			if (BuildingPoolAddress == null)
 				return Array.Empty<int>();
-
 			return GetHandlesInGenericPool(*NativeMemory.BuildingPoolAddress);
 		}
 
@@ -2871,7 +2663,6 @@ namespace SHVDN
 		{
 			if (BuildingPoolAddress == null)
 				return Array.Empty<int>();
-
 			return GetCEntityHandlesInRange(*NativeMemory.BuildingPoolAddress, position, radius);
 		}
 
@@ -2879,7 +2670,6 @@ namespace SHVDN
 		{
 			if (AnimatedBuildingPoolAddress == null)
 				return Array.Empty<int>();
-
 			return GetHandlesInGenericPool(*NativeMemory.AnimatedBuildingPoolAddress);
 		}
 
@@ -2887,7 +2677,6 @@ namespace SHVDN
 		{
 			if (AnimatedBuildingPoolAddress == null)
 				return Array.Empty<int>();
-
 			return GetCEntityHandlesInRange(*NativeMemory.AnimatedBuildingPoolAddress, position, radius);
 		}
 
@@ -2895,7 +2684,6 @@ namespace SHVDN
 		{
 			if (InteriorInstPoolAddress == null)
 				return Array.Empty<int>();
-
 			return GetHandlesInGenericPool(*NativeMemory.InteriorInstPoolAddress);
 		}
 
@@ -2903,7 +2691,6 @@ namespace SHVDN
 		{
 			if (InteriorInstPoolAddress == null)
 				return Array.Empty<int>();
-
 			return GetCEntityHandlesInRange(*NativeMemory.InteriorInstPoolAddress, position, radius);
 		}
 
@@ -2911,7 +2698,6 @@ namespace SHVDN
 		{
 			if (InteriorProxyPoolAddress == null)
 				return Array.Empty<int>();
-
 			return GetHandlesInGenericPool(*NativeMemory.InteriorProxyPoolAddress);
 		}
 
@@ -2919,9 +2705,7 @@ namespace SHVDN
 		{
 			if (InteriorProxyPoolAddress == null)
 				return Array.Empty<int>();
-
 			GenericPool* pool = (GenericPool*)(*NativeMemory.InteriorProxyPoolAddress);
-
 			// CInteriorProxy is not a subclass of CEntity and position data is placed at different offset
 			var returnHandles = new List<int>();
 			var poolSize = pool->size;
@@ -2930,17 +2714,13 @@ namespace SHVDN
 			{
 				if (!pool->IsValid(i))
 					continue;
-
 				var address = pool->GetAddress(i);
-
 				float x = *(float*)(address + 0x70) - position[0];
 				float y = *(float*)(address + 0x74) - position[1];
 				float z = *(float*)(address + 0x78) - position[2];
-
 				float distanceSquared = (x * x) + (y * y) + (z * z);
 				if (distanceSquared > radiusSquared)
 					continue;
-
 				returnHandles.Add(pool->GetGuidHandleByIndex(i));
 			}
 
@@ -2950,9 +2730,7 @@ namespace SHVDN
 		public static int GetEntityHandleFromAddress(IntPtr address)
 		{
 			var task = new GetEntityHandleTask(address);
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.returnEntityHandle;
 		}
 
@@ -2960,11 +2738,9 @@ namespace SHVDN
 		public static bool AnimatedBuildingHandleExists(int handle) => AnimatedBuildingPoolAddress != null ? ((GenericPool*)(*AnimatedBuildingPoolAddress))->IsHandleValid(handle) : false;
 		public static bool InteriorInstHandleExists(int handle) => InteriorInstPoolAddress != null ? ((GenericPool*)(*InteriorInstPoolAddress))->IsHandleValid(handle) : false;
 		public static bool InteriorProxyHandleExists(int handle) => InteriorProxyPoolAddress != null ? ((GenericPool*)(*InteriorProxyPoolAddress))->IsHandleValid(handle) : false;
-
 		static int[] GetHandlesInGenericPool(ulong poolAddress)
 		{
 			GenericPool* pool = (GenericPool*)poolAddress;
-
 			var returnHandles = new List<int>(pool->itemCount);
 			var poolSize = pool->size;
 			for (uint i = 0; i < poolSize; i++)
@@ -2981,7 +2757,6 @@ namespace SHVDN
 		static int[] GetCEntityHandlesInRange(ulong poolAddress, float[] position, float radius)
 		{
 			GenericPool* pool = (GenericPool*)poolAddress;
-
 			var returnHandles = new List<int>();
 			var poolSize = pool->size;
 			float radiusSquared = radius * radius;
@@ -2989,20 +2764,15 @@ namespace SHVDN
 			{
 				if (!pool->IsValid(i))
 					continue;
-
 				var address = pool->GetAddress(i);
-
 				float* entityPosition = stackalloc float[4];
-
 				NativeMemory.EntityPosFunc(address, entityPosition);
 				float x = entityPosition[0] - position[0];
 				float y = entityPosition[1] - position[1];
 				float z = entityPosition[2] - position[2];
-
 				float distanceSquared = (x * x) + (y * y) + (z * z);
 				if (distanceSquared > radiusSquared)
 					continue;
-
 				returnHandles.Add(pool->GetGuidHandleByIndex(i));
 			}
 
@@ -3017,7 +2787,6 @@ namespace SHVDN
 				var newArray = new int[array.Length * 2];
 				Array.Copy(array, newArray, array.Length);
 				newArray[index] = elementToAdd;
-
 				array = newArray;
 			}
 			else
@@ -3032,15 +2801,12 @@ namespace SHVDN
 		}
 
 		#endregion
-
 		#region -- Radar Blip Pool --
-
 		static ulong* RadarBlipPoolAddress;
 		static int* PossibleRadarBlipCountAddress;
 		static int* UnkFirstRadarBlipIndexAddress;
 		static int* NorthRadarBlipHandleAddress;
 		static int* CenterRadarBlipHandleAddress;
-
 		static bool CheckBlip(ulong blipAddress, float[] position, float radius, params int[] spriteTypes)
 		{
 			if (spriteTypes.Length > 0)
@@ -3053,17 +2819,14 @@ namespace SHVDN
 			if (position != null && radius > 0f)
 			{
 				float* blipPosition = stackalloc float[3];
-
 				blipPosition[0] = *(float*)(blipAddress + 0x10);
 				blipPosition[1] = *(float*)(blipAddress + 0x14);
 				blipPosition[2] = *(float*)(blipAddress + 0x18);
-
 				float x = blipPosition[0] - position[0];
 				float y = blipPosition[1] - position[1];
 				float z = blipPosition[2] - position[2];
 				float distanceSquared = (x * x) + (y * y) + (z * z);
 				float radiusSquared = radius * radius;
-
 				if (distanceSquared > radiusSquared)
 					return false;
 			}
@@ -3078,6 +2841,7 @@ namespace SHVDN
 			{
 				return -1;
 			}
+
 			ushort blipIndex = (ushort)handle;
 			ulong blipAddress = *(RadarBlipPoolAddress + blipIndex);
 			if (blipAddress == 0)
@@ -3093,10 +2857,12 @@ namespace SHVDN
 
 			return (short)blipIndex;
 		}
+
 		public static int[] GetNonCriticalRadarBlipHandles(params int[] spriteTypes)
 		{
 			return GetNonCriticalRadarBlipHandles(null, 0f, spriteTypes);
 		}
+
 		public static int[] GetNonCriticalRadarBlipHandles(float[] position = null, float radius = 0f, params int[] spriteTypes)
 		{
 			if (RadarBlipPoolAddress == null)
@@ -3108,18 +2874,14 @@ namespace SHVDN
 			int unkFirstBlipIndex = *UnkFirstRadarBlipIndexAddress;
 			int northBlipIndex = GetBlipIndexIfHandleIsValid(*NorthRadarBlipHandleAddress);
 			int centerBlipIndex = GetBlipIndexIfHandleIsValid(*CenterRadarBlipHandleAddress);
-
 			var handles = new List<int>(possibleBlipCount);
-
 			// Skip the 3 critical blips, just like GET_FIRST_BLIP_INFO_ID does
 			// The 3 critical blips is the north blip, the center blip, and the unknown simple blip (placeholder?).
 			for (int i = 0; i < possibleBlipCount; i++)
 			{
 				ulong address = *(RadarBlipPoolAddress + i);
-
 				if (address == 0 || i == unkFirstBlipIndex || i == northBlipIndex || i == centerBlipIndex)
 					continue;
-
 				if (CheckBlip(address, position, radius, spriteTypes))
 				{
 					ushort blipCreationIncrement = *(ushort*)(address + 8);
@@ -3131,7 +2893,6 @@ namespace SHVDN
 		}
 
 		public static int GetNorthBlip() => NorthRadarBlipHandleAddress != null ? *NorthRadarBlipHandleAddress : 0;
-
 		public static IntPtr GetBlipAddress(int handle)
 		{
 			if (RadarBlipPoolAddress == null)
@@ -3141,26 +2902,20 @@ namespace SHVDN
 
 			int poolIndexOfHandle = handle & 0xFFFF;
 			int possibleBlipCount = *PossibleRadarBlipCountAddress;
-
 			if (poolIndexOfHandle >= possibleBlipCount)
 			{
 				return IntPtr.Zero;
 			}
 
 			ulong address = *(RadarBlipPoolAddress + poolIndexOfHandle);
-
 			if (address != 0 && IsBlipCreationIncrementValid(address, handle))
 				return new IntPtr((long)address);
-
 			return IntPtr.Zero;
-
 			bool IsBlipCreationIncrementValid(ulong blipAddress, int blipHandle) => *(ushort*)(blipAddress + 8) == (((uint)blipHandle >> 0x10));
 		}
 
 		#endregion
-
 		#region -- CScriptResource Data --
-
 		internal enum CScriptResourceTypeNameIndex
 		{
 			Checkpoint = 6
@@ -3188,11 +2943,9 @@ namespace SHVDN
 			#region Fields
 			internal CScriptResourceTypeNameIndex typeNameIndex;
 			internal int[] returnHandles = Array.Empty<int>();
-
 			const int MAX_CHECKPOINT_COUNT = 64; // hard coded in the exe
 			static readonly int[] _cScriptResourceHandleBuffer = new int[MAX_CHECKPOINT_COUNT];
 			#endregion
-
 			internal GetAllCScriptResourceHandlesTask(CScriptResourceTypeNameIndex typeNameIndex)
 			{
 				this.typeNameIndex = typeNameIndex;
@@ -3201,23 +2954,19 @@ namespace SHVDN
 			public void Run()
 			{
 				var cGameScriptHandlerAddress = GetCGameScriptHandlerAddressFunc();
-
 				if (cGameScriptHandlerAddress == 0)
 					return;
-
 				int elementCount = 0;
 				var firstRegisteredScriptResourceItem = *(CGameScriptResource**)(cGameScriptHandlerAddress + 48);
 				for (CGameScriptResource* item = firstRegisteredScriptResourceItem; item != null; item = item->next)
 				{
 					if (item->resourceTypeNameIndex != typeNameIndex)
 						continue;
-
 					_cScriptResourceHandleBuffer[elementCount++] = item->counterOfPool;
 				}
 
 				if (elementCount == 0)
 					return;
-
 				returnHandles = new int[elementCount];
 				Array.Copy(_cScriptResourceHandleBuffer, returnHandles, elementCount);
 			}
@@ -3231,7 +2980,6 @@ namespace SHVDN
 			internal int elementSize;
 			internal IntPtr returnAddress;
 			#endregion
-
 			internal GetCScriptResourceAddressTask(int handle, ulong* poolAddress, int elementSize)
 			{
 				this.targetHandle = handle;
@@ -3242,10 +2990,8 @@ namespace SHVDN
 			public void Run()
 			{
 				var cGameScriptHandlerAddress = GetCGameScriptHandlerAddressFunc();
-
 				if (cGameScriptHandlerAddress == 0)
 					return;
-
 				var firstRegisteredScriptResourceItem = *(CGameScriptResource**)(cGameScriptHandlerAddress + 48);
 				for (CGameScriptResource* item = firstRegisteredScriptResourceItem; item != null; item = item->next)
 				{
@@ -3259,49 +3005,32 @@ namespace SHVDN
 		}
 
 		#endregion
-
 		#region -- Checkpoint Pool --
-
 		static ulong* CheckpointPoolAddress;
-
-		delegate ulong GetCGameScriptHandlerAddressDelegate();
-		static GetCGameScriptHandlerAddressDelegate GetCGameScriptHandlerAddressFunc;
-
+		static delegate* unmanaged[Stdcall]<ulong> GetCGameScriptHandlerAddressFunc;
 		public static int[] GetCheckpointHandles()
 		{
 			var task = new GetAllCScriptResourceHandlesTask(CScriptResourceTypeNameIndex.Checkpoint);
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.returnHandles;
 		}
 
 		public static IntPtr GetCheckpointAddress(int handle)
 		{
 			var task = new GetCScriptResourceAddressTask(handle, CheckpointPoolAddress, 0x60);
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.returnAddress;
 		}
 
-		#endregion
-
-		#region -- Waypoint Info Array --
-
-		delegate ulong GetLocalPlayerPedAddressFuncDelegate();
 		static ulong* waypointInfoArrayStartAddress;
 		static ulong* waypointInfoArrayEndAddress;
-		static GetLocalPlayerPedAddressFuncDelegate GetLocalPlayerPedAddressFunc;
-
+		static delegate* unmanaged[Stdcall]<ulong> GetLocalPlayerPedAddressFunc;
 		public static int GetWaypointBlip()
 		{
 			if (waypointInfoArrayStartAddress == null || waypointInfoArrayEndAddress == null)
 				return 0;
-
 			int playerPedModelHash = 0;
 			ulong playerPedAddress = GetLocalPlayerPedAddressFunc();
-
 			if (playerPedAddress != 0)
 			{
 				playerPedModelHash = GetModelHashFromEntity(new IntPtr((long)playerPedAddress));
@@ -3311,32 +3040,28 @@ namespace SHVDN
 			for (; waypointInfoAddress < (ulong)waypointInfoArrayEndAddress; waypointInfoAddress += 0x18)
 			{
 				int modelHash = *(int*)waypointInfoAddress;
-
 				if (modelHash == playerPedModelHash)
-				{				
+				{
 					return *(int*)(waypointInfoAddress + 4);
 				}
 			}
 
 			return 0;
 		}
-		#endregion
 
-		#region -- Pool Addresses --
-
-		delegate ulong GetHandleAddressFuncDelegate(int handle);
-		static GetHandleAddressFuncDelegate GetPtfxAddressFunc;
-		static GetHandleAddressFuncDelegate GetEntityAddressFunc;
-		static GetHandleAddressFuncDelegate GetPlayerAddressFunc;
-
+		static delegate* unmanaged[Stdcall]<int, ulong> GetPtfxAddressFunc;
+		static delegate* unmanaged[Stdcall]<int, ulong> GetEntityAddressFunc;
+		static delegate* unmanaged[Stdcall]<int, ulong> GetPlayerAddressFunc;
 		public static IntPtr GetPtfxAddress(int handle)
 		{
 			return new IntPtr((long)GetPtfxAddressFunc(handle));
 		}
+
 		public static IntPtr GetEntityAddress(int handle)
 		{
 			return new IntPtr((long)GetEntityAddressFunc(handle));
 		}
+
 		public static IntPtr GetPlayerAddress(int handle)
 		{
 			return new IntPtr((long)GetPlayerAddressFunc(handle));
@@ -3346,43 +3071,37 @@ namespace SHVDN
 		{
 			if (BuildingPoolAddress == null)
 				return IntPtr.Zero;
-
 			return ((GenericPool*)(*NativeMemory.BuildingPoolAddress))->GetAddressFromHandle(handle);
 		}
+
 		public static IntPtr GetAnimatedBuildingAddress(int handle)
 		{
 			if (AnimatedBuildingPoolAddress == null)
 				return IntPtr.Zero;
-
 			return ((GenericPool*)(*NativeMemory.AnimatedBuildingPoolAddress))->GetAddressFromHandle(handle);
 		}
+
 		public static IntPtr GetInteriorInstAddress(int handle)
 		{
 			if (InteriorInstPoolAddress == null)
 				return IntPtr.Zero;
-
 			return ((GenericPool*)(*NativeMemory.InteriorInstPoolAddress))->GetAddressFromHandle(handle);
 		}
+
 		public static IntPtr GetInteriorProxyAddress(int handle)
 		{
 			if (InteriorProxyPoolAddress == null)
 				return IntPtr.Zero;
-
 			return ((GenericPool*)(*NativeMemory.InteriorProxyPoolAddress))->GetAddressFromHandle(handle);
 		}
 
 		#endregion
-
 		#region -- Projectile Offsets --
 		public static int ProjectileAmmoInfoOffset { get; }
+
 		public static int ProjectileOwnerOffset { get; }
-		#endregion
 
-		#region -- Projectile Functions --
-
-		delegate void ExplodeProjectileDelegate(IntPtr projectileAddress, int unkParam);
-		static ExplodeProjectileDelegate ExplodeProjectileFunc;
-
+		static delegate* unmanaged[Stdcall]<IntPtr, int, void> ExplodeProjectileFunc;
 		public static void ExplodeProjectile(IntPtr projectileAddress)
 		{
 			var task = new ExplodeProjectileTask(projectileAddress);
@@ -3394,7 +3113,6 @@ namespace SHVDN
 			#region Fields
 			internal IntPtr projectileAddress;
 			#endregion
-
 			internal ExplodeProjectileTask(IntPtr projectileAddress)
 			{
 				this.projectileAddress = projectileAddress;
@@ -3407,69 +3125,52 @@ namespace SHVDN
 		}
 
 		#endregion
-
 		#region -- Interior Offsets --
-
 		public static ulong* InteriorProxyPtrFromGameplayCamAddress { get; }
+
 		public static int InteriorInstPtrInInteriorProxyOffset { get; }
 
 		public static int GetAssociatedInteriorInstHandleFromInteriorProxy(int interiorProxyHandle)
 		{
 			if (InteriorInstPtrInInteriorProxyOffset == 0 || InteriorInstPoolAddress == null)
 				return 0;
-
 			var interiorProxyAddress = GetInteriorProxyAddress(interiorProxyHandle);
 			if (interiorProxyAddress == IntPtr.Zero)
 				return 0;
-
 			var interiorInstAddress = *(ulong*)(interiorProxyAddress + InteriorInstPtrInInteriorProxyOffset).ToPointer();
 			if (interiorInstAddress == 0)
 				return 0;
-
 			return ((GenericPool*)(*NativeMemory.InteriorInstPoolAddress))->GetGuidHandleFromAddress(interiorInstAddress);
 		}
+
 		public static int GetInteriorProxyHandleFromInteriorInst(int interiorInstHandle)
 		{
 			if (InteriorProxyPoolAddress == null)
 				return 0;
-
 			var interiorInstAddress = GetInteriorInstAddress(interiorInstHandle);
 			if (interiorInstAddress == IntPtr.Zero)
 				return 0;
-
 			var interiorProxyAddress = *(ulong*)(interiorInstAddress + 0x188).ToPointer();
 			if (interiorProxyAddress == 0)
 				return 0;
-
 			return ((GenericPool*)(*NativeMemory.InteriorProxyPoolAddress))->GetGuidHandleFromAddress(interiorProxyAddress);
 		}
+
 		public static int GetInteriorProxyHandleFromGameplayCam()
 		{
 			if (InteriorProxyPtrFromGameplayCamAddress == null || InteriorInstPoolAddress == null)
 				return 0;
-
 			var interiorProxyAddress = *InteriorProxyPtrFromGameplayCamAddress;
 			if (interiorProxyAddress == 0)
 				return 0;
-
 			return ((GenericPool*)(*NativeMemory.InteriorProxyPoolAddress))->GetGuidHandleFromAddress(interiorProxyAddress);
 		}
 
 		#endregion
-
 		#region -- Weapon Info And Ammo Info --
-
 		static RageAtArrayPtr* weaponAndAmmoInfoArrayPtr;
-		static HashSet<uint> disallowWeaponHashSetForHumanPedsOnFoot = new HashSet<uint>() {
-				0x1B79F17,  /* weapon_briefcase_02 */
-				0x166218FF, /* weapon_passenger_rocket */
-				0x32A888BD, /* weapon_tranquilizer */
-				0x687652CE, /* weapon_stinger */
-				0x6D5E2801, /* weapon_bird_crap */
-				0x88C78EB7, /* weapon_briefcase */
-				0xFDBADCED, /* weapon_digiscanner */
-			};
-
+		static HashSet<uint> disallowWeaponHashSetForHumanPedsOnFoot = new HashSet<uint>()
+		{0x1B79F17, /* weapon_briefcase_02 */ 0x166218FF, /* weapon_passenger_rocket */ 0x32A888BD, /* weapon_tranquilizer */ 0x687652CE, /* weapon_stinger */ 0x6D5E2801, /* weapon_bird_crap */ 0x88C78EB7, /* weapon_briefcase */ 0xFDBADCED, /* weapon_digiscanner */ };
 		static uint* weaponComponentArrayCountAddr;
 		// Store the offset instead of the calculated address for compatibility with mods like Weapon Limits Adjuster by alexguirre (although Weapon Limits Adjuster allocates a new array in the very beginning).
 		static ulong offsetForCWeaponComponentArrayAddr;
@@ -3477,10 +3178,8 @@ namespace SHVDN
 		static int weaponAttachPointsArrayCountOffset;
 		static int weaponAttachPointElementComponentCountOffset;
 		static int weaponAttachPointElementSize;
-
 		static int weaponInfoHumanNameHashOffset;
-
-		[StructLayout(LayoutKind.Explicit, Size=0x20)]
+		[StructLayout(LayoutKind.Explicit, Size = 0x20)]
 		struct ItemInfo
 		{
 			[FieldOffset(0x0)]
@@ -3493,7 +3192,6 @@ namespace SHVDN
 			internal uint audioHash;
 			[FieldOffset(0x1C)]
 			internal uint slot;
-
 			// The function is for the game version b2802 or later ones.
 			// This one directly returns a hash value (not a pointer value) unlike the previous function.
 			delegate uint GetClassNameHashOfCItemInfoDelegate();
@@ -3503,7 +3201,6 @@ namespace SHVDN
 			// The function returns the address where the class name hash is in all versions prior to (the address will be the outVal address in newer versions).
 			delegate uint* GetClassNameHashAddressOfCItemInfoDelegate(ulong unused, uint* outVal);
 			static Dictionary<ulong, GetClassNameHashAddressOfCItemInfoDelegate> getClassNameHashAddressOfCItemInfoCacheDict = new Dictionary<ulong, GetClassNameHashAddressOfCItemInfoDelegate>();
-
 			internal uint GetClassNameHash()
 			{
 				// In the b2802 or a later exe, the function returns a hash value (not a pointer value)
@@ -3531,7 +3228,6 @@ namespace SHVDN
 				{
 					var newDelegate = GetDelegateForFunctionPointer<GetClassNameHashOfCItemInfoDelegate>(new IntPtr((long)virtualFuncAddr));
 					getClassNameHashOfCItemInfoCacheDict.Add(virtualFuncAddr, newDelegate);
-
 					return newDelegate;
 				}
 			}
@@ -3546,7 +3242,6 @@ namespace SHVDN
 				{
 					var newDelegate = GetDelegateForFunctionPointer<GetClassNameHashAddressOfCItemInfoDelegate>(new IntPtr((long)virtualFuncAddr));
 					getClassNameHashAddressOfCItemInfoCacheDict.Add(virtualFuncAddr, newDelegate);
-
 					return newDelegate;
 				}
 			}
@@ -3581,25 +3276,20 @@ namespace SHVDN
 			}
 
 			var weaponAndAmmoInfoElementCount = weaponAndAmmoInfoArrayPtr->size;
-
 			if (weaponAndAmmoInfoElementCount == 0)
 				return null;
-
 			int low = 0, high = weaponAndAmmoInfoElementCount - 1;
 			while (true)
 			{
 				int indexToRead = (low + high) >> 1;
 				var weaponOrAmmoInfo = (ItemInfo*)weaponAndAmmoInfoArrayPtr->GetElementAddress(indexToRead);
-
 				if (weaponOrAmmoInfo->nameHash == nameHash)
 					return weaponOrAmmoInfo;
-
 				// The array is sorted in ascending order
 				if (weaponOrAmmoInfo->nameHash <= nameHash)
 					low = indexToRead + 1;
 				else
 					high = indexToRead - 1;
-
 				if (low > high)
 					return null;
 			}
@@ -3608,16 +3298,12 @@ namespace SHVDN
 		static ItemInfo* FindWeaponInfo(uint nameHash)
 		{
 			var itemInfoPtr = FindItemInfoFromWeaponAndAmmoInfoArray(nameHash);
-
 			if (itemInfoPtr == null)
 				return null;
-
 			var classNameHash = itemInfoPtr->GetClassNameHash();
-
 			const uint CWEAPONINFO_NAME_HASH = 0x861905B4;
 			if (classNameHash == CWEAPONINFO_NAME_HASH)
 				return itemInfoPtr;
-
 			return null;
 		}
 
@@ -3635,42 +3321,33 @@ namespace SHVDN
 			{
 				int indexToRead = (low + high) >> 1;
 				var weaponComponentInfo = (WeaponComponentInfo*)cWeaponComponentArrayFirstPtr[indexToRead];
-
 				if (weaponComponentInfo->nameHash == nameHash)
 					return weaponComponentInfo;
-
 				// The array is sorted in ascending order
 				if (weaponComponentInfo->nameHash <= nameHash)
 					low = indexToRead + 1;
 				else
 					high = indexToRead - 1;
-
 				if (low > high)
 					return null;
 			}
 		}
 
 		public static bool IsHashValidAsWeaponHash(uint weaponHash) => FindWeaponInfo(weaponHash) != null;
-
 		public static uint GetAttachmentPointHash(uint weaponHash, uint componentHash)
 		{
 			var weaponInfo = FindWeaponInfo(weaponHash);
-
 			if (weaponInfo == null)
 				return 0xFFFFFFFF;
-
 			var weaponAttachPointsAddr = (byte*)weaponInfo + weaponAttachPointsStartOffset;
 			var weaponAttachPointsCount = *(int*)(weaponAttachPointsAddr + weaponAttachPointsArrayCountOffset);
 			var weaponAttachPointElementStartAddr = (byte*)(weaponAttachPointsAddr);
-
 			for (int i = 0; i < weaponAttachPointsCount; i++)
 			{
 				var weaponAttachPointElementAddr = weaponAttachPointElementStartAddr + (i * weaponAttachPointElementSize) + 0x8;
 				int componentItemsCount = *(int*)(weaponAttachPointElementAddr + weaponAttachPointElementComponentCountOffset);
-
 				if (componentItemsCount <= 0)
 					continue;
-
 				for (int j = 0; j < componentItemsCount; j++)
 				{
 					var componentHashInItemArray = *(uint*)(weaponAttachPointElementAddr + j * 0x8);
@@ -3691,23 +3368,18 @@ namespace SHVDN
 
 			var weaponAndAmmoInfoElementCount = weaponAndAmmoInfoArrayPtr->size;
 			var resultList = new List<uint>();
-
 			for (int i = 0; i < weaponAndAmmoInfoElementCount; i++)
 			{
 				var weaponOrAmmoInfo = (ItemInfo*)weaponAndAmmoInfoArrayPtr->GetElementAddress(i);
-
 				if (!CanPedEquip(weaponOrAmmoInfo) && !disallowWeaponHashSetForHumanPedsOnFoot.Contains(weaponOrAmmoInfo->nameHash))
 					continue;
-
 				var classNameHash = weaponOrAmmoInfo->GetClassNameHash();
-
 				const uint CWEAPONINFO_NAME_HASH = 0x861905B4;
 				if (classNameHash == CWEAPONINFO_NAME_HASH)
 					resultList.Add(weaponOrAmmoInfo->nameHash);
 			}
 
 			return resultList;
-
 			bool CanPedEquip(ItemInfo* weaponInfoAddress)
 			{
 				return weaponInfoAddress->modelHash != 0 && weaponInfoAddress->slot != 0;
@@ -3719,7 +3391,6 @@ namespace SHVDN
 			var cWeaponComponentArrayFirstPtr = (ulong*)((byte*)offsetForCWeaponComponentArrayAddr + 4 + *(int*)offsetForCWeaponComponentArrayAddr);
 			var arrayCount = weaponComponentArrayCountAddr != null ? *(uint*)weaponComponentArrayCountAddr : 0;
 			var resultList = new List<uint>();
-
 			for (uint i = 0; i < arrayCount; i++)
 			{
 				var cWeaponComponentInfo = cWeaponComponentArrayFirstPtr[i];
@@ -3733,12 +3404,9 @@ namespace SHVDN
 		public static List<uint> GetAllCompatibleWeaponComponentHashes(uint weaponHash)
 		{
 			var weaponInfo = FindWeaponInfo(weaponHash);
-
 			if (weaponInfo == null)
 				return new List<uint>();
-
 			var returnList = new List<uint>();
-
 			var weaponAttachPointsAddr = (byte*)weaponInfo + weaponAttachPointsStartOffset;
 			var weaponAttachPointsCount = *(int*)(weaponAttachPointsAddr + weaponAttachPointsArrayCountOffset);
 			var weaponAttachPointElementStartAddr = (byte*)(weaponAttachPointsAddr + 0x8);
@@ -3746,10 +3414,8 @@ namespace SHVDN
 			{
 				var weaponAttachPointElementAddr = weaponAttachPointElementStartAddr + i * weaponAttachPointElementSize;
 				int componentItemsCount = *(int*)(weaponAttachPointElementAddr + weaponAttachPointElementComponentCountOffset);
-
 				if (componentItemsCount <= 0)
 					continue;
-
 				for (int j = 0; j < componentItemsCount; j++)
 				{
 					returnList.Add(*(uint*)(weaponAttachPointElementAddr + j * 0x8));
@@ -3762,41 +3428,26 @@ namespace SHVDN
 		public static uint GetHumanNameHashOfWeaponInfo(uint weaponHash)
 		{
 			var weaponInfo = FindWeaponInfo(weaponHash);
-
 			if (weaponInfo == null)
 				// hashed value of WT_INVALID
 				return 0xBFED8500;
-
 			return *(uint*)((byte*)weaponInfo + weaponInfoHumanNameHashOffset);
 		}
 
 		public static uint GetHumanNameHashOfWeaponComponentInfo(uint weaponComponentHash)
 		{
 			var weaponComponentInfo = FindWeaponComponentInfo(weaponComponentHash);
-
 			if (weaponComponentInfo == null)
 				// hashed value of WCT_INVALID
 				return 0xDE4BE9F8;
-
 			return weaponComponentInfo->locNameHash;
 		}
 
-		#endregion
-
-		#region -- Fragment Object for Entity --
-
-		internal delegate FragInst* GetFragInstDelegate(IntPtr entityAddress);
-		internal delegate FragInst* DetachFragmentPartByIndexDelegate(FragInst* fragInst, int partIndex);
-
 		static int getFragInstVFuncOffset;
-		static DetachFragmentPartByIndexDelegate detachFragmentPartByIndexFunc;
+		static delegate* unmanaged[Stdcall]<FragInst*, int, FragInst*> detachFragmentPartByIndexFunc;
 		static ulong** phSimulatorInstPtr;
 		static int colliderCapacityOffset;
 		static int colliderCountOffset;
-
-		// Only 3 virtural functions are present (one for peds and objects and one for vehicles)
-		static Dictionary<ulong, GetFragInstDelegate> getFragInstVFuncCache = new Dictionary<ulong, GetFragInstDelegate>(3);
-
 		[StructLayout(LayoutKind.Explicit, Size = 0xC0)]
 		internal unsafe struct FragInst
 		{
@@ -3806,13 +3457,11 @@ namespace SHVDN
 			internal GtaFragType* gtaFragType;
 			[FieldOffset(0xB8)]
 			internal uint unkType;
-
 			internal FragPhysicsLOD* GetAppropriateFragPhysicsLOD()
 			{
 				var fragPhysicsLODGroup = gtaFragType->fragPhysicsLODGroup;
 				if (fragPhysicsLODGroup == null)
 					return null;
-
 				switch (unkType)
 				{
 					case 0:
@@ -3824,11 +3473,14 @@ namespace SHVDN
 				}
 			}
 		}
+
 		[StructLayout(LayoutKind.Explicit)]
 		internal unsafe struct FragCacheEntry
 		{
-			[FieldOffset(0x178)] internal CrSkeleton* crSkeleton;
+			[FieldOffset(0x178)]
+			internal CrSkeleton* crSkeleton;
 		}
+
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct GtaFragType
 		{
@@ -3837,20 +3489,22 @@ namespace SHVDN
 			[FieldOffset(0xF0)]
 			internal FragPhysicsLODGroup* fragPhysicsLODGroup;
 		}
+
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct FragDrawable
 		{
 			[FieldOffset(0x18)]
 			internal CrSkeletonData* crSkeletonData;
 		}
+
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct FragPhysicsLODGroup
 		{
 			[FieldOffset(0x10)]
 			internal fixed ulong fragPhysicsLODAddresses[3];
-
 			internal FragPhysicsLOD* GetFragPhysicsLODByIndex(int index) => (FragPhysicsLOD*)((ulong*)fragPhysicsLODAddresses[index]);
 		}
+
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct FragPhysicsLOD
 		{
@@ -3858,12 +3512,10 @@ namespace SHVDN
 			internal ulong fragTypeChildArr;
 			[FieldOffset(0x11E)]
 			internal byte fragmentGroupCount;
-
 			internal FragTypeChild* GetFragTypeChild(int index)
 			{
 				if (index >= fragmentGroupCount)
 					return null;
-
 				return (FragTypeChild*)*((ulong*)fragTypeChildArr + index);
 			}
 		}
@@ -3880,11 +3532,14 @@ namespace SHVDN
 		[StructLayout(LayoutKind.Explicit)]
 		internal unsafe struct CrSkeleton
 		{
-			[FieldOffset(0x00)] internal CrSkeletonData* skeletonData;
-			[FieldOffset(0x10)] internal ulong bonePoseMatrixArrayPtr;
-			[FieldOffset(0x18)] internal ulong boneMatrixArrayPtr;
-			[FieldOffset(0x20)] internal int boneCount;
-
+			[FieldOffset(0x00)]
+			internal CrSkeletonData* skeletonData;
+			[FieldOffset(0x10)]
+			internal ulong bonePoseMatrixArrayPtr;
+			[FieldOffset(0x18)]
+			internal ulong boneMatrixArrayPtr;
+			[FieldOffset(0x20)]
+			internal int boneCount;
 			public IntPtr GetBonePoseMatrixAddress(int boneIndex)
 			{
 				return new IntPtr((long)(bonePoseMatrixArrayPtr + ((uint)boneIndex * 0x40)));
@@ -3899,11 +3554,14 @@ namespace SHVDN
 		[StructLayout(LayoutKind.Explicit)]
 		internal unsafe struct CrSkeletonData
 		{
-			[FieldOffset(0x10)] internal ulong boneIdAndIndexTupleArrayPtr;
-			[FieldOffset(0x18)] internal ushort divisorForBoneIdAndIndexTuple;
-			[FieldOffset(0x1A)] internal ushort unkValue;
-			[FieldOffset(0x5E)] internal ushort boneCount;
-
+			[FieldOffset(0x10)]
+			internal ulong boneIdAndIndexTupleArrayPtr;
+			[FieldOffset(0x18)]
+			internal ushort divisorForBoneIdAndIndexTuple;
+			[FieldOffset(0x1A)]
+			internal ushort unkValue;
+			[FieldOffset(0x5E)]
+			internal ushort boneCount;
 			/// <summary>
 			/// Gets the bone id from specified bone index. Note that bone indexes are sequential values and bone ids are not sequential ones.
 			/// </summary>
@@ -3913,15 +3571,12 @@ namespace SHVDN
 				{
 					if (boneId < boneCount)
 						return boneId;
-
 					return -1;
 				}
 
 				if (divisorForBoneIdAndIndexTuple == 0)
 					return -1;
-
 				var firstTuplePtr = ((ulong*)boneIdAndIndexTupleArrayPtr + (boneId % divisorForBoneIdAndIndexTuple));
-
 				for (var boneIdAndIndexTuple = (BoneIdAndIndexTuple*)*firstTuplePtr; boneIdAndIndexTuple != null; boneIdAndIndexTuple = (BoneIdAndIndexTuple*)boneIdAndIndexTuple->nextTupleAddr)
 				{
 					if (boneId == boneIdAndIndexTuple->boneId)
@@ -3935,9 +3590,12 @@ namespace SHVDN
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct BoneIdAndIndexTuple
 		{
-			[FieldOffset(0x0)] internal int boneId;
-			[FieldOffset(0x4)] internal int boneIndex;
-			[FieldOffset(0x8)] internal ulong nextTupleAddr;
+			[FieldOffset(0x0)]
+			internal int boneId;
+			[FieldOffset(0x4)]
+			internal int boneIndex;
+			[FieldOffset(0x8)]
+			internal ulong nextTupleAddr;
 		}
 
 		internal class DetachFragmentPartByIndexTask : IScriptTask
@@ -3947,7 +3605,6 @@ namespace SHVDN
 			internal int fragmentGroupIndex;
 			internal bool wasNewFragInstCreated;
 			#endregion
-
 			internal DetachFragmentPartByIndexTask(FragInst* fragInst, int fragmentGroupIndex)
 			{
 				this.fragInst = fragInst;
@@ -3965,7 +3622,6 @@ namespace SHVDN
 			var fragInst = GetFragInstAddressOfEntity(entityAddress);
 			if (fragInst == null)
 				return 0;
-
 			return GetFragmentGroupCountOfFragInst(fragInst);
 		}
 
@@ -3973,22 +3629,17 @@ namespace SHVDN
 		{
 			if (fragmentGroupIndex < 0)
 				return false;
-
 			// If the entity collider count is at the capacity, the game can crash for trying to create the new entity while no free collider slots are available
 			if (GetEntityColliderCount() >= GetEntityColliderCapacity())
 				return false;
-
 			var fragInst = GetFragInstAddressOfEntity(entityAddress);
 			if (fragInst == null)
 				return false;
-
 			var fragmentGroupCount = GetFragmentGroupCountOfFragInst(fragInst);
 			if (fragmentGroupIndex >= fragmentGroupCount)
 				return false;
-
 			var task = new DetachFragmentPartByIndexTask(fragInst, fragmentGroupIndex);
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
-
 			return task.wasNewFragInstCreated;
 		}
 
@@ -3996,33 +3647,24 @@ namespace SHVDN
 		{
 			if ((boneIndex & 0x80000000) != 0) // boneIndex cant be negative
 				return -1;
-
 			var fragInst = GetFragInstAddressOfEntity(entityAddress);
 			if (fragInst == null)
 				return -1;
-
-
 			var crSkeletonData = fragInst->gtaFragType->fragDrawable->crSkeletonData;
 			if (crSkeletonData == null)
 				return -1;
-
 			var boneCount = crSkeletonData->boneCount;
 			if (boneIndex >= boneCount)
 				return -1;
-
 			var fragPhysicsLOD = fragInst->GetAppropriateFragPhysicsLOD();
 			if (fragPhysicsLOD == null)
 				return -1;
-
 			var fragmentGroupCount = fragPhysicsLOD->fragmentGroupCount;
-
 			for (int i = 0; i < fragmentGroupCount; i++)
 			{
 				var fragTypeChild = fragPhysicsLOD->GetFragTypeChild(i);
-
 				if (fragTypeChild == null)
 					continue;
-
 				if (boneIndex == crSkeletonData->GetBoneIndexByBoneId(fragTypeChild->boneId))
 					return i;
 			}
@@ -4034,7 +3676,6 @@ namespace SHVDN
 		{
 			if (*phSimulatorInstPtr == null)
 				return 0;
-
 			return *(int*)((byte*)*phSimulatorInstPtr + colliderCapacityOffset);
 		}
 
@@ -4042,7 +3683,6 @@ namespace SHVDN
 		{
 			if (*phSimulatorInstPtr == null)
 				return 0;
-
 			return *(int*)((byte*)*phSimulatorInstPtr + colliderCountOffset);
 		}
 
@@ -4055,8 +3695,7 @@ namespace SHVDN
 		private static FragInst* GetFragInstAddressOfEntity(IntPtr entityAddress)
 		{
 			var vFuncAddr = *(ulong*)(*(ulong*)entityAddress.ToPointer() + (uint)getFragInstVFuncOffset);
-			var getFragInstFunc = CreateGetFragInstDelegateIfNotCreated(vFuncAddr);
-
+			var getFragInstFunc = (delegate* unmanaged[Stdcall]<IntPtr, FragInst*>)(vFuncAddr);
 			return getFragInstFunc(entityAddress);
 		}
 
@@ -4066,58 +3705,18 @@ namespace SHVDN
 			return fragPhysicsLOD != null ? fragPhysicsLOD->fragmentGroupCount : 0;
 		}
 
-		private static GetFragInstDelegate CreateGetFragInstDelegateIfNotCreated(ulong virtualFuncAddr)
-		{
-			if (getFragInstVFuncCache.TryGetValue(virtualFuncAddr, out var outDelegate))
-			{
-				return outDelegate;
-			}
-			else
-			{
-				var newDelegate = GetDelegateForFunctionPointer<GetFragInstDelegate>(new IntPtr((long)virtualFuncAddr));
-				getFragInstVFuncCache.Add(virtualFuncAddr, newDelegate);
-
-				return newDelegate;
-			}
-		}
-
-		#endregion
-
-		#region -- NaturalMotion Euphoria --
-
-		delegate byte SetNmBoolAddressDelegate(ulong messageAddress, IntPtr argumentNamePtr, [MarshalAs(UnmanagedType.I1)] bool value);
-		delegate byte SetNmIntAddressDelegate(ulong messageAddress, IntPtr argumentNamePtr, int value);
-		delegate byte SetNmFloatAddressDelegate(ulong messageAddress, IntPtr argumentNamePtr, float value);
-		delegate byte SetNmVector3AddressDelegate(ulong messageAddress, IntPtr argumentNamePtr, float x, float y, float z);
-		delegate byte SetNmStringAddressDelegate(ulong messageAddress, IntPtr argumentNamePtr, IntPtr stringPtr);
-
-		delegate ulong InitMessageMemoryDelegate(ulong T1, ulong T2, int T3);
-		delegate void SendMessageToPedDelegate(ulong pedNmAddress, IntPtr messagePtr, ulong messageAddress);
-		delegate void FreeMessageMemoryDelegate(ulong messageAddress);
-
-		delegate CTask* GetActiveTaskFuncDelegate(ulong cTaskTreePedAddress);
-		delegate int GetEventTypeIndexDelegate(ulong cEventAddress);
-
-		delegate void ActionUlongDelegate(ulong T);
-		delegate int FuncUlongIntDelegate(ulong T);
-		delegate ulong FuncUlongUlongDelegate(ulong T);
-
-		static SetNmIntAddressDelegate SetNmIntAddress;
-		static SetNmBoolAddressDelegate SetNmBoolAddress;
-		static SetNmFloatAddressDelegate SetNmFloatAddress;
-		static SetNmStringAddressDelegate SetNmStringAddress;
-		static SetNmVector3AddressDelegate SetNmVector3Address;
-		static GetActiveTaskFuncDelegate GetActiveTaskFunc;
-		static InitMessageMemoryDelegate InitMessageMemoryFunc;
-		static SendMessageToPedDelegate SendMessageToPedFunc;
-
+		static delegate* unmanaged[Stdcall]<ulong, IntPtr, int, byte> SetNmIntAddress;
+		static delegate* unmanaged[Stdcall]<ulong, IntPtr, bool, byte> SetNmBoolAddress;
+		static delegate* unmanaged[Stdcall]<ulong, IntPtr, float, byte> SetNmFloatAddress;
+		static delegate* unmanaged[Stdcall]<ulong, IntPtr, IntPtr, byte> SetNmStringAddress;
+		static delegate* unmanaged[Stdcall]<ulong, IntPtr, float, float, float, byte> SetNmVector3Address;
+		static delegate* unmanaged[Stdcall]<ulong, CTask*> GetActiveTaskFunc;
+		static delegate* unmanaged[Stdcall]<ulong, ulong, int, ulong> InitMessageMemoryFunc;
+		static delegate* unmanaged[Stdcall]<ulong, IntPtr, ulong, void> SendMessageToPedFunc;
 		static int fragInstNMGtaOffset;
 		static int cTaskNMScriptControlTypeIndex;
 		static int cEventSwitch2NMTypeIndex;
-
-		static Dictionary<ulong, GetEventTypeIndexDelegate> getEventTypeIndexDelegateCacheDict = new Dictionary<ulong, GetEventTypeIndexDelegate>();
-
-		[StructLayout(LayoutKind.Explicit, Size=0x38)]
+		[StructLayout(LayoutKind.Explicit, Size = 0x38)]
 		struct CTask
 		{
 			[FieldOffset(0x34)]
@@ -4127,19 +3726,15 @@ namespace SHVDN
 		public static bool IsTaskNMScriptControlOrEventSwitch2NMActive(IntPtr pedAddress)
 		{
 			ulong phInstGtaAddress = *(ulong*)(pedAddress + 0x30);
-
 			if (phInstGtaAddress == 0)
 				return false;
-
 			ulong fragInstNMGtaAddress = *(ulong*)(pedAddress + fragInstNMGtaOffset);
-
 			if (phInstGtaAddress == fragInstNMGtaAddress && !IsPedInjured((byte*)pedAddress))
 			{
-				var funcUlongIntDelegate = GetDelegateForFunctionPointer<FuncUlongIntDelegate>(new IntPtr((long)*(ulong*)(*(ulong*)fragInstNMGtaAddress + 0x98)));
+				var funcUlongIntDelegate = (delegate* unmanaged[Stdcall]<ulong, int>)(new IntPtr((long)*(ulong*)(*(ulong*)fragInstNMGtaAddress + 0x98)));
 				if (funcUlongIntDelegate(fragInstNMGtaAddress) != -1)
 				{
 					var PedIntelligenceAddr = *(ulong*)(pedAddress + PedIntelligenceOffset);
-
 					var activeTask = GetActiveTaskFunc(*(ulong*)((byte*)PedIntelligenceAddr + CTaskTreePedOffset));
 					if (activeTask != null && activeTask->taskTypeIndex == cTaskNMScriptControlTypeIndex)
 					{
@@ -4153,7 +3748,7 @@ namespace SHVDN
 							var eventAddress = *(ulong*)((byte*)PedIntelligenceAddr + CEventStackOffset + 8 * ((i + *(int*)((byte*)PedIntelligenceAddr + (CEventCountOffset - 4)) + 1) % 16));
 							if (eventAddress != 0)
 							{
-								var getEventTypeIndexFunc = CreateGetEventTypeIndexDelegateIfNotCreated(eventAddress);
+								var getEventTypeIndexFunc = (delegate* unmanaged[Stdcall]<ulong, int>)(eventAddress);
 								if (getEventTypeIndexFunc(eventAddress) == cEventSwitch2NMTypeIndex)
 								{
 									var taskInEvent = *(CTask**)(eventAddress + 0x28);
@@ -4175,20 +3770,6 @@ namespace SHVDN
 		}
 
 		static bool IsPedInjured(byte* pedAddress) => *(float*)(pedAddress + 0x280) < *(float*)(pedAddress + InjuryHealthThresholdOffset);
-
-		static GetEventTypeIndexDelegate CreateGetEventTypeIndexDelegateIfNotCreated(ulong eventAddress)
-		{
-			var getEventTypeIndexVirtualFuncAddr = *(ulong*)(*(ulong*)eventAddress + 0x18);
-
-			if (getEventTypeIndexDelegateCacheDict.TryGetValue(getEventTypeIndexVirtualFuncAddr, out var cachedDelegate))
-				return cachedDelegate;
-
-			var createdDelegate = GetDelegateForFunctionPointer<GetEventTypeIndexDelegate>(new IntPtr((long)getEventTypeIndexVirtualFuncAddr));
-			getEventTypeIndexDelegateCacheDict[getEventTypeIndexVirtualFuncAddr] = createdDelegate;
-
-			return createdDelegate;
-		}
-
 		internal class EuphoriaMessageTask : IScriptTask
 		{
 			#region Fields
@@ -4197,7 +3778,6 @@ namespace SHVDN
 			Dictionary<string, (int value, Type type)> _boolIntFloatArguments;
 			Dictionary<string, object> _stringVector3ArrayArguments;
 			#endregion
-
 			internal EuphoriaMessageTask(int target, string message, Dictionary<string, (int, Type)> boolIntFloatArguments, Dictionary<string, object> stringVector3ArrayArguments)
 			{
 				targetHandle = target;
@@ -4209,25 +3789,18 @@ namespace SHVDN
 			public void Run()
 			{
 				byte* _PedAddress = (byte*)NativeMemory.GetEntityAddress(targetHandle).ToPointer();
-
 				if (_PedAddress == null)
 					return;
-
 				ulong messageMemory = (ulong)AllocCoTaskMem(0x1218).ToInt64();
-
 				if (messageMemory == 0)
 					return;
-
 				InitMessageMemoryFunc(messageMemory, messageMemory + 0x18, 0x40);
-
 				if (_boolIntFloatArguments != null)
 				{
 					foreach (var arg in _boolIntFloatArguments)
 					{
 						IntPtr name = ScriptDomain.CurrentDomain.PinString(arg.Key);
-
 						(var argValue, var argType) = arg.Value;
-
 						if (argType == typeof(float))
 						{
 							var argValueConverted = *(float*)(&argValue);
@@ -4250,7 +3823,6 @@ namespace SHVDN
 					foreach (var arg in _stringVector3ArrayArguments)
 					{
 						IntPtr name = ScriptDomain.CurrentDomain.PinString(arg.Key);
-
 						var argValue = arg.Value;
 						if (argValue is float[] vector3ArgValue)
 							NativeMemory.SetNmVector3Address(messageMemory, name, vector3ArgValue[0], vector3ArgValue[1], vector3ArgValue[2]);
@@ -4273,10 +3845,8 @@ namespace SHVDN
 		public static void SendEuphoriaMessage(int targetHandle, string message, Dictionary<string, (int, Type)> boolIntFloatArguments, Dictionary<string, object> stringVector3ArrayArguments)
 		{
 			var task = new EuphoriaMessageTask(targetHandle, message, boolIntFloatArguments, stringVector3ArrayArguments);
-
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
 		}
-
 		#endregion
 	}
 }

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1232,6 +1232,12 @@ namespace SHVDN
 		{
 			return new IntPtr((long)*GameplayCameraAddress);
 		}
+
+		#endregion
+
+		#region -- Game Data --
+
+
 		static delegate* unmanaged[Stdcall]<IntPtr, uint, uint> GetHashKeyFunc;
 
 		public static uint GetHashKey(string key)
@@ -1241,6 +1247,7 @@ namespace SHVDN
 		}
 
 		static ulong GetLabelTextByHashAddress;
+
 		static delegate* unmanaged[Stdcall]<ulong, int, ulong> GetLabelTextByHashFunc;
 
 		public static string GetGXTEntryByHash(int entryLabelHash)
@@ -1442,6 +1449,13 @@ namespace SHVDN
 
 			return IntPtr.Zero;
 		}
+
+		#endregion
+
+		#region -- CEntity Functions --
+
+
+
 		static delegate* unmanaged[Stdcall]<float*, ulong, int, float*> GetRotationFromMatrixFunc;
 		static delegate* unmanaged[Stdcall]<float*, ulong, int> GetQuaternionFromMatrixFunc;
 
@@ -1470,6 +1484,18 @@ namespace SHVDN
 		public static uint cAttackerArrayOfEntityOffset { get; }
 		public static uint elementCountOfCAttackerArrayOfEntityOffset { get; }
 		public static uint elementSizeOfCAttackerArrayOfEntity { get; }
+
+		#endregion
+
+		#region -- CPhysical Functions --
+
+
+		// return value will be the address of the temporary 4 float storage
+
+
+		// Only 2 virtural functions are present (one for peds and objects and one for vehicles)
+
+
 
 		internal class SetEntityAngularVelocityTask : IScriptTask
 		{
@@ -1515,6 +1541,10 @@ namespace SHVDN
 			var task = new SetEntityAngularVelocityTask(entityAddress, setEntityAngularVelocityDelegate, x, y, z);
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
 		}
+
+
+
+
 
 		#endregion
 
@@ -1699,6 +1729,16 @@ namespace SHVDN
 		public static int HandlingDataOffset { get; }
 
 		public static int FirstVehicleFlagsOffset { get; }
+
+		#endregion
+
+		#region -- Vehicle Wheel Data --
+
+
+
+
+
+
 
 		static delegate* unmanaged[Stdcall]<IntPtr, void> FixVehicleWheelFunc;
 		static delegate* unmanaged[Stdcall]<IntPtr, ulong, float, ulong, ulong, int, byte, bool, void> PunctureVehicleTireNewFunc;
@@ -2154,6 +2194,9 @@ namespace SHVDN
 		public static ReadOnlyCollection<ReadOnlyCollection<int>> VehicleModelsGroupedByType { get; }
 		public static ReadOnlyCollection<int> PedModels { get; }
 
+
+
+
 		static delegate* unmanaged[Stdcall]<IntPtr, ulong> GetHandlingDataByHash;
 		static delegate* unmanaged[Stdcall]<int, ulong> GetHandlingDataByIndex;
 
@@ -2372,6 +2415,11 @@ namespace SHVDN
 
 		static ulong* ProjectilePoolAddress;
 		static int* ProjectileCountAddress;
+
+
+
+
+
 
 		// if the entity is a ped and they are in a vehicle, the vehicle position will be returned instead (just like GET_ENTITY_COORDS does)
 		static delegate* unmanaged[Stdcall]<ulong, float*, ulong> EntityPosFunc;
@@ -3189,6 +3237,8 @@ namespace SHVDN
 		#region -- Checkpoint Pool --
 
 		static ulong* CheckpointPoolAddress;
+
+
 		static delegate* unmanaged[Stdcall]<ulong> GetCGameScriptHandlerAddressFunc;
 
 		public static int[] GetCheckpointHandles()
@@ -3208,6 +3258,12 @@ namespace SHVDN
 
 			return task.returnAddress;
 		}
+
+		#endregion
+
+		#region -- Waypoint Info Array --
+
+
 		static ulong* waypointInfoArrayStartAddress;
 		static ulong* waypointInfoArrayEndAddress;
 		static delegate* unmanaged[Stdcall]<ulong> GetLocalPlayerPedAddressFunc;
@@ -3238,6 +3294,11 @@ namespace SHVDN
 
 			return 0;
 		}
+		#endregion
+
+		#region -- Pool Addresses --
+
+
 		static delegate* unmanaged[Stdcall]<int, ulong> GetPtfxAddressFunc;
 		static delegate* unmanaged[Stdcall]<int, ulong> GetEntityAddressFunc;
 		static delegate* unmanaged[Stdcall]<int, ulong> GetPlayerAddressFunc;
@@ -3289,6 +3350,11 @@ namespace SHVDN
 		#region -- Projectile Offsets --
 		public static int ProjectileAmmoInfoOffset { get; }
 		public static int ProjectileOwnerOffset { get; }
+		#endregion
+
+		#region -- Projectile Functions --
+
+
 		static delegate* unmanaged[Stdcall]<IntPtr, int, void> ExplodeProjectileFunc;
 
 		public static void ExplodeProjectile(IntPtr projectileAddress)
@@ -3689,11 +3755,21 @@ namespace SHVDN
 			return weaponComponentInfo->locNameHash;
 		}
 
+		#endregion
+
+		#region -- Fragment Object for Entity --
+
+
+
+
 		static int getFragInstVFuncOffset;
 		static delegate* unmanaged[Stdcall]<FragInst*, int, FragInst*> detachFragmentPartByIndexFunc;
 		static ulong** phSimulatorInstPtr;
 		static int colliderCapacityOffset;
 		static int colliderCountOffset;
+
+		// Only 3 virtural functions are present (one for peds and objects and one for vehicles)
+
 
 		[StructLayout(LayoutKind.Explicit, Size = 0xC0)]
 		internal unsafe struct FragInst
@@ -3964,6 +4040,29 @@ namespace SHVDN
 			return fragPhysicsLOD != null ? fragPhysicsLOD->fragmentGroupCount : 0;
 		}
 
+
+
+		#endregion
+
+		#region -- NaturalMotion Euphoria --
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 		static delegate* unmanaged[Stdcall]<ulong, IntPtr, int, byte> SetNmIntAddress;
 		static delegate* unmanaged[Stdcall]<ulong, IntPtr, bool, byte> SetNmBoolAddress;
 		static delegate* unmanaged[Stdcall]<ulong, IntPtr, float, byte> SetNmFloatAddress;
@@ -3976,6 +4075,8 @@ namespace SHVDN
 		static int fragInstNMGtaOffset;
 		static int cTaskNMScriptControlTypeIndex;
 		static int cEventSwitch2NMTypeIndex;
+
+
 
 		[StructLayout(LayoutKind.Explicit, Size = 0x38)]
 		struct CTask
@@ -4035,6 +4136,8 @@ namespace SHVDN
 		}
 
 		static bool IsPedInjured(byte* pedAddress) => *(float*)(pedAddress + 0x280) < *(float*)(pedAddress + InjuryHealthThresholdOffset);
+
+
 
 		internal class EuphoriaMessageTask : IScriptTask
 		{

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1138,10 +1138,10 @@ namespace SHVDN
 			return (*data & (1 << bit)) != 0;
 		}
 
+		static byte[] _strBufferForStringToCoTaskMemUTF8 = new byte[100];
 		public static readonly IntPtr String = StringToCoTaskMemUTF8("STRING");
 		public static readonly IntPtr NullString = StringToCoTaskMemUTF8(string.Empty);
 		public static readonly IntPtr CellEmailBcon = StringToCoTaskMemUTF8("CELL_EMAIL_BCON");
-		static byte[] _strBufferForStringToCoTaskMemUTF8 = new byte[100];
 
 		public static string PtrToStringUTF8(IntPtr ptr)
 		{

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -2,6 +2,7 @@
 // Copyright (C) 2015 crosire & contributors
 // License: https://github.com/crosire/scripthookvdotnet#license
 //
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -24,50 +25,54 @@ namespace SHVDN
 		/// Creates a texture. Texture deletion is performed automatically when game reloads scripts.
 		/// Can be called only in the same thread as natives.
 		/// </summary>
-		/// <param name = "filename"></param>
+		/// <param name="filename"></param>
 		/// <returns>Internal texture ID.</returns>
 		[DllImport("ScriptHookV.dll", ExactSpelling = true, EntryPoint = "?createTexture@@YAHPEBD@Z")]
 		public static extern int CreateTexture([MarshalAs(UnmanagedType.LPStr)] string filename);
+
 		/// <summary>
 		/// Draws a texture on screen. Can be called only in the same thread as natives.
 		/// </summary>
-		/// <param name = "id">Texture ID returned by <see cref = "CreateTexture(string)"/>.</param>
-		/// <param name = "instance">The instance index. Each texture can have up to 64 different instances on screen at a time.</param>
-		/// <param name = "level">Texture instance with low levels draw first.</param>
-		/// <param name = "time">How long in milliseconds the texture instance should stay on screen.</param>
-		/// <param name = "sizeX">Width in screen space [0,1].</param>
-		/// <param name = "sizeY">Height in screen space [0,1].</param>
-		/// <param name = "centerX">Center position in texture space [0,1].</param>
-		/// <param name = "centerY">Center position in texture space [0,1].</param>
-		/// <param name = "posX">Position in screen space [0,1].</param>
-		/// <param name = "posY">Position in screen space [0,1].</param>
-		/// <param name = "rotation">Normalized rotation [0,1].</param>
-		/// <param name = "scaleFactor">Screen aspect ratio, used for size correction.</param>
-		/// <param name = "colorR">Red tint.</param>
-		/// <param name = "colorG">Green tint.</param>
-		/// <param name = "colorB">Blue tint.</param>
-		/// <param name = "colorA">Alpha value.</param>
+		/// <param name="id">Texture ID returned by <see cref="CreateTexture(string)"/>.</param>
+		/// <param name="instance">The instance index. Each texture can have up to 64 different instances on screen at a time.</param>
+		/// <param name="level">Texture instance with low levels draw first.</param>
+		/// <param name="time">How long in milliseconds the texture instance should stay on screen.</param>
+		/// <param name="sizeX">Width in screen space [0,1].</param>
+		/// <param name="sizeY">Height in screen space [0,1].</param>
+		/// <param name="centerX">Center position in texture space [0,1].</param>
+		/// <param name="centerY">Center position in texture space [0,1].</param>
+		/// <param name="posX">Position in screen space [0,1].</param>
+		/// <param name="posY">Position in screen space [0,1].</param>
+		/// <param name="rotation">Normalized rotation [0,1].</param>
+		/// <param name="scaleFactor">Screen aspect ratio, used for size correction.</param>
+		/// <param name="colorR">Red tint.</param>
+		/// <param name="colorG">Green tint.</param>
+		/// <param name="colorB">Blue tint.</param>
+		/// <param name="colorA">Alpha value.</param>
 		[DllImport("ScriptHookV.dll", ExactSpelling = true, EntryPoint = "?drawTexture@@YAXHHHHMMMMMMMMMMMM@Z")]
 		public static extern void DrawTexture(int id, int instance, int level, int time, float sizeX, float sizeY, float centerX, float centerY, float posX, float posY, float rotation, float scaleFactor, float colorR, float colorG, float colorB, float colorA);
+
 		/// <summary>
 		/// Gets the game version enumeration value as specified by ScriptHookV.
 		/// </summary>
 		[DllImport("ScriptHookV.dll", ExactSpelling = true, EntryPoint = "?getGameVersion@@YA?AW4eGameVersion@@XZ")]
 		public static extern int GetGameVersion();
+
 		/// <summary>
 		/// Returns pointer to a global variable. IDs may differ between game versions.
 		/// </summary>
-		/// <param name = "index">The variable ID to query.</param>
-		/// <returns>Pointer to the variable, or <see cref = "IntPtr.Zero"/> if it does not exist.</returns>
+		/// <param name="index">The variable ID to query.</param>
+		/// <returns>Pointer to the variable, or <see cref="IntPtr.Zero"/> if it does not exist.</returns>
 		[DllImport("ScriptHookV.dll", ExactSpelling = true, EntryPoint = "?getGlobalPtr@@YAPEA_KH@Z")]
 		public static extern IntPtr GetGlobalPtr(int index);
 		#endregion
+
 		/// <summary>
 		/// Searches the address space of the current process for a memory pattern.
 		/// </summary>
-		/// <param name = "pattern">The pattern.</param>
-		/// <param name = "mask">The pattern mask.</param>
-		/// <returns>The address of a region matching the pattern or <see langword="null"/> if none was found.</returns>
+		/// <param name="pattern">The pattern.</param>
+		/// <param name="mask">The pattern mask.</param>
+		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
 		public static unsafe byte* FindPattern(string pattern, string mask)
 		{
 			ProcessModule module = Process.GetCurrentProcess().MainModule;
@@ -77,31 +82,35 @@ namespace SHVDN
 		/// <summary>
 		/// Searches the specific address space of the current process for a memory pattern.
 		/// </summary>
-		/// <param name = "pattern">The pattern.</param>
-		/// <param name = "mask">The pattern mask.</param>
-		/// <param name = "startAddress">The address to start searching at.</param>
-		/// <returns>The address of a region matching the pattern or <see langword="null"/> if none was found.</returns>
+		/// <param name="pattern">The pattern.</param>
+		/// <param name="mask">The pattern mask.</param>
+		/// <param name="startAddress">The address to start searching at.</param>
+		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
 		public static unsafe byte* FindPattern(string pattern, string mask, IntPtr startAddress)
 		{
 			ProcessModule module = Process.GetCurrentProcess().MainModule;
+
 			if ((ulong)startAddress.ToInt64() < (ulong)module.BaseAddress.ToInt64())
 				return null;
+
 			ulong size = (ulong)module.ModuleMemorySize - ((ulong)startAddress - (ulong)module.BaseAddress);
+
 			return FindPattern(pattern, mask, startAddress, size);
 		}
 
 		/// <summary>
 		/// Searches the specific address space of the current process for a memory pattern.
 		/// </summary>
-		/// <param name = "pattern">The pattern.</param>
-		/// <param name = "mask">The pattern mask.</param>
-		/// <param name = "startAddress">The address to start searching at.</param>
-		/// <param name = "size">The size where the pattern search will be performed from <paramref name = "startAddress"/>.</param>
-		/// <returns>The address of a region matching the pattern or <see langword="null"/> if none was found.</returns>
+		/// <param name="pattern">The pattern.</param>
+		/// <param name="mask">The pattern mask.</param>
+		/// <param name="startAddress">The address to start searching at.</param>
+		/// <param name="size">The size where the pattern search will be performed from <paramref name="startAddress"/>.</param>
+		/// <returns>The address of a region matching the pattern or <see langword="null" /> if none was found.</returns>
 		public static unsafe byte* FindPattern(string pattern, string mask, IntPtr startAddress, ulong size)
 		{
 			ulong address = (ulong)startAddress.ToInt64();
 			ulong endAddress = address + size;
+
 			for (; address < endAddress; address++)
 			{
 				for (int i = 0; i < pattern.Length; i++)
@@ -123,51 +132,73 @@ namespace SHVDN
 		{
 			byte* address;
 			IntPtr startAddressToSearch;
+
 			// Get relative address and add it to the instruction address.
 			address = FindPattern("\x74\x21\x48\x8B\x48\x20\x48\x85\xC9\x74\x18\x48\x8B\xD6\xE8", "xxxxxxxxxxxxxxx") - 10;
-			GetPtfxAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(new IntPtr(*(int*)(address) + address + 4));
+			GetPtfxAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(
+				new IntPtr(*(int*)(address) + address + 4));
+
 			address = FindPattern("\xE8\x00\x00\x00\x00\x48\x8B\xD8\x48\x85\xC0\x74\x2E\x48\x83\x3D", "x????xxxxxxxxxxx");
-			GetEntityAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(new IntPtr(*(int*)(address + 1) + address + 5));
+			GetEntityAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(
+				new IntPtr(*(int*)(address + 1) + address + 5));
+
 			address = FindPattern("\xB2\x01\xE8\x00\x00\x00\x00\x48\x85\xC0\x74\x1C\x8A\x88", "xxx????xxxxxxx");
-			GetPlayerAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(new IntPtr(*(int*)(address + 3) + address + 7));
+			GetPlayerAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(
+				new IntPtr(*(int*)(address + 3) + address + 7));
+
 			address = FindPattern("\x48\xF7\xF9\x49\x8B\x48\x08\x48\x63\xD0\xC1\xE0\x08\x0F\xB6\x1C\x11\x03\xD8", "xxxxxxxxxxxxxxxxxxx");
-			AddEntityToPoolFunc = (delegate* unmanaged[Stdcall]<ulong, int>)(new IntPtr(address - 0x68));
+			AddEntityToPoolFunc = (delegate* unmanaged[Stdcall]<ulong, int>)(
+				new IntPtr(address - 0x68));
+
 			address = FindPattern("\x48\x8B\xDA\xE8\x00\x00\x00\x00\xF3\x0F\x10\x44\x24", "xxxx????xxxxx");
-			EntityPosFunc = (delegate* unmanaged[Stdcall]<ulong, float*, ulong>)(new IntPtr((address - 6)));
+			EntityPosFunc = (delegate* unmanaged[Stdcall]<ulong, float*, ulong>)(
+				new IntPtr((address - 6)));
+
 			address = FindPattern("\x0F\x85\x00\x00\x00\x00\x48\x8B\x4B\x20\xE8\x00\x00\x00\x00\x48\x8B\xC8", "xx????xxxxx????xxx");
-			EntityModel1Func = (delegate* unmanaged[Stdcall]<ulong, ulong>)(new IntPtr((*(int*)address + 11) + address + 15));
+			EntityModel1Func = (delegate* unmanaged[Stdcall]<ulong, ulong>)(
+				new IntPtr((*(int*)address + 11) + address + 15));
+
 			address = FindPattern("\x45\x33\xC9\x3B\x05", "xxxxx");
-			EntityModel2Func = (delegate* unmanaged[Stdcall]<ulong, ulong>)(new IntPtr(address - 0x46));
+			EntityModel2Func = (delegate* unmanaged[Stdcall]<ulong, ulong>)(
+				new IntPtr(address - 0x46));
+
 			// Find handling data functions
 			address = FindPattern("\x0F\x84\x00\x00\x00\x00\x8B\x8B\x00\x00\x00\x00\xE8\x00\x00\x00\x00\xBA\x09\x00\x00\x00", "xx????xx????x????xxxxx");
-			GetHandlingDataByIndex = (delegate* unmanaged[Stdcall]<int, ulong>)(new IntPtr(*(int*)(address + 13) + address + 17));
+			GetHandlingDataByIndex = (delegate* unmanaged[Stdcall]<int, ulong>)(
+				new IntPtr(*(int*)(address + 13) + address + 17));
 			handlingIndexOffsetInModelInfo = *(int*)(address + 8);
+
 			address = FindPattern("\xE8\x00\x00\x00\x00\x48\x85\xC0\x75\x5A\xB2\x01", "x????xxxxxxx");
-			GetHandlingDataByHash = (delegate* unmanaged[Stdcall]<IntPtr, ulong>)(new IntPtr(*(int*)(address + 1) + address + 5));
+			GetHandlingDataByHash = (delegate* unmanaged[Stdcall]<IntPtr, ulong>)(
+				new IntPtr(*(int*)(address + 1) + address + 5));
+
 			// Find entity pools and interior proxy pool
 			address = FindPattern("\x48\x8B\x05\x00\x00\x00\x00\x41\x0F\xBF\xC8\x0F\xBF\x40\x10", "xxx????xxxxxxxx");
 			PedPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
+
 			address = FindPattern("\x48\x8B\x05\x00\x00\x00\x00\x8B\x78\x10\x85\xFF", "xxx????xxxxx");
 			ObjectPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
+
 			address = FindPattern("\x4C\x8B\x0D\x00\x00\x00\x00\x44\x8B\xC1\x49\x8B\x41\x08", "xxx????xxxxxxx");
 			EntityPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
+
 			address = FindPattern("\x48\x8B\x05\x00\x00\x00\x00\xF3\x0F\x59\xF6\x48\x8B\x08", "xxx????xxxxxxx");
 			VehiclePoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
+
 			address = FindPattern("\x4C\x8B\x05\x00\x00\x00\x00\x40\x8A\xF2\x8B\xE9", "xxx????xxxxx");
 			PickupObjectPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
+
 			address = FindPattern("\x83\x38\xFF\x74\x27\xD1\xEA\xF6\xC2\x01\x74\x20", "xxxxxxxxxxxx");
 			if (address != null)
 			{
 				BuildingPoolAddress = (ulong*)(*(int*)(address + 47) + address + 51);
 				AnimatedBuildingPoolAddress = (ulong*)(*(int*)(address + 15) + address + 19);
 			}
-
 			address = FindPattern("\x83\xBB\x80\x01\x00\x00\x01\x75\x12", "xxxxxxxxx");
 			if (address != null)
 			{
 				InteriorInstPoolAddress = (ulong*)(*(int*)(address + 23) + address + 27);
 			}
-
 			address = FindPattern("\x0F\x85\xA3\x00\x00\x00\x8B\x52\x0C\x48\x8B\x0D\x00\x00\x00\x00", "xxxxxxxxxxxx????");
 			if (address != null)
 			{
@@ -177,20 +208,28 @@ namespace SHVDN
 			// Find euphoria functions
 			address = FindPattern("\x40\x53\x48\x83\xEC\x20\x83\x61\x0C\x00\x44\x89\x41\x08\x49\x63\xC0", "xxxxxxxxxxxxxxxxx");
 			InitMessageMemoryFunc = (delegate* unmanaged[Stdcall]<ulong, ulong, int, ulong>)(new IntPtr(address));
+
 			address = FindPattern("\x41\x83\xFA\xFF\x74\x4A\x48\x85\xD2\x74\x19", "xxxxxxxxxxx") - 0xE;
 			SendMessageToPedFunc = (delegate* unmanaged[Stdcall]<ulong, IntPtr, ulong, void>)(new IntPtr(address));
+
 			address = FindPattern("\x48\x89\x5C\x24\x00\x57\x48\x83\xEC\x20\x48\x8B\xD9\x48\x63\x49\x0C\x41\x8B\xF8", "xxxx?xxxxxxxxxxxxxxx");
 			SetNmIntAddress = (delegate* unmanaged[Stdcall]<ulong, IntPtr, int, byte>)(new IntPtr(address));
+
 			address = FindPattern("\x48\x89\x5C\x24\x00\x57\x48\x83\xEC\x20\x48\x8B\xD9\x48\x63\x49\x0C\x41\x8A\xF8", "xxxx?xxxxxxxxxxxxxxx");
 			SetNmBoolAddress = (delegate* unmanaged[Stdcall]<ulong, IntPtr, bool, byte>)(new IntPtr(address));
+
 			address = FindPattern("\x40\x53\x48\x83\xEC\x30\x48\x8B\xD9\x48\x63\x49\x0C", "xxxxxxxxxxxxx");
 			SetNmFloatAddress = (delegate* unmanaged[Stdcall]<ulong, IntPtr, float, byte>)(new IntPtr(address));
+
 			address = FindPattern("\x57\x48\x83\xEC\x20\x48\x8B\xD9\x48\x63\x49\x0C\x49\x8B\xE8", "xxxxxxxxxxxxxxx") - 15;
 			SetNmStringAddress = (delegate* unmanaged[Stdcall]<ulong, IntPtr, IntPtr, byte>)(new IntPtr(address));
+
 			address = FindPattern("\x40\x53\x48\x83\xEC\x40\x48\x8B\xD9\x48\x63\x49\x0C", "xxxxxxxxxxxxx");
 			SetNmVector3Address = (delegate* unmanaged[Stdcall]<ulong, IntPtr, float, float, float, byte>)(new IntPtr(address));
+
 			address = FindPattern("\x83\x79\x10\xFF\x7E\x1D\x48\x63\x41\x10", "xxxxxxxxxx");
 			GetActiveTaskFunc = (delegate* unmanaged[Stdcall]<ulong, CTask*>)(new IntPtr(address));
+
 			address = FindPattern("\x75\xEF\x48\x8B\x5C\x24\x30\xB8\x00\x00\x00\x00", "xxxxxxxx????");
 			if (address != null)
 			{
@@ -207,11 +246,14 @@ namespace SHVDN
 
 			address = FindPattern("\x84\xC0\x74\x34\x48\x8D\x0D\x00\x00\x00\x00\x48\x8B\xD3", "xxxxxxx????xxx");
 			GetLabelTextByHashAddress = (ulong)(*(int*)(address + 7) + address + 11);
+
 			address = FindPattern("\x48\x89\x5C\x24\x08\x48\x89\x6C\x24\x18\x89\x54\x24\x10\x56\x57\x41\x56\x48\x83\xEC\x20", "xxxxxxxxxxxxxxxxxxxxxx");
 			GetLabelTextByHashFunc = (delegate* unmanaged[Stdcall]<ulong, int, ulong>)(new IntPtr(address));
+
 			address = FindPattern("\x8A\x4C\x24\x60\x8B\x50\x10\x44\x8A\xCE", "xxxxxxxxxx");
 			CheckpointPoolAddress = (ulong*)(*(int*)(address + 17) + address + 21);
 			GetCGameScriptHandlerAddressFunc = (delegate* unmanaged[Stdcall]<ulong>)(new IntPtr(*(int*)(address - 19) + address - 15));
+
 			address = FindPattern("\x4C\x8D\x05\x00\x00\x00\x00\x0F\xB7\xC1", "xxx????xxx");
 			RadarBlipPoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
 			address = FindPattern("\xFF\xC6\x49\x83\xC6\x08\x3B\x35\x00\x00\x00\x00\x7C\x9B", "xxxxxxxx????xx");
@@ -222,8 +264,10 @@ namespace SHVDN
 			NorthRadarBlipHandleAddress = (int*)(*(int*)(address + 10) + address + 14);
 			address = FindPattern("\x41\xB8\x06\x00\x00\x00\x8B\xD0\x89\x05\x00\x00\x00\x00\x41\x8D\x48\xFD", "xxxxxxxxxx????xxxx");
 			CenterRadarBlipHandleAddress = (int*)(*(int*)(address + 10) + address + 14);
+
 			address = FindPattern("\x33\xDB\xE8\x00\x00\x00\x00\x48\x85\xC0\x74\x07\x48\x8B\x40\x20\x8B\x58\x18", "xxx????xxxxxxxxxxxx");
 			GetLocalPlayerPedAddressFunc = (delegate* unmanaged[Stdcall]<ulong>)(new IntPtr(*(int*)(address + 3) + address + 7));
+
 			address = FindPattern("\x4C\x8D\x05\x00\x00\x00\x00\x74\x07\xB8\x00\x00\x00\x00\xEB\x2D\x33\xC0", "xxx????xxx????xxxx");
 			waypointInfoArrayStartAddress = (ulong*)(*(int*)(address + 3) + address + 7);
 			if (waypointInfoArrayStartAddress != null)
@@ -238,7 +282,6 @@ namespace SHVDN
 			{
 				GetRotationFromMatrixFunc = (delegate* unmanaged[Stdcall]<float*, ulong, int, float*>)(new IntPtr(*(int*)(address + 12) + address + 16));
 			}
-
 			address = FindPattern("\xF3\x0F\x11\x4D\x38\xF3\x0F\x11\x45\x3C\xE8\x00\x00\x00\x00", "xxxxxxxxxxx????");
 			if (address != null)
 			{
@@ -265,6 +308,7 @@ namespace SHVDN
 				startAddressToSearch = new IntPtr(address);
 				address = FindPattern("\x48\x63\x51\x00\x48\x85\xD2", "xxx?xxx", startAddressToSearch);
 				elementCountOfCAttackerArrayOfEntityOffset = (uint)(*(sbyte*)(address + 3));
+
 				startAddressToSearch = new IntPtr(address);
 				address = FindPattern("\x48\x83\xC1\x00\x48\x3B\xC2\x7C\xEF", "xxx?xxxxx", startAddressToSearch);
 				// the element size might be 0x10 in older builds (the size is 0x18 at least in b1604 and b2372)
@@ -273,32 +317,41 @@ namespace SHVDN
 
 			address = FindPattern("\x48\x8B\x0B\x33\xD2\xE8\x00\x00\x00\x00\x89\x03", "xxxxxx????xx");
 			GetHashKeyFunc = (delegate* unmanaged[Stdcall]<IntPtr, uint, uint>)(new IntPtr(*(int*)(address + 6) + address + 10));
+
 			address = FindPattern("\x74\x11\x8B\xD1\x48\x8D\x0D\x00\x00\x00\x00\x45\x33\xC0", "xxxxxxx????xxx");
 			cursorSpriteAddr = (int*)(*(int*)(address - 4) + address);
+
 			address = FindPattern("\x48\x63\xC1\x48\x8D\x0D\x00\x00\x00\x00\xF3\x0F\x10\x04\x81\xF3\x0F\x11\x05\x00\x00\x00\x00", "xxxxxx????xxxxxxxxx????");
 			readWorldGravityAddress = (float*)(*(int*)(address + 19) + address + 23);
 			writeWorldGravityAddress = (float*)(*(int*)(address + 6) + address + 10);
+
 			address = FindPattern("\xF3\x0F\x11\x05\x00\x00\x00\x00\xF3\x0F\x10\x08\x0F\x2F\xC8\x73\x03\x0F\x28\xC1\x48\x83\xC0\x04\x49\x2B", "xxxx????xxxxxxxxxxxxxxxxxx");
 			var timeScaleArrayAddress = (float*)(*(int*)(address + 4) + address + 8);
 			if (timeScaleArrayAddress != null)
 				// SET_TIME_SCALE changes the 2nd element, so obtain the address of it
 				timeScaleAddress = timeScaleArrayAddress + 1;
+
 			address = FindPattern("\x66\x0F\x6E\x05\x00\x00\x00\x00\x0F\x57\xF6", "xxxx????xxx");
 			millisecondsPerGameMinuteAddress = (int*)(*(int*)(address + 4) + address + 8);
+
 			address = FindPattern("\x75\x2D\x44\x38\x3D\x00\x00\x00\x00\x75\x24", "xxxxx????xx");
 			isClockPausedAddress = (bool*)(*(int*)(address + 5) + address + 9);
+
 			// Find camera objects
 			address = FindPattern("\x48\x8B\xC8\xEB\x02\x33\xC9\x48\x85\xC9\x74\x26", "xxxxxxxxxxxx") - 9;
 			CameraPoolAddress = (ulong*)(*(int*)(address) + address + 4);
 			address = FindPattern("\x48\x8B\xC7\xF3\x0F\x10\x0D", "xxxxxxx") - 0x1D;
 			address = address + *(int*)(address) + 4;
 			GameplayCameraAddress = (ulong*)(*(int*)(address + 3) + address + 7);
+
 			// Find model hash table
 			address = FindPattern("\x3C\x05\x75\x16\x8B\x81\x00\x00\x00\x00", "xxxxxx????");
 			if (address != null)
 				VehicleTypeOffsetInModelInfo = *(int*)(address + 6);
+
 			address = FindPattern("\x66\x81\xF9\x00\x00\x74\x10\x4D\x85\xC0", "xxx??xxxxx") - 0x21;
 			uint vehicleClassOffset = *(uint*)(address + 0x31);
+
 			address = address + *(int*)(address) + 4;
 			modelNum1 = *(UInt32*)(*(int*)(address + 0x52) + address + 0x56);
 			modelNum2 = *(UInt64*)(*(int*)(address + 0x63) + address + 0x67);
@@ -306,22 +359,30 @@ namespace SHVDN
 			modelNum4 = *(UInt64*)(*(int*)(address + 0x81) + address + 0x85);
 			modelHashTable = *(UInt64*)(*(int*)(address + 0x24) + address + 0x28);
 			modelHashEntries = *(UInt16*)(address + *(int*)(address + 3) + 7);
+
 			address = FindPattern("\x33\xD2\x00\x8B\xD0\x00\x2B\x05\x00\x00\x00\x00\xC1\xE6\x10", "xx?xx?xx????xxx");
 			modelInfoArrayPtr = (ulong*)(*(int*)(address + 8) + address + 12);
+
 			address = FindPattern("\x8B\x54\x00\x00\x00\x8D\x0D\x00\x00\x00\x00\xE8\x00\x00\x00\x00\x8A\xC3", "xx???xx????x????xx");
 			cStreamingAddr = (ulong*)(*(int*)(address + 7) + address + 11);
+
 			address = FindPattern("\x48\x8B\x05\x00\x00\x00\x00\x41\x8B\x1E", "xxx????xxx");
 			weaponAndAmmoInfoArrayPtr = (RageAtArrayPtr*)(*(int*)(address + 3) + address + 7);
+
 			address = FindPattern("\x48\x85\xC0\x74\x08\x8B\x90\x00\x00\x00\x00\xEB\x02", "xxxxxxx????xx");
 			weaponInfoHumanNameHashOffset = *(int*)(address + 7);
+
 			address = FindPattern("\x8B\x05\x00\x00\x00\x00\x44\x8B\xD3\x8D\x48\xFF", "xx????xxxxxx");
 			if (address != null)
 			{
 				weaponComponentArrayCountAddr = (uint*)(*(int*)(address + 2) + address + 6);
+
 				address = FindPattern("\x46\x8D\x04\x11\x48\x8D\x15\x00\x00\x00\x00\x41\xD1\xF8", "xxxxxxx????xxx", new IntPtr(address));
 				offsetForCWeaponComponentArrayAddr = (ulong)(address + 7);
+
 				address = FindPattern("\x74\x10\x49\x8B\xC9\xE8\x00\x00\x00\x00", "xxxxxx????", new IntPtr(address));
 				var findAttachPointFuncAddr = new IntPtr((long)(*(int*)(address + 6) + address + 10));
+
 				address = FindPattern("\x4C\x8D\x81\x00\x00\x00\x00", "xxx????", findAttachPointFuncAddr);
 				weaponAttachPointsStartOffset = *(int*)(address + 3);
 				address = FindPattern("\x4D\x63\x98\x00\x00\x00\x00", "xxx????", new IntPtr(address));
@@ -359,7 +420,6 @@ namespace SHVDN
 			{
 				FuelLevelOffset = *(int*)(address + 8);
 			}
-
 			address = FindPattern("\x74\x2D\x0F\x57\xC0\x0F\x2F\x83\x00\x00\x00\x00", "xxxxxxxx????");
 			if (address != null)
 			{
@@ -396,7 +456,9 @@ namespace SHVDN
 
 			// use the former pattern if the version is 1.0.1604.0 or newer
 			var gameVersion = GetGameVersion();
-			address = gameVersion >= 46 ? FindPattern("\xF3\x0F\x10\x9F\xD4\x08\x00\x00\x0F\x2F\xDF\x73\x0A", "xxxx????xxxxx") : FindPattern("\xF3\x0F\x10\x8F\x68\x08\x00\x00\x88\x4D\x8C\x0F\x2F\xCF", "xxxx????xxx???");
+			address = gameVersion >= 46 ?
+						FindPattern("\xF3\x0F\x10\x9F\xD4\x08\x00\x00\x0F\x2F\xDF\x73\x0A", "xxxx????xxxxx") :
+						FindPattern("\xF3\x0F\x10\x8F\x68\x08\x00\x00\x88\x4D\x8C\x0F\x2F\xCF", "xxxx????xxx???");
 			if (address != null)
 			{
 				TurboOffset = *(int*)(address + 4);
@@ -498,11 +560,14 @@ namespace SHVDN
 				string patternForHeliHealthOffsets = "\x48\x85\xC0\x74\x18\x8B\x88\x00\x00\x00\x00\x83\xE9\x08\x83\xF9\x01\x77\x0A\xF3\x0F\x10\x80\x00\x00\x00\x00";
 				string maskForHeliHealthOffsets = "xxxxxxx????xxxxxxxxxxxx????";
 				startAddressToSearch = Process.GetCurrentProcess().MainModule.BaseAddress;
+
 				int[] heliHealthOffsets = new int[3];
+
 				// the pattern will match 3 times
 				for (int i = 0; i < 3; i++)
 				{
 					address = FindPattern(patternForHeliHealthOffsets, maskForHeliHealthOffsets, startAddressToSearch);
+
 					if (address != null)
 					{
 						heliHealthOffsets[i] = *(int*)(address + 23);
@@ -636,7 +701,6 @@ namespace SHVDN
 				PedIsInVehicleOffset = *(int*)(address + 12);
 				PedLastVehicleOffset = *(int*)(address + 0x1A);
 			}
-
 			address = FindPattern("\x24\x3F\x0F\xB6\xC0\x66\x89\x87\x00\x00\x00\x00", "xxxxxxxx????");
 			if (address != null)
 			{
@@ -705,26 +769,22 @@ namespace SHVDN
 			{
 				ProjectilePoolAddress = (ulong*)(*(int*)(address + 3) + address + 7);
 			}
-
 			// Find address of the projectile count, just in case the max number of projectile changes from 50
 			address = FindPattern("\x44\x8B\x0D\x00\x00\x00\x00\x33\xDB\x45\x8A\xF8", "xxx????xxxxx");
 			if (address != null)
 			{
 				ProjectileCountAddress = (int*)(*(int*)(address + 3) + address + 7);
 			}
-
 			address = FindPattern("\x48\x85\xED\x74\x09\x48\x39\xA9\x00\x00\x00\x00\x75\x2D", "xxxxxxxx????xx");
 			if (address != null)
 			{
 				ProjectileOwnerOffset = *(int*)(address + 8);
 			}
-
 			address = FindPattern("\x45\x85\xF6\x74\x0D\x48\x8B\x81\x00\x00\x00\x00\x44\x39\x70\x10", "xxxxxxxx????xxxx");
 			if (address != null)
 			{
 				ProjectileAmmoInfoOffset = *(int*)(address + 8);
 			}
-
 			address = FindPattern("\x39\x70\x10\x75\x17\x40\x84\xED\x74\x09\x33\xD2\xE8", "xxxxxxxxxxxxx");
 			if (address != null)
 			{
@@ -737,13 +797,11 @@ namespace SHVDN
 				getFragInstVFuncOffset = *(sbyte*)(address + 9);
 				detachFragmentPartByIndexFunc = (delegate* unmanaged[Stdcall]<FragInst*, int, FragInst*>)(new IntPtr(*(int*)(address + 16) + address + 20));
 			}
-
 			address = FindPattern("\x00\x8B\x0D\x00\x00\x00\x00\x00\x83\x64\x00\x00\x00\x00\x0F\xB7\xD1\x00\x33\xC9\xE8", "?xx?????xx????xxx?xxx");
 			if (address != null)
 			{
 				phSimulatorInstPtr = (ulong**)(*(int*)(address + 3) + address + 7);
 			}
-
 			address = FindPattern("\x00\x63\x00\x00\x00\x00\x00\x3B\x00\x00\x00\x00\x00\x0F\x8D\x00\x00\x00\x00\x00\x8B\xC8", "?x?????x?????xx?????xx");
 			if (address != null)
 			{
@@ -758,17 +816,28 @@ namespace SHVDN
 				InteriorInstPtrInInteriorProxyOffset = (int)*(byte*)(address + 49);
 			}
 
+
 			// Generate vehicle model list
 			var vehicleHashesGroupedByClass = new List<int>[0x20];
 			for (int i = 0; i < 0x20; i++)
 				vehicleHashesGroupedByClass[i] = new List<int>();
+
 			var vehicleHashesGroupedByType = new List<int>[0x10];
 			for (int i = 0; i < 0x10; i++)
 				vehicleHashesGroupedByType[i] = new List<int>();
+
 			var weaponObjectHashes = new List<int>();
 			var pedHashes = new List<int>();
+
 			// The game will crash when it load these vehicles because of the stub vehicle models
-			var stubVehicles = new HashSet<uint> { 0xA71D0D4F, /* astron2 */ 0x170341C2, /* cyclone2 */ 0x5C54030C, /* arbitergt */ 0x39085F47, /* ignus2 */ 0x438F6593, /* s95 */ };
+			var stubVehicles = new HashSet<uint> {
+				0xA71D0D4F, /* astron2 */
+				0x170341C2, /* cyclone2 */
+				0x5C54030C, /* arbitergt */
+				0x39085F47, /* ignus2 */
+				0x438F6593, /* s95 */
+			};
+
 			for (int i = 0; i < modelHashEntries; i++)
 			{
 				for (HashNode* cur = ((HashNode**)modelHashTable)[i]; cur != null; cur = cur->next)
@@ -793,12 +862,14 @@ namespace SHVDN
 										if (stubVehicles.Contains((uint)cur->hash))
 											continue;
 										vehicleHashesGroupedByClass[*(byte*)(addr2 + vehicleClassOffset) & 0x1F].Add(cur->hash);
+
 										// Normalize the value to vehicle type range for b944 or later versions if current game version is earlier than b944.
 										// The values for CAmphibiousAutomobile and CAmphibiousQuadBike were inserted between those for CSubmarineCar and CHeli in b944.
 										int vehicleTypeInt = *(int*)((byte*)addr2 + VehicleTypeOffsetInModelInfo);
 										if (gameVersion < 28 && vehicleTypeInt >= 6)
 											vehicleTypeInt += 2;
 										vehicleHashesGroupedByType[vehicleTypeInt].Add(cur->hash);
+
 										break;
 									case ModelInfoClassType.Ped:
 										pedHashes.Add(cur->hash);
@@ -814,12 +885,15 @@ namespace SHVDN
 			for (int i = 0; i < 0x20; i++)
 				vehicleResult[i] = Array.AsReadOnly(vehicleHashesGroupedByClass[i].ToArray());
 			VehicleModels = Array.AsReadOnly(vehicleResult);
+
 			vehicleResult = new ReadOnlyCollection<int>[0x10];
 			for (int i = 0; i < 0x10; i++)
 				vehicleResult[i] = Array.AsReadOnly(vehicleHashesGroupedByType[i].ToArray());
 			VehicleModelsGroupedByType = Array.AsReadOnly(vehicleResult);
+
 			WeaponModels = Array.AsReadOnly(weaponObjectHashes.ToArray());
 			PedModels = Array.AsReadOnly(pedHashes.ToArray());
+
 			#region -- Enable All DLC Vehicles --
 			// no need to patch the global variable in v1.0.573.1 or older builds
 			if (gameVersion <= 15)
@@ -829,14 +903,17 @@ namespace SHVDN
 
 			address = FindPattern("\x48\x03\x15\x00\x00\x00\x00\x4C\x23\xC2\x49\x8B\x08", "xxx????xxxxxx");
 			var yscScriptTable = (YscScriptTable*)(address + *(int*)(address + 3) + 7);
+
 			// find the shop_controller script
 			YscScriptTableItem* shopControllerItem = yscScriptTable->FindScript(0x39DA738B);
+
 			if (shopControllerItem == null || !shopControllerItem->IsLoaded())
 			{
 				return;
 			}
 
 			YscScriptHeader* shopControllerHeader = shopControllerItem->header;
+
 			string enableCarsGlobalPattern;
 			if (gameVersion >= 80)
 			{
@@ -851,15 +928,16 @@ namespace SHVDN
 			{
 				enableCarsGlobalPattern = "\x2D\x00\x00\x00\x00\x2C\x01\x00\x00\x56\x04\x00\x6E\x2E\x00\x01\x5F\x00\x00\x00\x00\x04\x00\x6E\x2E\x00\x01";
 			}
-
 			var enableCarsGlobalMask = gameVersion >= 46 ? "x??xxxx??xxxxx?xx????xxxx?x" : "xx??xxxxxx?xx????xxxx?x";
 			var enableCarsGlobalOffset = gameVersion >= 46 ? 17 : 13;
+
 			for (int i = 0; i < shopControllerHeader->CodePageCount(); i++)
 			{
 				int size = shopControllerHeader->GetCodePageSize(i);
 				if (size > 0)
 				{
 					address = FindPattern(enableCarsGlobalPattern, enableCarsGlobalMask, shopControllerHeader->GetCodePageAddress(i), (ulong)size);
+
 					if (address != null)
 					{
 						int globalindex = *(int*)(address + enableCarsGlobalOffset) & 0xFFFFFF;
@@ -871,80 +949,73 @@ namespace SHVDN
 		}
 
 		/// <summary>
-		/// Reads a single 8-bit value from the specified <paramref name = "address"/>.
+		/// Reads a single 8-bit value from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
+		/// <param name="address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static byte ReadByte(IntPtr address)
 		{
 			return *(byte*)address.ToPointer();
 		}
-
 		/// <summary>
-		/// Reads a single 16-bit value from the specified <paramref name = "address"/>.
+		/// Reads a single 16-bit value from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
+		/// <param name="address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static Int16 ReadInt16(IntPtr address)
 		{
 			return *(short*)address.ToPointer();
 		}
-
 		/// <summary>
-		/// Reads a single 32-bit value from the specified <paramref name = "address"/>.
+		/// Reads a single 32-bit value from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
+		/// <param name="address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static Int32 ReadInt32(IntPtr address)
 		{
 			return *(int*)address.ToPointer();
 		}
-
 		/// <summary>
-		/// Reads a single floating-point value from the specified <paramref name = "address"/>.
+		/// Reads a single floating-point value from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
+		/// <param name="address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static float ReadFloat(IntPtr address)
 		{
 			return *(float*)address.ToPointer();
 		}
-
 		/// <summary>
-		/// Reads a null-terminated UTF-8 string from the specified <paramref name = "address"/>.
+		/// Reads a null-terminated UTF-8 string from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
+		/// <param name="address">The memory address to access.</param>
 		/// <returns>The string at the address.</returns>
 		public static String ReadString(IntPtr address)
 		{
 			return PtrToStringUTF8(address);
 		}
-
 		/// <summary>
-		/// Reads a single 64-bit value from the specified <paramref name = "address"/>.
+		/// Reads a single 64-bit value from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
+		/// <param name="address">The memory address to access.</param>
 		/// <returns>The value at the address.</returns>
 		public static IntPtr ReadAddress(IntPtr address)
 		{
 			return new IntPtr(*(void**)(address.ToPointer()));
 		}
-
 		/// <summary>
-		/// Reads a 4x4 floating-point matrix from the specified <paramref name = "address"/>.
+		/// Reads a 4x4 floating-point matrix from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
+		/// <param name="address">The memory address to access.</param>
 		/// <returns>All elements of the matrix in row major arrangement.</returns>
 		public static float[] ReadMatrix(IntPtr address)
 		{
 			var data = (float*)address.ToPointer();
 			return new float[16] { data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15] };
 		}
-
 		/// <summary>
-		/// Reads a 3-component floating-point vector from the specified <paramref name = "address"/>.
+		/// Reads a 3-component floating-point vector from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
+		/// <param name="address">The memory address to access.</param>
 		/// <returns>All elements of the vector.</returns>
 		public static float[] ReadVector3(IntPtr address)
 		{
@@ -953,66 +1024,61 @@ namespace SHVDN
 		}
 
 		/// <summary>
-		/// Writes a single 8-bit value to the specified <paramref name = "address"/>.
+		/// Writes a single 8-bit value to the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "value">The value to write.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="value">The value to write.</param>
 		public static void WriteByte(IntPtr address, byte value)
 		{
 			var data = (byte*)address.ToPointer();
 			*data = value;
 		}
-
 		/// <summary>
-		/// Writes a single 16-bit value to the specified <paramref name = "address"/>.
+		/// Writes a single 16-bit value to the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "value">The value to write.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="value">The value to write.</param>
 		public static void WriteInt16(IntPtr address, Int16 value)
 		{
 			var data = (short*)address.ToPointer();
 			*data = value;
 		}
-
 		/// <summary>
-		/// Writes a single 32-bit value to the specified <paramref name = "address"/>.
+		/// Writes a single 32-bit value to the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "value">The value to write.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="value">The value to write.</param>
 		public static void WriteInt32(IntPtr address, Int32 value)
 		{
 			var data = (int*)address.ToPointer();
 			*data = value;
 		}
-
 		/// <summary>
-		/// Writes a single floating-point value to the specified <paramref name = "address"/>.
+		/// Writes a single floating-point value to the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "value">The value to write.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="value">The value to write.</param>
 		public static void WriteFloat(IntPtr address, float value)
 		{
 			var data = (float*)address.ToPointer();
 			*data = value;
 		}
-
 		/// <summary>
-		/// Writes a 4x4 floating-point matrix to the specified <paramref name = "address"/>.
+		/// Writes a 4x4 floating-point matrix to the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "value">The elements of the matrix in row major arrangement to write.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="value">The elements of the matrix in row major arrangement to write.</param>
 		public static void WriteMatrix(IntPtr address, float[] value)
 		{
 			var data = (float*)(address.ToPointer());
 			for (int i = 0; i < value.Length; i++)
 				data[i] = value[i];
 		}
-
 		/// <summary>
-		/// Writes a 3-component floating-point to the specified <paramref name = "address"/>.
+		/// Writes a 3-component floating-point to the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "value">The vector components to write.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="value">The vector components to write.</param>
 		public static void WriteVector3(IntPtr address, float[] value)
 		{
 			var data = (float*)address.ToPointer();
@@ -1020,12 +1086,11 @@ namespace SHVDN
 			data[1] = value[1];
 			data[2] = value[2];
 		}
-
 		/// <summary>
-		/// Writes a single 64-bit value from the specified <paramref name = "address"/>.
+		/// Writes a single 64-bit value from the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "value">The value to write.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="value">The value to write.</param>
 		public static void WriteAddress(IntPtr address, IntPtr value)
 		{
 			var data = (long*)address.ToPointer();
@@ -1033,41 +1098,42 @@ namespace SHVDN
 		}
 
 		/// <summary>
-		/// Sets a single bit in the 32-bit value at the specified <paramref name = "address"/>.
+		/// Sets a single bit in the 32-bit value at the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "bit">The bit index to change.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="bit">The bit index to change.</param>
 		public static void SetBit(IntPtr address, int bit)
 		{
 			if (bit < 0 || bit > 31)
 				throw new ArgumentOutOfRangeException(nameof(bit), "The bit index has to be between 0 and 31");
+
 			var data = (int*)address.ToPointer();
 			*data |= (1 << bit);
 		}
-
 		/// <summary>
-		/// Clears a single bit in the 32-bit value at the specified <paramref name = "address"/>.
+		/// Clears a single bit in the 32-bit value at the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "bit">The bit index to change.</param>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="bit">The bit index to change.</param>
 		public static void ClearBit(IntPtr address, int bit)
 		{
 			if (bit < 0 || bit > 31)
 				throw new ArgumentOutOfRangeException(nameof(bit), "The bit index has to be between 0 and 31");
+
 			var data = (int*)address.ToPointer();
 			*data &= ~(1 << bit);
 		}
-
 		/// <summary>
-		/// Checks a single bit in the 32-bit value at the specified <paramref name = "address"/>.
+		/// Checks a single bit in the 32-bit value at the specified <paramref name="address"/>.
 		/// </summary>
-		/// <param name = "address">The memory address to access.</param>
-		/// <param name = "bit">The bit index to check.</param>
-		/// <returns><see langword="true"/> if the bit is set, <see langword="false"/> if it is unset.</returns>
+		/// <param name="address">The memory address to access.</param>
+		/// <param name="bit">The bit index to check.</param>
+		/// <returns><see langword="true" /> if the bit is set, <see langword="false" /> if it is unset.</returns>
 		public static bool IsBitSet(IntPtr address, int bit)
 		{
 			if (bit < 0 || bit > 31)
 				throw new ArgumentOutOfRangeException(nameof(bit), "The bit index has to be between 0 and 31");
+
 			var data = (int*)address.ToPointer();
 			return (*data & (1 << bit)) != 0;
 		}
@@ -1076,33 +1142,38 @@ namespace SHVDN
 		public static readonly IntPtr String = StringToCoTaskMemUTF8("STRING");
 		public static readonly IntPtr NullString = StringToCoTaskMemUTF8(string.Empty);
 		public static readonly IntPtr CellEmailBcon = StringToCoTaskMemUTF8("CELL_EMAIL_BCON");
+
 		public static string PtrToStringUTF8(IntPtr ptr)
 		{
 			if (ptr == IntPtr.Zero)
 				return string.Empty;
+
 			var data = (byte*)ptr.ToPointer();
+
 			// Calculate length of null-terminated string
 			int len = 0;
 			while (data[len] != 0)
 				++len;
+
 			return PtrToStringUTF8(ptr, len);
 		}
-
 		public static string PtrToStringUTF8(IntPtr ptr, int len)
 		{
 			if (len < 0)
 				throw new ArgumentException(null, nameof(len));
+
 			if (ptr == IntPtr.Zero)
 				return null;
 			if (len == 0)
 				return string.Empty;
+
 			return Encoding.UTF8.GetString((byte*)ptr.ToPointer(), len);
 		}
-
 		public static IntPtr StringToCoTaskMemUTF8(string s)
 		{
 			if (s == null)
 				return IntPtr.Zero;
+
 			int byteCountUtf8 = Encoding.UTF8.GetByteCount(s);
 			if (byteCountUtf8 > _strBufferForStringToCoTaskMemUTF8.Length)
 			{
@@ -1113,13 +1184,16 @@ namespace SHVDN
 			IntPtr dest = AllocCoTaskMem(byteCountUtf8 + 1);
 			if (dest == IntPtr.Zero)
 				throw new OutOfMemoryException();
+
 			Copy(_strBufferForStringToCoTaskMemUTF8, 0, dest, byteCountUtf8);
 			// Add null-terminator to end
 			((byte*)dest.ToPointer())[byteCountUtf8] = 0;
+
 			return dest;
 		}
 
 		#region -- RAGE classes --
+
 		[StructLayout(LayoutKind.Explicit, Size = 0xC)]
 		struct RageAtArrayPtr
 		{
@@ -1129,6 +1203,7 @@ namespace SHVDN
 			internal ushort size;
 			[FieldOffset(0xA)]
 			internal ushort capacity;
+
 			internal ulong GetElementAddress(int i)
 			{
 				return data[i];
@@ -1136,9 +1211,12 @@ namespace SHVDN
 		}
 
 		#endregion
+
 		#region -- Cameras --
+
 		static ulong* CameraPoolAddress;
 		static ulong* GameplayCameraAddress;
+
 		public static IntPtr GetCameraAddress(int handle)
 		{
 			uint index = (uint)(handle >> 8);
@@ -1147,16 +1225,15 @@ namespace SHVDN
 			{
 				return new IntPtr(*(long*)poolAddr + (index * *(uint*)(poolAddr + 20)));
 			}
-
 			return IntPtr.Zero;
-		}
 
+		}
 		public static IntPtr GetGameplayCameraAddress()
 		{
 			return new IntPtr((long)*GameplayCameraAddress);
 		}
-
 		static delegate* unmanaged[Stdcall]<IntPtr, uint, uint> GetHashKeyFunc;
+
 		public static uint GetHashKey(string key)
 		{
 			IntPtr keyPtr = ScriptDomain.CurrentDomain.PinString(key);
@@ -1165,6 +1242,7 @@ namespace SHVDN
 
 		static ulong GetLabelTextByHashAddress;
 		static delegate* unmanaged[Stdcall]<ulong, int, ulong> GetLabelTextByHashFunc;
+
 		public static string GetGXTEntryByHash(int entryLabelHash)
 		{
 			var entryText = (char*)GetLabelTextByHashFunc(GetLabelTextByHashAddress, entryLabelHash);
@@ -1172,7 +1250,9 @@ namespace SHVDN
 		}
 
 		#endregion
+
 		#region -- YSC Script Data --
+
 		[StructLayout(LayoutKind.Explicit)]
 		struct YscScriptHeader
 		{
@@ -1190,16 +1270,15 @@ namespace SHVDN
 			internal long* nativeOffset;
 			[FieldOffset(0x58)]
 			internal int nameHash;
+
 			internal int CodePageCount()
 			{
 				return (codeLength + 0x3FFF) >> 14;
 			}
-
 			internal int GetCodePageSize(int page)
 			{
 				return (page < 0 || page >= CodePageCount() ? 0 : (page == CodePageCount() - 1) ? codeLength & 0x3FFF : 0x4000);
 			}
-
 			internal IntPtr GetCodePageAddress(int page)
 			{
 				return new IntPtr(codeBlocksOffset[page]);
@@ -1213,6 +1292,7 @@ namespace SHVDN
 			internal YscScriptHeader* header;
 			[FieldOffset(0xC)]
 			internal int hash;
+
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			internal bool IsLoaded()
 			{
@@ -1227,13 +1307,13 @@ namespace SHVDN
 			internal YscScriptTableItem* TablePtr;
 			[FieldOffset(0x18)]
 			internal uint count;
+
 			internal YscScriptTableItem* FindScript(int hash)
 			{
 				if (TablePtr == null)
 				{
 					return null; //table initialisation hasnt happened yet
 				}
-
 				for (int i = 0; i < count; i++)
 				{
 					if (TablePtr[i].hash == hash)
@@ -1241,66 +1321,56 @@ namespace SHVDN
 						return &TablePtr[i];
 					}
 				}
-
 				return null;
 			}
 		}
 
+
 		#endregion
+
 		#region -- World Data --
+
 		static int* cursorSpriteAddr;
+
 		public static int CursorSprite
 		{
-			get
-			{
-				return *cursorSpriteAddr;
-			}
+			get { return *cursorSpriteAddr; }
 		}
 
 		static float* timeScaleAddress;
+
 		public static float TimeScale
 		{
-			get
-			{
-				return *timeScaleAddress;
-			}
+			get { return *timeScaleAddress; }
 		}
 
 		static int* millisecondsPerGameMinuteAddress;
+
 		public static int MillisecondsPerGameMinute
 		{
-			set
-			{
-				*millisecondsPerGameMinuteAddress = value;
-			}
+			set { *millisecondsPerGameMinuteAddress = value; }
 		}
 
 		static bool* isClockPausedAddress;
+
 		public static bool IsClockPaused
 		{
-			get
-			{
-				return *isClockPausedAddress;
-			}
+			get { return *isClockPausedAddress; }
 		}
 
 		static float* readWorldGravityAddress;
 		static float* writeWorldGravityAddress;
+
 		public static float WorldGravity
 		{
-			get
-			{
-				return *readWorldGravityAddress;
-			}
-
-			set
-			{
-				*writeWorldGravityAddress = value;
-			}
+			get { return *readWorldGravityAddress; }
+			set { *writeWorldGravityAddress = value; }
 		}
 
 		#endregion
+
 		#region -- Skeleton Data --
+
 		static CrSkeleton* GetCrSkeletonOfEntityHandle(int handle) => GetCrSkeletonOfEntity(new IntPtr((long)GetEntityAddressFunc(handle)));
 		static CrSkeleton* GetCrSkeletonOfEntity(IntPtr entityAddress)
 		{
@@ -1323,14 +1393,15 @@ namespace SHVDN
 				}
 			}
 		}
-
 		static CrSkeleton* GetEntityCrSkeletonOfFragInst(FragInst* fragInst)
 		{
 			var fragCacheEntry = fragInst->fragCacheEntry;
 			var gtaFragType = fragInst->gtaFragType;
+
 			// Check if either pointer is null just like native functions that take a bone index argument
 			if (fragCacheEntry == null || gtaFragType == null)
 				return null;
+
 			return fragCacheEntry->crSkeleton;
 		}
 
@@ -1339,14 +1410,15 @@ namespace SHVDN
 			var crSkeleton = GetCrSkeletonOfEntityHandle(handle);
 			return crSkeleton != null ? crSkeleton->boneCount : 0;
 		}
-
 		public static IntPtr GetEntityBonePoseAddress(int handle, int boneIndex)
 		{
 			if ((boneIndex & 0x80000000) != 0) // boneIndex cant be negative
 				return IntPtr.Zero;
+
 			var crSkeletonData = GetCrSkeletonOfEntityHandle(handle);
 			if (crSkeletonData == null)
 				return IntPtr.Zero;
+
 			if (boneIndex < crSkeletonData->boneCount)
 			{
 				return crSkeletonData->GetBonePoseMatrixAddress(boneIndex);
@@ -1354,14 +1426,15 @@ namespace SHVDN
 
 			return IntPtr.Zero;
 		}
-
 		public static IntPtr GetEntityBoneMatrixAddress(int handle, int boneIndex)
 		{
 			if ((boneIndex & 0x80000000) != 0) // boneIndex cant be negative
 				return IntPtr.Zero;
+
 			var crSkeletonData = GetCrSkeletonOfEntityHandle(handle);
 			if (crSkeletonData == null)
 				return IntPtr.Zero;
+
 			if (boneIndex < crSkeletonData->boneCount)
 			{
 				return crSkeletonData->GetBoneMatrixAddress(boneIndex);
@@ -1369,35 +1442,33 @@ namespace SHVDN
 
 			return IntPtr.Zero;
 		}
-
 		static delegate* unmanaged[Stdcall]<float*, ulong, int, float*> GetRotationFromMatrixFunc;
 		static delegate* unmanaged[Stdcall]<float*, ulong, int> GetQuaternionFromMatrixFunc;
+
 		public static void GetRotationFromMatrix(float* returnRotationArray, IntPtr matrixAddress, int rotationOrder = 2)
 		{
 			GetRotationFromMatrixFunc(returnRotationArray, (ulong)matrixAddress.ToInt64(), rotationOrder);
+
 			const float RAD_2_DEG = 57.2957763671875f; // 0x42652EE0 in hex. Exactly the same value as the GET_ENTITY_ROTATION multiplies the rotation values in radian by.
 			returnRotationArray[0] *= RAD_2_DEG;
 			returnRotationArray[1] *= RAD_2_DEG;
 			returnRotationArray[2] *= RAD_2_DEG;
 		}
-
 		public static void GetQuaternionFromMatrix(float* returnRotationArray, IntPtr matrixAddress)
 		{
 			GetQuaternionFromMatrixFunc(returnRotationArray, (ulong)matrixAddress.ToInt64());
 		}
 
 		#endregion
+
 		#region -- CPhysical Offsets --
+
 		public static int EntityMaxHealthOffset { get; }
-
 		public static int SetAngularVelocityVFuncOfEntityOffset { get; }
-
 		public static int GetAngularVelocityVFuncOfEntityOffset { get; }
 
 		public static uint cAttackerArrayOfEntityOffset { get; }
-
 		public static uint elementCountOfCAttackerArrayOfEntityOffset { get; }
-
 		public static uint elementSizeOfCAttackerArrayOfEntity { get; }
 
 		internal class SetEntityAngularVelocityTask : IScriptTask
@@ -1407,6 +1478,7 @@ namespace SHVDN
 			delegate* unmanaged[Stdcall]<IntPtr, float*, void> setAngularVelocityDelegate;
 			float x, y, z;
 			#endregion
+
 			internal SetEntityAngularVelocityTask(IntPtr entityAddress, delegate* unmanaged[Stdcall]<IntPtr, float*, void> vFuncDelegate, float x, float y, float z)
 			{
 				this.entityAddress = entityAddress;
@@ -1422,6 +1494,7 @@ namespace SHVDN
 				angularVelocity[0] = x;
 				angularVelocity[1] = y;
 				angularVelocity[2] = z;
+
 				setAngularVelocityDelegate(entityAddress, angularVelocity);
 			}
 		}
@@ -1430,6 +1503,7 @@ namespace SHVDN
 		{
 			var vFuncAddr = *(ulong*)(*(ulong*)entityAddress.ToPointer() + (uint)GetAngularVelocityVFuncOfEntityOffset);
 			var getEntityAngularVelocity = (delegate* unmanaged[Stdcall]<IntPtr, float*>)(vFuncAddr);
+
 			return getEntityAngularVelocity(entityAddress);
 		}
 
@@ -1437,12 +1511,15 @@ namespace SHVDN
 		{
 			var vFuncAddr = *(ulong*)(*(ulong*)entityAddress.ToPointer() + (uint)SetAngularVelocityVFuncOfEntityOffset);
 			var setEntityAngularVelocityDelegate = (delegate* unmanaged[Stdcall]<IntPtr, float*, void>)(vFuncAddr);
+
 			var task = new SetEntityAngularVelocityTask(entityAddress, setEntityAngularVelocityDelegate, x, y, z);
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
 		}
 
 		#endregion
+
 		#region -- CPhysical Data --
+
 		// the size is at least 0x10 in all game versions
 		[StructLayout(LayoutKind.Explicit, Size = 0x10)]
 		struct CAttacker
@@ -1457,42 +1534,57 @@ namespace SHVDN
 
 		public static bool IsIndexOfEntityDamageRecordValid(IntPtr entityAddress, uint index)
 		{
-			if (index < 0 || cAttackerArrayOfEntityOffset == 0 || elementCountOfCAttackerArrayOfEntityOffset == 0 || elementSizeOfCAttackerArrayOfEntity == 0)
+			if (index < 0 ||
+				cAttackerArrayOfEntityOffset == 0 ||
+				elementCountOfCAttackerArrayOfEntityOffset == 0 ||
+				elementSizeOfCAttackerArrayOfEntity == 0)
 				return false;
+
 			ulong entityCAttackerArrayAddress = *(ulong*)(entityAddress + (int)cAttackerArrayOfEntityOffset).ToPointer();
+
 			if (entityCAttackerArrayAddress == 0)
 				return false;
+
 			var entryCount = *(int*)(entityCAttackerArrayAddress + elementCountOfCAttackerArrayOfEntityOffset);
+
 			return index < entryCount;
 		}
-
 		static (int attackerHandle, int weaponHash, int gameTime) GetEntityDamageRecordEntryAtIndexInternal(ulong cAttackerArrayAddress, uint index)
 		{
 			var cAttacker = (CAttacker*)(cAttackerArrayAddress + index * elementSizeOfCAttackerArrayOfEntity);
+
 			var attackerEntityAddress = cAttacker->attackerEntityAddress;
 			var weaponHash = cAttacker->weaponHash;
 			var gameTime = cAttacker->gameTime;
 			var attackerHandle = attackerEntityAddress != 0 ? GetEntityHandleFromAddress(new IntPtr((long)attackerEntityAddress)) : 0;
+
 			return (attackerHandle, weaponHash, gameTime);
 		}
-
 		public static (int attackerHandle, int weaponHash, int gameTime) GetEntityDamageRecordEntryAtIndex(IntPtr entityAddress, uint index)
 		{
 			ulong entityCAttackerArrayAddress = *(ulong*)(entityAddress + (int)cAttackerArrayOfEntityOffset).ToPointer();
+
 			if (entityCAttackerArrayAddress == 0)
 				return default((int attackerHandle, int weaponHash, int gameTime));
+
 			return GetEntityDamageRecordEntryAtIndexInternal(entityCAttackerArrayAddress, index);
 		}
 
 		public static (int attackerHandle, int weaponHash, int gameTime)[] GetEntityDamageRecordEntries(IntPtr entityAddress)
 		{
-			if (cAttackerArrayOfEntityOffset == 0 || elementCountOfCAttackerArrayOfEntityOffset == 0 || elementSizeOfCAttackerArrayOfEntity == 0)
+			if (cAttackerArrayOfEntityOffset == 0 ||
+				elementCountOfCAttackerArrayOfEntityOffset == 0 ||
+				elementSizeOfCAttackerArrayOfEntity == 0)
 				return Array.Empty<(int handle, int weaponHash, int gameTime)>();
+
 			ulong entityCAttackerArrayAddress = *(ulong*)(entityAddress + (int)cAttackerArrayOfEntityOffset).ToPointer();
+
 			if (entityCAttackerArrayAddress == 0)
 				return Array.Empty<(int attackerHandle, int weaponHash, int gameTime)>();
+
 			var returnEntrySize = *(int*)(entityCAttackerArrayAddress + elementCountOfCAttackerArrayOfEntityOffset);
 			var returnEntries = returnEntrySize != 0 ? new (int attackerHandle, int weaponHash, int gameTime)[returnEntrySize] : Array.Empty<(int attackerHandle, int weaponHash, int gameTime)>();
+
 			for (uint i = 0; i < returnEntries.Length; i++)
 			{
 				returnEntries[i] = GetEntityDamageRecordEntryAtIndexInternal(entityCAttackerArrayAddress, i);
@@ -1502,7 +1594,9 @@ namespace SHVDN
 		}
 
 		#endregion
+
 		#region -- CPed Data --
+
 		/// <summary>
 		/// <para>Gets the last vehicle the ped used or is using.</para>
 		/// <para>
@@ -1516,6 +1610,7 @@ namespace SHVDN
 		{
 			if (PedLastVehicleOffset == 0)
 				return 0;
+
 			var lastVehicleAddress = new IntPtr(*(long*)(pedAddress + PedLastVehicleOffset));
 			return lastVehicleAddress != IntPtr.Zero ? GetEntityHandleFromAddress(lastVehicleAddress) : 0;
 		}
@@ -1530,56 +1625,47 @@ namespace SHVDN
 		{
 			if (PedIsInVehicleOffset == 0 || PedLastVehicleOffset == 0)
 				return 0;
+
 			var bitFlags = *(uint*)(pedAddress + PedIsInVehicleOffset);
 			bool isPedInVehicle = ((bitFlags & (1 << 0x1E)) != 0);
 			if (!isPedInVehicle)
 				return 0;
+
 			var lastVehicleAddress = new IntPtr(*(long*)(pedAddress + PedLastVehicleOffset));
 			return lastVehicleAddress != IntPtr.Zero ? GetEntityHandleFromAddress(lastVehicleAddress) : 0;
 		}
 
 		#endregion
+
 		#region -- Vehicle Offsets --
+
 		public static int NextGearOffset { get; }
-
 		public static int GearOffset { get; }
-
 		public static int HighGearOffset { get; }
 
 		public static int CurrentRPMOffset { get; }
-
 		public static int ClutchOffset { get; }
-
 		public static int AccelerationOffset { get; }
 
 		public static int TurboOffset { get; }
 
 		public static int FuelLevelOffset { get; }
-
 		public static int OilLevelOffset { get; }
 
 		public static int VehicleTypeOffsetInCVehicle { get; }
 
 		public static int WheelPtrArrayOffset { get; }
-
 		public static int WheelCountOffset { get; }
-
 		public static int WheelBoneIdToPtrArrayIndexOffset { get; }
-
 		public static int WheelSpeedOffset { get; }
-
 		public static int CanWheelBreakOffset { get; }
 
 		public static int SteeringAngleOffset { get; }
-
 		public static int SteeringScaleOffset { get; }
-
 		public static int ThrottlePowerOffset { get; }
-
 		public static int BrakePowerOffset { get; }
 
 		public static int EngineTemperatureOffset { get; }
-
 		public static int EnginePowerMultiplierOffset { get; }
 
 		public static int DisablePretendOccupantOffset { get; }
@@ -1589,7 +1675,6 @@ namespace SHVDN
 		public static int VehicleLightsMultiplierOffset { get; }
 
 		public static int IsInteriorLightOnOffset { get; }
-
 		public static int IsEngineStartingOffset { get; }
 
 		public static int IsWantedOffset { get; }
@@ -1597,7 +1682,6 @@ namespace SHVDN
 		public static int IsHeadlightDamagedOffset { get; }
 
 		public static int PreviouslyOwnedByPlayerOffset { get; }
-
 		public static int NeedsToBeHotwiredOffset { get; }
 
 		public static int AlarmTimeOffset { get; }
@@ -1609,9 +1693,7 @@ namespace SHVDN
 		public static int HeliBladesSpeedOffset { get; }
 
 		public static int HeliMainRotorHealthOffset { get; }
-
 		public static int HeliTailRotorHealthOffset { get; }
-
 		public static int HeliTailBoomHealthOffset { get; }
 
 		public static int HandlingDataOffset { get; }
@@ -1623,6 +1705,7 @@ namespace SHVDN
 		static delegate* unmanaged[Stdcall]<IntPtr, ulong, float, IntPtr, ulong, ulong, int, byte, bool, void> PunctureVehicleTireOldFunc;
 		static delegate* unmanaged[Stdcall]<IntPtr, void> BurstVehicleTireOnRimNewFunc;
 		static delegate* unmanaged[Stdcall]<IntPtr, IntPtr, void> BurstVehicleTireOnRimOldFunc;
+
 		public static int VehicleWheelSteeringLimitMultiplierOffset { get; }
 
 		public static int VehicleWheelTemperatureOffset { get; }
@@ -1641,11 +1724,14 @@ namespace SHVDN
 		public static int ShouldShowOnlyVehicleTiresWithPositiveHealthOffset { get; }
 
 		public static void FixVehicleWheel(IntPtr wheelAddress) => FixVehicleWheelFunc(wheelAddress);
+
 		public static IntPtr GetVehicleWheelAddressByIndexOfWheelArray(IntPtr vehicleAddress, int index)
 		{
 			var vehicleWheelArrayAddr = *(ulong**)(vehicleAddress + SHVDN.NativeMemory.WheelPtrArrayOffset);
+
 			if (vehicleWheelArrayAddr == null)
 				return IntPtr.Zero;
+
 			return new IntPtr((long)*(vehicleWheelArrayAddr + index));
 		}
 
@@ -1653,23 +1739,28 @@ namespace SHVDN
 		{
 			if (VehicleWheelTouchingFlagsOffset == 0)
 				return false;
+
 			var wheelTouchingFlag = *(uint*)(wheelAddress + VehicleWheelTouchingFlagsOffset).ToPointer();
 			if ((wheelTouchingFlag & 1) != 0)
 				return true;
+
 			#region Slower Check
 			if (((wheelTouchingFlag >> 1) & 1) == 0)
 				return false;
+
 			var phCollider = *(ulong*)(*(ulong*)(vehicleAddress + 0x50).ToPointer() + 0x50);
 			if (phCollider == 0)
 				return true;
 			var unkStructAddr = *(ulong*)(phCollider + 0x18);
 			if (unkStructAddr == 0)
 				return false;
+
 			return (*(uint*)(unkStructAddr + 0x14) & 0xFFFFFFFD) == 0;
 			#endregion
 		}
 
 		static bool VehicleWheelHasVehiclePtr() => PunctureVehicleTireNewFunc != null;
+
 		public static void PunctureTire(IntPtr wheelAddress, float damage, IntPtr vehicleAddress)
 		{
 			var task = new VehicleWheelPunctureTask(wheelAddress, vehicleAddress, false, damage);
@@ -1692,6 +1783,7 @@ namespace SHVDN
 			bool burstWheelCompletely;
 			float damage;
 			#endregion
+
 			internal VehicleWheelPunctureTask(IntPtr wheelAddress, IntPtr vehicleAddress, bool burstWheelCompletely, float damage = 1000f)
 			{
 				this.wheelAddress = wheelAddress;
@@ -1704,6 +1796,7 @@ namespace SHVDN
 			{
 				int outValInt;
 				float outValFloat;
+
 				if (VehicleWheelHasVehiclePtr())
 				{
 					PunctureVehicleTireNewFunc(wheelAddress, 0, damage, (ulong)&outValInt, (ulong)&outValFloat, 3, 0, true);
@@ -1720,7 +1813,9 @@ namespace SHVDN
 		}
 
 		#endregion
+
 		#region -- Ped Offsets --
+
 		public static int SweatOffset { get; }
 
 		// the same offset as the offset for SET_PED_CAN_BE_TARGETTED
@@ -1731,40 +1826,29 @@ namespace SHVDN
 		public static int ArmorOffset { get; }
 
 		public static int InjuryHealthThresholdOffset { get; }
-
 		public static int FatalInjuryHealthThresholdOffset { get; }
 
 		public static int PedIsInVehicleOffset { get; }
-
 		public static int PedLastVehicleOffset { get; }
-
 		public static int SeatIndexOffset { get; }
 
 		public static int PedSourceOfDeathOffset { get; }
-
 		public static int PedCauseOfDeathOffset { get; }
-
 		public static int PedTimeOfDeathOffset { get; }
 
 		#region -- Ped Intelligence Offsets --
+
 		public static int PedIntelligenceOffset { get; }
 
 		public static int FiringPatternOffset { get; }
 
 		public static int SeeingRangeOffset { get; }
-
 		public static int HearingRangeOffset { get; }
-
 		public static int VisualFieldMinAngleOffset { get; }
-
 		public static int VisualFieldMaxAngleOffset { get; }
-
 		public static int VisualFieldMinElevationAngleOffset { get; }
-
 		public static int VisualFieldMaxElevationAngleOffset { get; }
-
 		public static int VisualFieldPeripheralRangeOffset { get; }
-
 		public static int VisualFieldCenterAngleOffset { get; }
 
 		static int CTaskTreePedOffset { get; }
@@ -1774,8 +1858,11 @@ namespace SHVDN
 		static int CEventStackOffset { get; }
 
 		#endregion
+
 		#endregion
+
 		#region -- Model Info --
+
 		[StructLayout(LayoutKind.Sequential)]
 		struct HashNode
 		{
@@ -1795,7 +1882,6 @@ namespace SHVDN
 			Vehicle = 5,
 			Ped = 6
 		}
-
 		enum VehicleStructClassType
 		{
 			None = -1,
@@ -1815,7 +1901,6 @@ namespace SHVDN
 			Train = 0xE,
 			Submarine = 0xF
 		}
-
 		[Flags]
 		public enum VehicleFlag1 : ulong
 		{
@@ -1829,7 +1914,6 @@ namespace SHVDN
 			IsOffroadVehicle = 0x1000000000000,
 			IsBus = 0x400000000000000,
 		}
-
 		[Flags]
 		public enum VehicleFlag2 : ulong
 		{
@@ -1870,12 +1954,14 @@ namespace SHVDN
 		static ulong* modelInfoArrayPtr;
 		static ulong* cStreamingAddr;
 		static ulong* pedPersonalitiesArrayAddr;
+
 		static IntPtr FindCModelInfo(int modelHash)
 		{
 			for (HashNode* cur = ((HashNode**)modelHashTable)[(uint)(modelHash) % modelHashEntries]; cur != null; cur = cur->next)
 			{
 				if (cur->hash != modelHash)
 					continue;
+
 				ushort data = cur->data;
 				bool bitTest = ((*(int*)(modelNum2 + (ulong)(4 * data >> 5))) & (1 << (data & 0x1F))) != 0;
 				if (data < modelNum1 && bitTest)
@@ -1891,7 +1977,6 @@ namespace SHVDN
 
 			return IntPtr.Zero;
 		}
-
 		static ModelInfoClassType GetModelInfoClass(IntPtr address)
 		{
 			if (address != IntPtr.Zero)
@@ -1901,30 +1986,31 @@ namespace SHVDN
 
 			return ModelInfoClassType.Invalid;
 		}
-
 		static VehicleStructClassType GetVehicleStructClass(IntPtr modelInfoAddress)
 		{
 			if (GetModelInfoClass(modelInfoAddress) == ModelInfoClassType.Vehicle)
 			{
 				int typeInt = (*(int*)((byte*)modelInfoAddress.ToPointer() + VehicleTypeOffsetInModelInfo));
+
 				// Normalize the value to vehicle type range for b944 or later versions if current game version is earlier than b944.
 				// The values for CAmphibiousAutomobile and CAmphibiousQuadBike were inserted between those for CSubmarineCar and CHeli in b944.
 				if (GetGameVersion() < 28 && typeInt >= 6)
 					typeInt += 2;
+
 				return (VehicleStructClassType)typeInt;
 			}
 
 			return VehicleStructClassType.None;
 		}
-
 		public static int GetVehicleType(int modelHash)
 		{
 			var modelInfo = FindCModelInfo(modelHash);
+
 			if (modelInfo == IntPtr.Zero)
 				return -1;
+
 			return (int)GetVehicleStructClass(modelInfo);
 		}
-
 		static IntPtr GetModelInfo(IntPtr entityAddress)
 		{
 			if (entityAddress != IntPtr.Zero)
@@ -1934,7 +2020,6 @@ namespace SHVDN
 
 			return IntPtr.Zero;
 		}
-
 		static int GetModelHashFromFwArcheType(IntPtr fwArcheTypeAddress)
 		{
 			if (fwArcheTypeAddress != IntPtr.Zero)
@@ -1944,7 +2029,6 @@ namespace SHVDN
 
 			return 0;
 		}
-
 		public static int GetModelHashFromEntity(IntPtr entityAddress)
 		{
 			if (entityAddress != IntPtr.Zero)
@@ -1963,74 +2047,72 @@ namespace SHVDN
 		{
 			if (modelInfoArrayPtr == null || index < 0)
 				return IntPtr.Zero;
+
 			ulong modelInfoArrayFirstElemPtr = *modelInfoArrayPtr;
+
 			return new IntPtr(*(long*)(modelInfoArrayFirstElemPtr + index * 0x8));
 		}
-
 		public static List<int> GetLoadedAppropriateVehicleHashes()
 		{
 			return GetLoadedHashesOfModelList(0x2D00);
 		}
-
 		public static List<int> GetLoadedAppropriatePedHashes()
 		{
 			return GetLoadedHashesOfModelList(0x4504);
 		}
-
 		internal static List<int> GetLoadedHashesOfModelList(int startOffsetOfCStreaming)
 		{
 			if (modelInfoArrayPtr == null || cStreamingAddr == null)
 				return new List<int>();
+
 			var resultList = new List<int>();
+
 			const int MAX_MODEL_LIST_ELEMENT_COUNT = 256;
 			var modelSet = (CModelList*)((ulong)cStreamingAddr + (uint)startOffsetOfCStreaming);
 			for (uint i = 0; i < MAX_MODEL_LIST_ELEMENT_COUNT; i++)
 			{
 				uint indexOfModelInfo = modelSet->modelMemberIndices[i];
+
 				if (indexOfModelInfo == 0xFFFF)
 					break;
+
 				resultList.Add(GetModelHashFromFwArcheType(GetModelInfoByIndex(indexOfModelInfo)));
 			}
 
 			return resultList;
 		}
 
+
 		public static bool IsModelAPed(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetModelInfoClass(modelInfo) == ModelInfoClassType.Ped;
 		}
-
 		public static bool IsModelABlimp(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Blimp;
 		}
-
 		public static bool IsModelAMotorcycle(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Bike;
 		}
-
 		public static bool IsModelASubmarine(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Submarine;
 		}
-
 		public static bool IsModelASubmarineCar(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.SubmarineCar;
 		}
-
 		public static bool IsModelATrailer(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			return GetVehicleStructClass(modelInfo) == VehicleStructClassType.Trailer;
 		}
-
 		public static bool IsModelAMlo(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
@@ -2040,6 +2122,7 @@ namespace SHVDN
 		public static string GetVehicleMakeName(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
+
 			if (GetModelInfoClass(modelInfo) == ModelInfoClassType.Vehicle)
 			{
 				return PtrToStringUTF8(modelInfo + vehicleMakeNameOffsetInModelInfo);
@@ -2054,7 +2137,9 @@ namespace SHVDN
 		{
 			if (FirstVehicleFlagsOffset == 0)
 				return false;
+
 			IntPtr modelInfo = FindCModelInfo(modelHash);
+
 			if (GetModelInfoClass(modelInfo) == ModelInfoClassType.Vehicle)
 			{
 				var modelFlags = *(ulong*)(modelInfo + FirstVehicleFlagsOffset + flagOffset).ToPointer();
@@ -2065,24 +2150,22 @@ namespace SHVDN
 		}
 
 		public static ReadOnlyCollection<int> WeaponModels { get; }
-
 		public static ReadOnlyCollection<ReadOnlyCollection<int>> VehicleModels { get; }
-
 		public static ReadOnlyCollection<ReadOnlyCollection<int>> VehicleModelsGroupedByType { get; }
-
 		public static ReadOnlyCollection<int> PedModels { get; }
 
 		static delegate* unmanaged[Stdcall]<IntPtr, ulong> GetHandlingDataByHash;
 		static delegate* unmanaged[Stdcall]<int, ulong> GetHandlingDataByIndex;
+
 		public static IntPtr GetHandlingDataByModelHash(int modelHash)
 		{
 			IntPtr modelInfo = FindCModelInfo(modelHash);
 			if (GetModelInfoClass(modelInfo) != ModelInfoClassType.Vehicle)
 				return IntPtr.Zero;
+
 			int handlingIndex = *(int*)(modelInfo + handlingIndexOffsetInModelInfo).ToPointer();
 			return new IntPtr((long)GetHandlingDataByIndex(handlingIndex));
 		}
-
 		public static IntPtr GetHandlingDataByHandlingNameHash(int handlingNameHash)
 		{
 			return new IntPtr((long)GetHandlingDataByHash(new IntPtr(&handlingNameHash)));
@@ -2090,58 +2173,71 @@ namespace SHVDN
 
 		private static PedPersonality* GetPedPersonalityElementAddress(IntPtr modelInfoAddress)
 		{
-			if (modelInfoAddress == IntPtr.Zero || pedPersonalitiesArrayAddr == null || pedPersonalityIndexOffsetInModelInfo == 0 || *(ulong*)pedPersonalitiesArrayAddr == 0)
+			if (modelInfoAddress == IntPtr.Zero ||
+				pedPersonalitiesArrayAddr == null ||
+				pedPersonalityIndexOffsetInModelInfo == 0 ||
+				*(ulong*)pedPersonalitiesArrayAddr == 0)
 				return null;
+
 			if (GetModelInfoClass(modelInfoAddress) != ModelInfoClassType.Ped)
 				return null;
+
 			// This values is not likely to be changed in further updates
 			const int PED_PERSONALITY_ELEMENT_SIZE = 0xB8;
+
 			var indexOfPedPersonality = *(ushort*)(modelInfoAddress + pedPersonalityIndexOffsetInModelInfo).ToPointer();
 			return (PedPersonality*)(*(ulong*)pedPersonalitiesArrayAddr + (uint)(indexOfPedPersonality * PED_PERSONALITY_ELEMENT_SIZE));
 		}
-
 		public static bool IsModelAMalePed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
+
 			if (pedPersonalityAddress == null)
 				return false;
+
 			return pedPersonalityAddress->isMale;
 		}
-
 		public static bool IsModelAFemalePed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
+
 			if (pedPersonalityAddress == null)
 				return false;
+
 			return !pedPersonalityAddress->isMale;
 		}
-
 		public static bool IsModelHumanPed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
+
 			if (pedPersonalityAddress == null)
 				return false;
+
 			return pedPersonalityAddress->isHuman;
 		}
-
 		public static bool IsModelAnAnimalPed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
+
 			if (pedPersonalityAddress == null)
 				return false;
+
 			return !pedPersonalityAddress->isHuman;
 		}
-
 		public static bool IsModelAGangPed(int modelHash)
 		{
 			var pedPersonalityAddress = GetPedPersonalityElementAddress(FindCModelInfo(modelHash));
+
 			if (pedPersonalityAddress == null)
 				return false;
+
 			return pedPersonalityAddress->isGang;
 		}
 
 		#endregion
+
 		#region -- Entity Pools --
+
 		[StructLayout(LayoutKind.Explicit)]
 		struct EntityPool
 		{
@@ -2149,6 +2245,7 @@ namespace SHVDN
 			internal uint num1;
 			[FieldOffset(0x20)]
 			internal uint num2;
+
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			internal bool IsFull()
 			{
@@ -2167,6 +2264,7 @@ namespace SHVDN
 			internal uint* bitArray;
 			[FieldOffset(0x60)]
 			internal uint itemCount;
+
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			internal bool IsValid(uint i)
 			{
@@ -2193,6 +2291,7 @@ namespace SHVDN
 			public uint itemSize;
 			[FieldOffset(0x20)]
 			public ushort itemCount;
+
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			public bool IsValid(uint index)
 			{
@@ -2230,9 +2329,11 @@ namespace SHVDN
 			{
 				if (address < poolStartAddress || address >= poolStartAddress + size * itemSize)
 					return 0;
+
 				var offset = address - poolStartAddress;
 				if (offset % itemSize != 0)
 					return 0;
+
 				var indexOfPool = (uint)(offset / itemSize);
 				return (int)((indexOfPool << 8) + GetCounter(indexOfPool));
 			}
@@ -2268,13 +2369,16 @@ namespace SHVDN
 		static ulong* AnimatedBuildingPoolAddress;
 		static ulong* InteriorInstPoolAddress;
 		static ulong* InteriorProxyPoolAddress;
+
 		static ulong* ProjectilePoolAddress;
 		static int* ProjectileCountAddress;
+
 		// if the entity is a ped and they are in a vehicle, the vehicle position will be returned instead (just like GET_ENTITY_COORDS does)
 		static delegate* unmanaged[Stdcall]<ulong, float*, ulong> EntityPosFunc;
 		static delegate* unmanaged[Stdcall]<ulong, ulong> EntityModel1Func;
 		static delegate* unmanaged[Stdcall]<ulong, ulong> EntityModel2Func;
 		static delegate* unmanaged[Stdcall]<ulong, int> AddEntityToPoolFunc;
+
 		internal class EntityPoolTask : IScriptTask
 		{
 			#region Fields
@@ -2285,6 +2389,7 @@ namespace SHVDN
 			internal int[] modelHashes;
 			internal float radiusSquared;
 			internal float[] position;
+
 			// We should avoid wasting (temp) arrays many times by casually using List, but ArrayPool is not available in .NET Framework. So prepare resource pools manually
 			static int[] _vehicleHandleBuffer;
 			static int[] _pedHandleBuffer;
@@ -2292,6 +2397,7 @@ namespace SHVDN
 			static int[] _pickupObjectHandleBuffer;
 			static int[] _projectileHandleBuffer = new int[50];
 			#endregion
+
 			internal enum Type
 			{
 				Ped = 1,
@@ -2311,13 +2417,16 @@ namespace SHVDN
 			{
 				if (address == 0)
 					return false;
+
 				if (doPosCheck)
 				{
 					float* position = stackalloc float[4];
+
 					NativeMemory.EntityPosFunc(address, position);
 					float x = this.position[0] - position[0];
 					float y = this.position[1] - position[1];
 					float z = this.position[2] - position[2];
+
 					float distanceSquared = (x * x) + (y * y) + (z * z);
 					if (distanceSquared > radiusSquared)
 						return false;
@@ -2336,11 +2445,13 @@ namespace SHVDN
 			int CopyCPhysicalHandlesFromArrayGenericPool(GenericPool* pool, ref int[] handleBuffer)
 			{
 				int returnEntityCount = 0;
+
 				uint entityCountInPool = pool->itemCount;
 				if (handleBuffer == null)
 					handleBuffer = new int[(int)entityCountInPool * 2];
 				else if (entityCountInPool > handleBuffer.Length)
 					handleBuffer = new int[CalculateAppropriateExtendedArrayLength(handleBuffer, (int)entityCountInPool)];
+
 				uint poolSize = pool->size;
 				for (uint i = 0; i < poolSize; i++)
 				{
@@ -2359,22 +2470,27 @@ namespace SHVDN
 			{
 				if (*NativeMemory.EntityPoolAddress == 0)
 					return;
+
 				EntityPool* entityPool = (EntityPool*)(*NativeMemory.EntityPoolAddress);
+
 				#region Store Entity Handles to Buffer Arrays
 				int vehicleCountStored = 0;
 				if (HasFlagFast(poolType, Type.Vehicle) && *NativeMemory.VehiclePoolAddress != 0)
 				{
 					VehiclePool* vehiclePool = *(VehiclePool**)(*NativeMemory.VehiclePoolAddress);
+
 					uint vehicleCountInPool = vehiclePool->itemCount;
 					if (_vehicleHandleBuffer == null)
 						_vehicleHandleBuffer = new int[(int)vehicleCountInPool * 2];
 					else if (_vehicleHandleBuffer == null || vehicleCountInPool > _vehicleHandleBuffer.Length)
 						_vehicleHandleBuffer = new int[CalculateAppropriateExtendedArrayLength(_vehicleHandleBuffer, (int)vehicleCountInPool)];
+
 					uint poolSize = vehiclePool->size;
 					for (uint i = 0; i < poolSize; i++)
 					{
 						if (entityPool->IsFull())
 							break;
+
 						if (vehiclePool->IsValid(i))
 						{
 							ulong address = vehiclePool->GetAddress(i);
@@ -2411,60 +2527,63 @@ namespace SHVDN
 					int projectilesLeft = NativeMemory.GetProjectileCount();
 					int projectileCapacity = NativeMemory.GetProjectileCapacity();
 					ulong* projectilePoolAddress = NativeMemory.ProjectilePoolAddress;
+
 					int projectileCountInPool = projectilesLeft;
 					if (_projectileHandleBuffer == null)
 						_projectileHandleBuffer = new int[(int)projectileCountInPool * 2];
 					else if (projectileCountInPool > _projectileHandleBuffer.Length)
 						_projectileHandleBuffer = new int[CalculateAppropriateExtendedArrayLength(_projectileHandleBuffer, (int)projectileCountInPool)];
+
 					for (uint i = 0; (projectilesLeft > 0 && i < projectileCapacity); i++)
 					{
 						ulong entityAddress = (ulong)ReadAddress(new IntPtr(projectilePoolAddress + i)).ToInt64();
+
 						if (entityAddress == 0)
 							continue;
+
 						projectilesLeft--;
+
 						if (CheckEntity(entityAddress))
 							AddElementAndReallocateIfLengthIsNotLongEnough(ref _projectileHandleBuffer, projectileCountStored++, NativeMemory.AddEntityToPoolFunc(entityAddress));
 					}
 				}
-
 				#endregion
+
 				#region Copy Entity Handles to a New Result Array
 				int totalEntityCount = vehicleCountStored + pedCountStored + objectCountStored + pickupCountStored + projectileCountStored;
 				if (totalEntityCount == 0)
 					return;
+
 				handles = new int[totalEntityCount];
 				int currentStartIndexToCopy = 0;
+
 				if (vehicleCountStored != 0)
 				{
 					Array.Copy(_vehicleHandleBuffer, 0, handles, currentStartIndexToCopy, vehicleCountStored);
 					currentStartIndexToCopy += vehicleCountStored;
 				}
-
 				if (pedCountStored != 0)
 				{
 					Array.Copy(_pedHandleBuffer, 0, handles, currentStartIndexToCopy, pedCountStored);
 					currentStartIndexToCopy += pedCountStored;
 				}
-
 				if (objectCountStored != 0)
 				{
 					Array.Copy(_objectHandleBuffer, 0, handles, currentStartIndexToCopy, objectCountStored);
 					currentStartIndexToCopy += objectCountStored;
 				}
-
 				if (pickupCountStored != 0)
 				{
 					Array.Copy(_pickupObjectHandleBuffer, 0, handles, currentStartIndexToCopy, pickupCountStored);
 					currentStartIndexToCopy += pickupCountStored;
 				}
-
 				if (projectileCountStored != 0)
 				{
 					Array.Copy(_projectileHandleBuffer, 0, handles, currentStartIndexToCopy, projectileCountStored);
 					currentStartIndexToCopy += projectileCountStored;
 				}
-
 				#endregion
+
 				// Enum.HasFlag causes the boxing in .NET Framework and much slower than manually comparing enum flags with bitwise AND
 				bool HasFlagFast(Type poolTypeValue, Type flag) => (poolTypeValue & flag) == flag;
 			}
@@ -2476,6 +2595,7 @@ namespace SHVDN
 			internal ulong entityAddress;
 			internal int returnEntityHandle;
 			#endregion
+
 			internal GetEntityHandleTask(IntPtr entityAddress)
 			{
 				this.entityAddress = (ulong)entityAddress.ToInt64();
@@ -2494,10 +2614,8 @@ namespace SHVDN
 				VehiclePool* pool = *(VehiclePool**)(*VehiclePoolAddress);
 				return (int)pool->itemCount;
 			}
-
 			return 0;
 		}
-
 		public static int GetPedCount() => PedPoolAddress != null ? GetGenericPoolCount(*PedPoolAddress) : 0;
 		public static int GetObjectCount() => ObjectPoolAddress != null ? GetGenericPoolCount(*ObjectPoolAddress) : 0;
 		public static int GetPickupObjectCount() => PickupObjectPoolAddress != null ? GetGenericPoolCount(*PickupObjectPoolAddress) : 0;
@@ -2519,10 +2637,8 @@ namespace SHVDN
 				VehiclePool* pool = *(VehiclePool**)(*VehiclePoolAddress);
 				return (int)pool->size;
 			}
-
 			return 0;
 		}
-
 		public static int GetPedCapacity() => PedPoolAddress != null ? GetGenericPoolCapacity(*PedPoolAddress) : 0;
 		public static int GetObjectCapacity() => ObjectPoolAddress != null ? GetGenericPoolCapacity(*ObjectPoolAddress) : 0;
 		public static int GetPickupObjectCapacity() => PickupObjectPoolAddress != null ? GetGenericPoolCapacity(*PickupObjectPoolAddress) : 0;
@@ -2543,10 +2659,11 @@ namespace SHVDN
 			var task = new EntityPoolTask(EntityPoolTask.Type.Ped);
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
-
 		public static int[] GetPedHandles(float[] position, float radius, int[] modelHashes = null)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Ped);
@@ -2555,7 +2672,9 @@ namespace SHVDN
 			task.doPosCheck = true;
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
 
@@ -2564,10 +2683,11 @@ namespace SHVDN
 			var task = new EntityPoolTask(EntityPoolTask.Type.Object);
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
-
 		public static int[] GetPropHandles(float[] position, float radius, int[] modelHashes = null)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Object);
@@ -2576,24 +2696,29 @@ namespace SHVDN
 			task.doPosCheck = true;
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
 
 		public static int[] GetEntityHandles()
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Ped | EntityPoolTask.Type.Object | EntityPoolTask.Type.Vehicle);
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
-
 		public static int[] GetEntityHandles(float[] position, float radius)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Ped | EntityPoolTask.Type.Object | EntityPoolTask.Type.Vehicle);
 			task.position = position;
 			task.radiusSquared = radius * radius;
 			task.doPosCheck = true;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
 
@@ -2602,10 +2727,11 @@ namespace SHVDN
 			var task = new EntityPoolTask(EntityPoolTask.Type.Vehicle);
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
-
 		public static int[] GetVehicleHandles(float[] position, float radius, int[] modelHashes = null)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Vehicle);
@@ -2614,41 +2740,48 @@ namespace SHVDN
 			task.doPosCheck = true;
 			task.modelHashes = modelHashes;
 			task.doModelCheck = modelHashes != null && modelHashes.Length > 0;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
 
 		public static int[] GetPickupObjectHandles()
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.PickupObject);
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
-
 		public static int[] GetPickupObjectHandles(float[] position, float radius)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.PickupObject);
 			task.position = position;
 			task.radiusSquared = radius * radius;
 			task.doPosCheck = true;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
-
 		public static int[] GetProjectileHandles()
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Projectile);
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
-
 		public static int[] GetProjectileHandles(float[] position, float radius)
 		{
 			var task = new EntityPoolTask(EntityPoolTask.Type.Projectile);
 			task.position = position;
 			task.radiusSquared = radius * radius;
 			task.doPosCheck = true;
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.handles;
 		}
 
@@ -2656,6 +2789,7 @@ namespace SHVDN
 		{
 			if (BuildingPoolAddress == null)
 				return Array.Empty<int>();
+
 			return GetHandlesInGenericPool(*NativeMemory.BuildingPoolAddress);
 		}
 
@@ -2663,6 +2797,7 @@ namespace SHVDN
 		{
 			if (BuildingPoolAddress == null)
 				return Array.Empty<int>();
+
 			return GetCEntityHandlesInRange(*NativeMemory.BuildingPoolAddress, position, radius);
 		}
 
@@ -2670,6 +2805,7 @@ namespace SHVDN
 		{
 			if (AnimatedBuildingPoolAddress == null)
 				return Array.Empty<int>();
+
 			return GetHandlesInGenericPool(*NativeMemory.AnimatedBuildingPoolAddress);
 		}
 
@@ -2677,6 +2813,7 @@ namespace SHVDN
 		{
 			if (AnimatedBuildingPoolAddress == null)
 				return Array.Empty<int>();
+
 			return GetCEntityHandlesInRange(*NativeMemory.AnimatedBuildingPoolAddress, position, radius);
 		}
 
@@ -2684,6 +2821,7 @@ namespace SHVDN
 		{
 			if (InteriorInstPoolAddress == null)
 				return Array.Empty<int>();
+
 			return GetHandlesInGenericPool(*NativeMemory.InteriorInstPoolAddress);
 		}
 
@@ -2691,6 +2829,7 @@ namespace SHVDN
 		{
 			if (InteriorInstPoolAddress == null)
 				return Array.Empty<int>();
+
 			return GetCEntityHandlesInRange(*NativeMemory.InteriorInstPoolAddress, position, radius);
 		}
 
@@ -2698,6 +2837,7 @@ namespace SHVDN
 		{
 			if (InteriorProxyPoolAddress == null)
 				return Array.Empty<int>();
+
 			return GetHandlesInGenericPool(*NativeMemory.InteriorProxyPoolAddress);
 		}
 
@@ -2705,7 +2845,9 @@ namespace SHVDN
 		{
 			if (InteriorProxyPoolAddress == null)
 				return Array.Empty<int>();
+
 			GenericPool* pool = (GenericPool*)(*NativeMemory.InteriorProxyPoolAddress);
+
 			// CInteriorProxy is not a subclass of CEntity and position data is placed at different offset
 			var returnHandles = new List<int>();
 			var poolSize = pool->size;
@@ -2714,13 +2856,17 @@ namespace SHVDN
 			{
 				if (!pool->IsValid(i))
 					continue;
+
 				var address = pool->GetAddress(i);
+
 				float x = *(float*)(address + 0x70) - position[0];
 				float y = *(float*)(address + 0x74) - position[1];
 				float z = *(float*)(address + 0x78) - position[2];
+
 				float distanceSquared = (x * x) + (y * y) + (z * z);
 				if (distanceSquared > radiusSquared)
 					continue;
+
 				returnHandles.Add(pool->GetGuidHandleByIndex(i));
 			}
 
@@ -2730,7 +2876,9 @@ namespace SHVDN
 		public static int GetEntityHandleFromAddress(IntPtr address)
 		{
 			var task = new GetEntityHandleTask(address);
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.returnEntityHandle;
 		}
 
@@ -2738,9 +2886,11 @@ namespace SHVDN
 		public static bool AnimatedBuildingHandleExists(int handle) => AnimatedBuildingPoolAddress != null ? ((GenericPool*)(*AnimatedBuildingPoolAddress))->IsHandleValid(handle) : false;
 		public static bool InteriorInstHandleExists(int handle) => InteriorInstPoolAddress != null ? ((GenericPool*)(*InteriorInstPoolAddress))->IsHandleValid(handle) : false;
 		public static bool InteriorProxyHandleExists(int handle) => InteriorProxyPoolAddress != null ? ((GenericPool*)(*InteriorProxyPoolAddress))->IsHandleValid(handle) : false;
+
 		static int[] GetHandlesInGenericPool(ulong poolAddress)
 		{
 			GenericPool* pool = (GenericPool*)poolAddress;
+
 			var returnHandles = new List<int>(pool->itemCount);
 			var poolSize = pool->size;
 			for (uint i = 0; i < poolSize; i++)
@@ -2757,6 +2907,7 @@ namespace SHVDN
 		static int[] GetCEntityHandlesInRange(ulong poolAddress, float[] position, float radius)
 		{
 			GenericPool* pool = (GenericPool*)poolAddress;
+
 			var returnHandles = new List<int>();
 			var poolSize = pool->size;
 			float radiusSquared = radius * radius;
@@ -2764,15 +2915,20 @@ namespace SHVDN
 			{
 				if (!pool->IsValid(i))
 					continue;
+
 				var address = pool->GetAddress(i);
+
 				float* entityPosition = stackalloc float[4];
+
 				NativeMemory.EntityPosFunc(address, entityPosition);
 				float x = entityPosition[0] - position[0];
 				float y = entityPosition[1] - position[1];
 				float z = entityPosition[2] - position[2];
+
 				float distanceSquared = (x * x) + (y * y) + (z * z);
 				if (distanceSquared > radiusSquared)
 					continue;
+
 				returnHandles.Add(pool->GetGuidHandleByIndex(i));
 			}
 
@@ -2787,6 +2943,7 @@ namespace SHVDN
 				var newArray = new int[array.Length * 2];
 				Array.Copy(array, newArray, array.Length);
 				newArray[index] = elementToAdd;
+
 				array = newArray;
 			}
 			else
@@ -2801,12 +2958,15 @@ namespace SHVDN
 		}
 
 		#endregion
+
 		#region -- Radar Blip Pool --
+
 		static ulong* RadarBlipPoolAddress;
 		static int* PossibleRadarBlipCountAddress;
 		static int* UnkFirstRadarBlipIndexAddress;
 		static int* NorthRadarBlipHandleAddress;
 		static int* CenterRadarBlipHandleAddress;
+
 		static bool CheckBlip(ulong blipAddress, float[] position, float radius, params int[] spriteTypes)
 		{
 			if (spriteTypes.Length > 0)
@@ -2819,14 +2979,17 @@ namespace SHVDN
 			if (position != null && radius > 0f)
 			{
 				float* blipPosition = stackalloc float[3];
+
 				blipPosition[0] = *(float*)(blipAddress + 0x10);
 				blipPosition[1] = *(float*)(blipAddress + 0x14);
 				blipPosition[2] = *(float*)(blipAddress + 0x18);
+
 				float x = blipPosition[0] - position[0];
 				float y = blipPosition[1] - position[1];
 				float z = blipPosition[2] - position[2];
 				float distanceSquared = (x * x) + (y * y) + (z * z);
 				float radiusSquared = radius * radius;
+
 				if (distanceSquared > radiusSquared)
 					return false;
 			}
@@ -2841,7 +3004,6 @@ namespace SHVDN
 			{
 				return -1;
 			}
-
 			ushort blipIndex = (ushort)handle;
 			ulong blipAddress = *(RadarBlipPoolAddress + blipIndex);
 			if (blipAddress == 0)
@@ -2857,12 +3019,10 @@ namespace SHVDN
 
 			return (short)blipIndex;
 		}
-
 		public static int[] GetNonCriticalRadarBlipHandles(params int[] spriteTypes)
 		{
 			return GetNonCriticalRadarBlipHandles(null, 0f, spriteTypes);
 		}
-
 		public static int[] GetNonCriticalRadarBlipHandles(float[] position = null, float radius = 0f, params int[] spriteTypes)
 		{
 			if (RadarBlipPoolAddress == null)
@@ -2874,14 +3034,18 @@ namespace SHVDN
 			int unkFirstBlipIndex = *UnkFirstRadarBlipIndexAddress;
 			int northBlipIndex = GetBlipIndexIfHandleIsValid(*NorthRadarBlipHandleAddress);
 			int centerBlipIndex = GetBlipIndexIfHandleIsValid(*CenterRadarBlipHandleAddress);
+
 			var handles = new List<int>(possibleBlipCount);
+
 			// Skip the 3 critical blips, just like GET_FIRST_BLIP_INFO_ID does
 			// The 3 critical blips is the north blip, the center blip, and the unknown simple blip (placeholder?).
 			for (int i = 0; i < possibleBlipCount; i++)
 			{
 				ulong address = *(RadarBlipPoolAddress + i);
+
 				if (address == 0 || i == unkFirstBlipIndex || i == northBlipIndex || i == centerBlipIndex)
 					continue;
+
 				if (CheckBlip(address, position, radius, spriteTypes))
 				{
 					ushort blipCreationIncrement = *(ushort*)(address + 8);
@@ -2893,6 +3057,7 @@ namespace SHVDN
 		}
 
 		public static int GetNorthBlip() => NorthRadarBlipHandleAddress != null ? *NorthRadarBlipHandleAddress : 0;
+
 		public static IntPtr GetBlipAddress(int handle)
 		{
 			if (RadarBlipPoolAddress == null)
@@ -2902,20 +3067,26 @@ namespace SHVDN
 
 			int poolIndexOfHandle = handle & 0xFFFF;
 			int possibleBlipCount = *PossibleRadarBlipCountAddress;
+
 			if (poolIndexOfHandle >= possibleBlipCount)
 			{
 				return IntPtr.Zero;
 			}
 
 			ulong address = *(RadarBlipPoolAddress + poolIndexOfHandle);
+
 			if (address != 0 && IsBlipCreationIncrementValid(address, handle))
 				return new IntPtr((long)address);
+
 			return IntPtr.Zero;
+
 			bool IsBlipCreationIncrementValid(ulong blipAddress, int blipHandle) => *(ushort*)(blipAddress + 8) == (((uint)blipHandle >> 0x10));
 		}
 
 		#endregion
+
 		#region -- CScriptResource Data --
+
 		internal enum CScriptResourceTypeNameIndex
 		{
 			Checkpoint = 6
@@ -2943,9 +3114,11 @@ namespace SHVDN
 			#region Fields
 			internal CScriptResourceTypeNameIndex typeNameIndex;
 			internal int[] returnHandles = Array.Empty<int>();
+
 			const int MAX_CHECKPOINT_COUNT = 64; // hard coded in the exe
 			static readonly int[] _cScriptResourceHandleBuffer = new int[MAX_CHECKPOINT_COUNT];
 			#endregion
+
 			internal GetAllCScriptResourceHandlesTask(CScriptResourceTypeNameIndex typeNameIndex)
 			{
 				this.typeNameIndex = typeNameIndex;
@@ -2954,19 +3127,23 @@ namespace SHVDN
 			public void Run()
 			{
 				var cGameScriptHandlerAddress = GetCGameScriptHandlerAddressFunc();
+
 				if (cGameScriptHandlerAddress == 0)
 					return;
+
 				int elementCount = 0;
 				var firstRegisteredScriptResourceItem = *(CGameScriptResource**)(cGameScriptHandlerAddress + 48);
 				for (CGameScriptResource* item = firstRegisteredScriptResourceItem; item != null; item = item->next)
 				{
 					if (item->resourceTypeNameIndex != typeNameIndex)
 						continue;
+
 					_cScriptResourceHandleBuffer[elementCount++] = item->counterOfPool;
 				}
 
 				if (elementCount == 0)
 					return;
+
 				returnHandles = new int[elementCount];
 				Array.Copy(_cScriptResourceHandleBuffer, returnHandles, elementCount);
 			}
@@ -2980,6 +3157,7 @@ namespace SHVDN
 			internal int elementSize;
 			internal IntPtr returnAddress;
 			#endregion
+
 			internal GetCScriptResourceAddressTask(int handle, ulong* poolAddress, int elementSize)
 			{
 				this.targetHandle = handle;
@@ -2990,8 +3168,10 @@ namespace SHVDN
 			public void Run()
 			{
 				var cGameScriptHandlerAddress = GetCGameScriptHandlerAddressFunc();
+
 				if (cGameScriptHandlerAddress == 0)
 					return;
+
 				var firstRegisteredScriptResourceItem = *(CGameScriptResource**)(cGameScriptHandlerAddress + 48);
 				for (CGameScriptResource* item = firstRegisteredScriptResourceItem; item != null; item = item->next)
 				{
@@ -3005,32 +3185,41 @@ namespace SHVDN
 		}
 
 		#endregion
+
 		#region -- Checkpoint Pool --
+
 		static ulong* CheckpointPoolAddress;
 		static delegate* unmanaged[Stdcall]<ulong> GetCGameScriptHandlerAddressFunc;
+
 		public static int[] GetCheckpointHandles()
 		{
 			var task = new GetAllCScriptResourceHandlesTask(CScriptResourceTypeNameIndex.Checkpoint);
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.returnHandles;
 		}
 
 		public static IntPtr GetCheckpointAddress(int handle)
 		{
 			var task = new GetCScriptResourceAddressTask(handle, CheckpointPoolAddress, 0x60);
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.returnAddress;
 		}
-
 		static ulong* waypointInfoArrayStartAddress;
 		static ulong* waypointInfoArrayEndAddress;
 		static delegate* unmanaged[Stdcall]<ulong> GetLocalPlayerPedAddressFunc;
+
 		public static int GetWaypointBlip()
 		{
 			if (waypointInfoArrayStartAddress == null || waypointInfoArrayEndAddress == null)
 				return 0;
+
 			int playerPedModelHash = 0;
 			ulong playerPedAddress = GetLocalPlayerPedAddressFunc();
+
 			if (playerPedAddress != 0)
 			{
 				playerPedModelHash = GetModelHashFromEntity(new IntPtr((long)playerPedAddress));
@@ -3040,6 +3229,7 @@ namespace SHVDN
 			for (; waypointInfoAddress < (ulong)waypointInfoArrayEndAddress; waypointInfoAddress += 0x18)
 			{
 				int modelHash = *(int*)waypointInfoAddress;
+
 				if (modelHash == playerPedModelHash)
 				{
 					return *(int*)(waypointInfoAddress + 4);
@@ -3048,20 +3238,18 @@ namespace SHVDN
 
 			return 0;
 		}
-
 		static delegate* unmanaged[Stdcall]<int, ulong> GetPtfxAddressFunc;
 		static delegate* unmanaged[Stdcall]<int, ulong> GetEntityAddressFunc;
 		static delegate* unmanaged[Stdcall]<int, ulong> GetPlayerAddressFunc;
+
 		public static IntPtr GetPtfxAddress(int handle)
 		{
 			return new IntPtr((long)GetPtfxAddressFunc(handle));
 		}
-
 		public static IntPtr GetEntityAddress(int handle)
 		{
 			return new IntPtr((long)GetEntityAddressFunc(handle));
 		}
-
 		public static IntPtr GetPlayerAddress(int handle)
 		{
 			return new IntPtr((long)GetPlayerAddressFunc(handle));
@@ -3071,37 +3259,38 @@ namespace SHVDN
 		{
 			if (BuildingPoolAddress == null)
 				return IntPtr.Zero;
+
 			return ((GenericPool*)(*NativeMemory.BuildingPoolAddress))->GetAddressFromHandle(handle);
 		}
-
 		public static IntPtr GetAnimatedBuildingAddress(int handle)
 		{
 			if (AnimatedBuildingPoolAddress == null)
 				return IntPtr.Zero;
+
 			return ((GenericPool*)(*NativeMemory.AnimatedBuildingPoolAddress))->GetAddressFromHandle(handle);
 		}
-
 		public static IntPtr GetInteriorInstAddress(int handle)
 		{
 			if (InteriorInstPoolAddress == null)
 				return IntPtr.Zero;
+
 			return ((GenericPool*)(*NativeMemory.InteriorInstPoolAddress))->GetAddressFromHandle(handle);
 		}
-
 		public static IntPtr GetInteriorProxyAddress(int handle)
 		{
 			if (InteriorProxyPoolAddress == null)
 				return IntPtr.Zero;
+
 			return ((GenericPool*)(*NativeMemory.InteriorProxyPoolAddress))->GetAddressFromHandle(handle);
 		}
 
 		#endregion
+
 		#region -- Projectile Offsets --
 		public static int ProjectileAmmoInfoOffset { get; }
-
 		public static int ProjectileOwnerOffset { get; }
-
 		static delegate* unmanaged[Stdcall]<IntPtr, int, void> ExplodeProjectileFunc;
+
 		public static void ExplodeProjectile(IntPtr projectileAddress)
 		{
 			var task = new ExplodeProjectileTask(projectileAddress);
@@ -3113,6 +3302,7 @@ namespace SHVDN
 			#region Fields
 			internal IntPtr projectileAddress;
 			#endregion
+
 			internal ExplodeProjectileTask(IntPtr projectileAddress)
 			{
 				this.projectileAddress = projectileAddress;
@@ -3125,52 +3315,69 @@ namespace SHVDN
 		}
 
 		#endregion
-		#region -- Interior Offsets --
-		public static ulong* InteriorProxyPtrFromGameplayCamAddress { get; }
 
+		#region -- Interior Offsets --
+
+		public static ulong* InteriorProxyPtrFromGameplayCamAddress { get; }
 		public static int InteriorInstPtrInInteriorProxyOffset { get; }
 
 		public static int GetAssociatedInteriorInstHandleFromInteriorProxy(int interiorProxyHandle)
 		{
 			if (InteriorInstPtrInInteriorProxyOffset == 0 || InteriorInstPoolAddress == null)
 				return 0;
+
 			var interiorProxyAddress = GetInteriorProxyAddress(interiorProxyHandle);
 			if (interiorProxyAddress == IntPtr.Zero)
 				return 0;
+
 			var interiorInstAddress = *(ulong*)(interiorProxyAddress + InteriorInstPtrInInteriorProxyOffset).ToPointer();
 			if (interiorInstAddress == 0)
 				return 0;
+
 			return ((GenericPool*)(*NativeMemory.InteriorInstPoolAddress))->GetGuidHandleFromAddress(interiorInstAddress);
 		}
-
 		public static int GetInteriorProxyHandleFromInteriorInst(int interiorInstHandle)
 		{
 			if (InteriorProxyPoolAddress == null)
 				return 0;
+
 			var interiorInstAddress = GetInteriorInstAddress(interiorInstHandle);
 			if (interiorInstAddress == IntPtr.Zero)
 				return 0;
+
 			var interiorProxyAddress = *(ulong*)(interiorInstAddress + 0x188).ToPointer();
 			if (interiorProxyAddress == 0)
 				return 0;
+
 			return ((GenericPool*)(*NativeMemory.InteriorProxyPoolAddress))->GetGuidHandleFromAddress(interiorProxyAddress);
 		}
-
 		public static int GetInteriorProxyHandleFromGameplayCam()
 		{
 			if (InteriorProxyPtrFromGameplayCamAddress == null || InteriorInstPoolAddress == null)
 				return 0;
+
 			var interiorProxyAddress = *InteriorProxyPtrFromGameplayCamAddress;
 			if (interiorProxyAddress == 0)
 				return 0;
+
 			return ((GenericPool*)(*NativeMemory.InteriorProxyPoolAddress))->GetGuidHandleFromAddress(interiorProxyAddress);
 		}
 
 		#endregion
+
 		#region -- Weapon Info And Ammo Info --
+
 		static RageAtArrayPtr* weaponAndAmmoInfoArrayPtr;
-		static HashSet<uint> disallowWeaponHashSetForHumanPedsOnFoot = new HashSet<uint>()
-		{0x1B79F17, /* weapon_briefcase_02 */ 0x166218FF, /* weapon_passenger_rocket */ 0x32A888BD, /* weapon_tranquilizer */ 0x687652CE, /* weapon_stinger */ 0x6D5E2801, /* weapon_bird_crap */ 0x88C78EB7, /* weapon_briefcase */ 0xFDBADCED, /* weapon_digiscanner */ };
+		static HashSet<uint> disallowWeaponHashSetForHumanPedsOnFoot = new HashSet<uint>() {
+				0x1B79F17,  /* weapon_briefcase_02 */
+				0x166218FF, /* weapon_passenger_rocket */
+				0x32A888BD, /* weapon_tranquilizer */
+				0x687652CE, /* weapon_stinger */
+				0x6D5E2801, /* weapon_bird_crap */
+				0x88C78EB7, /* weapon_briefcase */
+				0xFDBADCED, /* weapon_digiscanner */
+			};
+
 		static uint* weaponComponentArrayCountAddr;
 		// Store the offset instead of the calculated address for compatibility with mods like Weapon Limits Adjuster by alexguirre (although Weapon Limits Adjuster allocates a new array in the very beginning).
 		static ulong offsetForCWeaponComponentArrayAddr;
@@ -3178,7 +3385,9 @@ namespace SHVDN
 		static int weaponAttachPointsArrayCountOffset;
 		static int weaponAttachPointElementComponentCountOffset;
 		static int weaponAttachPointElementSize;
+
 		static int weaponInfoHumanNameHashOffset;
+
 		[StructLayout(LayoutKind.Explicit, Size = 0x20)]
 		struct ItemInfo
 		{
@@ -3192,6 +3401,7 @@ namespace SHVDN
 			internal uint audioHash;
 			[FieldOffset(0x1C)]
 			internal uint slot;
+
 			// The function is for the game version b2802 or later ones.
 			// This one directly returns a hash value (not a pointer value) unlike the previous function.
 			delegate uint GetClassNameHashOfCItemInfoDelegate();
@@ -3201,6 +3411,7 @@ namespace SHVDN
 			// The function returns the address where the class name hash is in all versions prior to (the address will be the outVal address in newer versions).
 			delegate uint* GetClassNameHashAddressOfCItemInfoDelegate(ulong unused, uint* outVal);
 			static Dictionary<ulong, GetClassNameHashAddressOfCItemInfoDelegate> getClassNameHashAddressOfCItemInfoCacheDict = new Dictionary<ulong, GetClassNameHashAddressOfCItemInfoDelegate>();
+
 			internal uint GetClassNameHash()
 			{
 				// In the b2802 or a later exe, the function returns a hash value (not a pointer value)
@@ -3228,6 +3439,7 @@ namespace SHVDN
 				{
 					var newDelegate = GetDelegateForFunctionPointer<GetClassNameHashOfCItemInfoDelegate>(new IntPtr((long)virtualFuncAddr));
 					getClassNameHashOfCItemInfoCacheDict.Add(virtualFuncAddr, newDelegate);
+
 					return newDelegate;
 				}
 			}
@@ -3242,6 +3454,7 @@ namespace SHVDN
 				{
 					var newDelegate = GetDelegateForFunctionPointer<GetClassNameHashAddressOfCItemInfoDelegate>(new IntPtr((long)virtualFuncAddr));
 					getClassNameHashAddressOfCItemInfoCacheDict.Add(virtualFuncAddr, newDelegate);
+
 					return newDelegate;
 				}
 			}
@@ -3276,20 +3489,25 @@ namespace SHVDN
 			}
 
 			var weaponAndAmmoInfoElementCount = weaponAndAmmoInfoArrayPtr->size;
+
 			if (weaponAndAmmoInfoElementCount == 0)
 				return null;
+
 			int low = 0, high = weaponAndAmmoInfoElementCount - 1;
 			while (true)
 			{
 				int indexToRead = (low + high) >> 1;
 				var weaponOrAmmoInfo = (ItemInfo*)weaponAndAmmoInfoArrayPtr->GetElementAddress(indexToRead);
+
 				if (weaponOrAmmoInfo->nameHash == nameHash)
 					return weaponOrAmmoInfo;
+
 				// The array is sorted in ascending order
 				if (weaponOrAmmoInfo->nameHash <= nameHash)
 					low = indexToRead + 1;
 				else
 					high = indexToRead - 1;
+
 				if (low > high)
 					return null;
 			}
@@ -3298,12 +3516,16 @@ namespace SHVDN
 		static ItemInfo* FindWeaponInfo(uint nameHash)
 		{
 			var itemInfoPtr = FindItemInfoFromWeaponAndAmmoInfoArray(nameHash);
+
 			if (itemInfoPtr == null)
 				return null;
+
 			var classNameHash = itemInfoPtr->GetClassNameHash();
+
 			const uint CWEAPONINFO_NAME_HASH = 0x861905B4;
 			if (classNameHash == CWEAPONINFO_NAME_HASH)
 				return itemInfoPtr;
+
 			return null;
 		}
 
@@ -3321,33 +3543,42 @@ namespace SHVDN
 			{
 				int indexToRead = (low + high) >> 1;
 				var weaponComponentInfo = (WeaponComponentInfo*)cWeaponComponentArrayFirstPtr[indexToRead];
+
 				if (weaponComponentInfo->nameHash == nameHash)
 					return weaponComponentInfo;
+
 				// The array is sorted in ascending order
 				if (weaponComponentInfo->nameHash <= nameHash)
 					low = indexToRead + 1;
 				else
 					high = indexToRead - 1;
+
 				if (low > high)
 					return null;
 			}
 		}
 
 		public static bool IsHashValidAsWeaponHash(uint weaponHash) => FindWeaponInfo(weaponHash) != null;
+
 		public static uint GetAttachmentPointHash(uint weaponHash, uint componentHash)
 		{
 			var weaponInfo = FindWeaponInfo(weaponHash);
+
 			if (weaponInfo == null)
 				return 0xFFFFFFFF;
+
 			var weaponAttachPointsAddr = (byte*)weaponInfo + weaponAttachPointsStartOffset;
 			var weaponAttachPointsCount = *(int*)(weaponAttachPointsAddr + weaponAttachPointsArrayCountOffset);
 			var weaponAttachPointElementStartAddr = (byte*)(weaponAttachPointsAddr);
+
 			for (int i = 0; i < weaponAttachPointsCount; i++)
 			{
 				var weaponAttachPointElementAddr = weaponAttachPointElementStartAddr + (i * weaponAttachPointElementSize) + 0x8;
 				int componentItemsCount = *(int*)(weaponAttachPointElementAddr + weaponAttachPointElementComponentCountOffset);
+
 				if (componentItemsCount <= 0)
 					continue;
+
 				for (int j = 0; j < componentItemsCount; j++)
 				{
 					var componentHashInItemArray = *(uint*)(weaponAttachPointElementAddr + j * 0x8);
@@ -3368,18 +3599,23 @@ namespace SHVDN
 
 			var weaponAndAmmoInfoElementCount = weaponAndAmmoInfoArrayPtr->size;
 			var resultList = new List<uint>();
+
 			for (int i = 0; i < weaponAndAmmoInfoElementCount; i++)
 			{
 				var weaponOrAmmoInfo = (ItemInfo*)weaponAndAmmoInfoArrayPtr->GetElementAddress(i);
+
 				if (!CanPedEquip(weaponOrAmmoInfo) && !disallowWeaponHashSetForHumanPedsOnFoot.Contains(weaponOrAmmoInfo->nameHash))
 					continue;
+
 				var classNameHash = weaponOrAmmoInfo->GetClassNameHash();
+
 				const uint CWEAPONINFO_NAME_HASH = 0x861905B4;
 				if (classNameHash == CWEAPONINFO_NAME_HASH)
 					resultList.Add(weaponOrAmmoInfo->nameHash);
 			}
 
 			return resultList;
+
 			bool CanPedEquip(ItemInfo* weaponInfoAddress)
 			{
 				return weaponInfoAddress->modelHash != 0 && weaponInfoAddress->slot != 0;
@@ -3391,6 +3627,7 @@ namespace SHVDN
 			var cWeaponComponentArrayFirstPtr = (ulong*)((byte*)offsetForCWeaponComponentArrayAddr + 4 + *(int*)offsetForCWeaponComponentArrayAddr);
 			var arrayCount = weaponComponentArrayCountAddr != null ? *(uint*)weaponComponentArrayCountAddr : 0;
 			var resultList = new List<uint>();
+
 			for (uint i = 0; i < arrayCount; i++)
 			{
 				var cWeaponComponentInfo = cWeaponComponentArrayFirstPtr[i];
@@ -3404,9 +3641,12 @@ namespace SHVDN
 		public static List<uint> GetAllCompatibleWeaponComponentHashes(uint weaponHash)
 		{
 			var weaponInfo = FindWeaponInfo(weaponHash);
+
 			if (weaponInfo == null)
 				return new List<uint>();
+
 			var returnList = new List<uint>();
+
 			var weaponAttachPointsAddr = (byte*)weaponInfo + weaponAttachPointsStartOffset;
 			var weaponAttachPointsCount = *(int*)(weaponAttachPointsAddr + weaponAttachPointsArrayCountOffset);
 			var weaponAttachPointElementStartAddr = (byte*)(weaponAttachPointsAddr + 0x8);
@@ -3414,8 +3654,10 @@ namespace SHVDN
 			{
 				var weaponAttachPointElementAddr = weaponAttachPointElementStartAddr + i * weaponAttachPointElementSize;
 				int componentItemsCount = *(int*)(weaponAttachPointElementAddr + weaponAttachPointElementComponentCountOffset);
+
 				if (componentItemsCount <= 0)
 					continue;
+
 				for (int j = 0; j < componentItemsCount; j++)
 				{
 					returnList.Add(*(uint*)(weaponAttachPointElementAddr + j * 0x8));
@@ -3428,18 +3670,22 @@ namespace SHVDN
 		public static uint GetHumanNameHashOfWeaponInfo(uint weaponHash)
 		{
 			var weaponInfo = FindWeaponInfo(weaponHash);
+
 			if (weaponInfo == null)
 				// hashed value of WT_INVALID
 				return 0xBFED8500;
+
 			return *(uint*)((byte*)weaponInfo + weaponInfoHumanNameHashOffset);
 		}
 
 		public static uint GetHumanNameHashOfWeaponComponentInfo(uint weaponComponentHash)
 		{
 			var weaponComponentInfo = FindWeaponComponentInfo(weaponComponentHash);
+
 			if (weaponComponentInfo == null)
 				// hashed value of WCT_INVALID
 				return 0xDE4BE9F8;
+
 			return weaponComponentInfo->locNameHash;
 		}
 
@@ -3448,6 +3694,7 @@ namespace SHVDN
 		static ulong** phSimulatorInstPtr;
 		static int colliderCapacityOffset;
 		static int colliderCountOffset;
+
 		[StructLayout(LayoutKind.Explicit, Size = 0xC0)]
 		internal unsafe struct FragInst
 		{
@@ -3457,11 +3704,13 @@ namespace SHVDN
 			internal GtaFragType* gtaFragType;
 			[FieldOffset(0xB8)]
 			internal uint unkType;
+
 			internal FragPhysicsLOD* GetAppropriateFragPhysicsLOD()
 			{
 				var fragPhysicsLODGroup = gtaFragType->fragPhysicsLODGroup;
 				if (fragPhysicsLODGroup == null)
 					return null;
+
 				switch (unkType)
 				{
 					case 0:
@@ -3473,14 +3722,11 @@ namespace SHVDN
 				}
 			}
 		}
-
 		[StructLayout(LayoutKind.Explicit)]
 		internal unsafe struct FragCacheEntry
 		{
-			[FieldOffset(0x178)]
-			internal CrSkeleton* crSkeleton;
+			[FieldOffset(0x178)] internal CrSkeleton* crSkeleton;
 		}
-
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct GtaFragType
 		{
@@ -3489,22 +3735,20 @@ namespace SHVDN
 			[FieldOffset(0xF0)]
 			internal FragPhysicsLODGroup* fragPhysicsLODGroup;
 		}
-
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct FragDrawable
 		{
 			[FieldOffset(0x18)]
 			internal CrSkeletonData* crSkeletonData;
 		}
-
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct FragPhysicsLODGroup
 		{
 			[FieldOffset(0x10)]
 			internal fixed ulong fragPhysicsLODAddresses[3];
+
 			internal FragPhysicsLOD* GetFragPhysicsLODByIndex(int index) => (FragPhysicsLOD*)((ulong*)fragPhysicsLODAddresses[index]);
 		}
-
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct FragPhysicsLOD
 		{
@@ -3512,10 +3756,12 @@ namespace SHVDN
 			internal ulong fragTypeChildArr;
 			[FieldOffset(0x11E)]
 			internal byte fragmentGroupCount;
+
 			internal FragTypeChild* GetFragTypeChild(int index)
 			{
 				if (index >= fragmentGroupCount)
 					return null;
+
 				return (FragTypeChild*)*((ulong*)fragTypeChildArr + index);
 			}
 		}
@@ -3532,14 +3778,11 @@ namespace SHVDN
 		[StructLayout(LayoutKind.Explicit)]
 		internal unsafe struct CrSkeleton
 		{
-			[FieldOffset(0x00)]
-			internal CrSkeletonData* skeletonData;
-			[FieldOffset(0x10)]
-			internal ulong bonePoseMatrixArrayPtr;
-			[FieldOffset(0x18)]
-			internal ulong boneMatrixArrayPtr;
-			[FieldOffset(0x20)]
-			internal int boneCount;
+			[FieldOffset(0x00)] internal CrSkeletonData* skeletonData;
+			[FieldOffset(0x10)] internal ulong bonePoseMatrixArrayPtr;
+			[FieldOffset(0x18)] internal ulong boneMatrixArrayPtr;
+			[FieldOffset(0x20)] internal int boneCount;
+
 			public IntPtr GetBonePoseMatrixAddress(int boneIndex)
 			{
 				return new IntPtr((long)(bonePoseMatrixArrayPtr + ((uint)boneIndex * 0x40)));
@@ -3554,14 +3797,11 @@ namespace SHVDN
 		[StructLayout(LayoutKind.Explicit)]
 		internal unsafe struct CrSkeletonData
 		{
-			[FieldOffset(0x10)]
-			internal ulong boneIdAndIndexTupleArrayPtr;
-			[FieldOffset(0x18)]
-			internal ushort divisorForBoneIdAndIndexTuple;
-			[FieldOffset(0x1A)]
-			internal ushort unkValue;
-			[FieldOffset(0x5E)]
-			internal ushort boneCount;
+			[FieldOffset(0x10)] internal ulong boneIdAndIndexTupleArrayPtr;
+			[FieldOffset(0x18)] internal ushort divisorForBoneIdAndIndexTuple;
+			[FieldOffset(0x1A)] internal ushort unkValue;
+			[FieldOffset(0x5E)] internal ushort boneCount;
+
 			/// <summary>
 			/// Gets the bone id from specified bone index. Note that bone indexes are sequential values and bone ids are not sequential ones.
 			/// </summary>
@@ -3571,12 +3811,15 @@ namespace SHVDN
 				{
 					if (boneId < boneCount)
 						return boneId;
+
 					return -1;
 				}
 
 				if (divisorForBoneIdAndIndexTuple == 0)
 					return -1;
+
 				var firstTuplePtr = ((ulong*)boneIdAndIndexTupleArrayPtr + (boneId % divisorForBoneIdAndIndexTuple));
+
 				for (var boneIdAndIndexTuple = (BoneIdAndIndexTuple*)*firstTuplePtr; boneIdAndIndexTuple != null; boneIdAndIndexTuple = (BoneIdAndIndexTuple*)boneIdAndIndexTuple->nextTupleAddr)
 				{
 					if (boneId == boneIdAndIndexTuple->boneId)
@@ -3590,12 +3833,9 @@ namespace SHVDN
 		[StructLayout(LayoutKind.Explicit)]
 		internal struct BoneIdAndIndexTuple
 		{
-			[FieldOffset(0x0)]
-			internal int boneId;
-			[FieldOffset(0x4)]
-			internal int boneIndex;
-			[FieldOffset(0x8)]
-			internal ulong nextTupleAddr;
+			[FieldOffset(0x0)] internal int boneId;
+			[FieldOffset(0x4)] internal int boneIndex;
+			[FieldOffset(0x8)] internal ulong nextTupleAddr;
 		}
 
 		internal class DetachFragmentPartByIndexTask : IScriptTask
@@ -3605,6 +3845,7 @@ namespace SHVDN
 			internal int fragmentGroupIndex;
 			internal bool wasNewFragInstCreated;
 			#endregion
+
 			internal DetachFragmentPartByIndexTask(FragInst* fragInst, int fragmentGroupIndex)
 			{
 				this.fragInst = fragInst;
@@ -3622,6 +3863,7 @@ namespace SHVDN
 			var fragInst = GetFragInstAddressOfEntity(entityAddress);
 			if (fragInst == null)
 				return 0;
+
 			return GetFragmentGroupCountOfFragInst(fragInst);
 		}
 
@@ -3629,17 +3871,22 @@ namespace SHVDN
 		{
 			if (fragmentGroupIndex < 0)
 				return false;
+
 			// If the entity collider count is at the capacity, the game can crash for trying to create the new entity while no free collider slots are available
 			if (GetEntityColliderCount() >= GetEntityColliderCapacity())
 				return false;
+
 			var fragInst = GetFragInstAddressOfEntity(entityAddress);
 			if (fragInst == null)
 				return false;
+
 			var fragmentGroupCount = GetFragmentGroupCountOfFragInst(fragInst);
 			if (fragmentGroupIndex >= fragmentGroupCount)
 				return false;
+
 			var task = new DetachFragmentPartByIndexTask(fragInst, fragmentGroupIndex);
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
+
 			return task.wasNewFragInstCreated;
 		}
 
@@ -3647,24 +3894,33 @@ namespace SHVDN
 		{
 			if ((boneIndex & 0x80000000) != 0) // boneIndex cant be negative
 				return -1;
+
 			var fragInst = GetFragInstAddressOfEntity(entityAddress);
 			if (fragInst == null)
 				return -1;
+
+
 			var crSkeletonData = fragInst->gtaFragType->fragDrawable->crSkeletonData;
 			if (crSkeletonData == null)
 				return -1;
+
 			var boneCount = crSkeletonData->boneCount;
 			if (boneIndex >= boneCount)
 				return -1;
+
 			var fragPhysicsLOD = fragInst->GetAppropriateFragPhysicsLOD();
 			if (fragPhysicsLOD == null)
 				return -1;
+
 			var fragmentGroupCount = fragPhysicsLOD->fragmentGroupCount;
+
 			for (int i = 0; i < fragmentGroupCount; i++)
 			{
 				var fragTypeChild = fragPhysicsLOD->GetFragTypeChild(i);
+
 				if (fragTypeChild == null)
 					continue;
+
 				if (boneIndex == crSkeletonData->GetBoneIndexByBoneId(fragTypeChild->boneId))
 					return i;
 			}
@@ -3676,6 +3932,7 @@ namespace SHVDN
 		{
 			if (*phSimulatorInstPtr == null)
 				return 0;
+
 			return *(int*)((byte*)*phSimulatorInstPtr + colliderCapacityOffset);
 		}
 
@@ -3683,6 +3940,7 @@ namespace SHVDN
 		{
 			if (*phSimulatorInstPtr == null)
 				return 0;
+
 			return *(int*)((byte*)*phSimulatorInstPtr + colliderCountOffset);
 		}
 
@@ -3696,6 +3954,7 @@ namespace SHVDN
 		{
 			var vFuncAddr = *(ulong*)(*(ulong*)entityAddress.ToPointer() + (uint)getFragInstVFuncOffset);
 			var getFragInstFunc = (delegate* unmanaged[Stdcall]<IntPtr, FragInst*>)(vFuncAddr);
+
 			return getFragInstFunc(entityAddress);
 		}
 
@@ -3713,9 +3972,11 @@ namespace SHVDN
 		static delegate* unmanaged[Stdcall]<ulong, CTask*> GetActiveTaskFunc;
 		static delegate* unmanaged[Stdcall]<ulong, ulong, int, ulong> InitMessageMemoryFunc;
 		static delegate* unmanaged[Stdcall]<ulong, IntPtr, ulong, void> SendMessageToPedFunc;
+
 		static int fragInstNMGtaOffset;
 		static int cTaskNMScriptControlTypeIndex;
 		static int cEventSwitch2NMTypeIndex;
+
 		[StructLayout(LayoutKind.Explicit, Size = 0x38)]
 		struct CTask
 		{
@@ -3726,15 +3987,19 @@ namespace SHVDN
 		public static bool IsTaskNMScriptControlOrEventSwitch2NMActive(IntPtr pedAddress)
 		{
 			ulong phInstGtaAddress = *(ulong*)(pedAddress + 0x30);
+
 			if (phInstGtaAddress == 0)
 				return false;
+
 			ulong fragInstNMGtaAddress = *(ulong*)(pedAddress + fragInstNMGtaOffset);
+
 			if (phInstGtaAddress == fragInstNMGtaAddress && !IsPedInjured((byte*)pedAddress))
 			{
 				var funcUlongIntDelegate = (delegate* unmanaged[Stdcall]<ulong, int>)(new IntPtr((long)*(ulong*)(*(ulong*)fragInstNMGtaAddress + 0x98)));
 				if (funcUlongIntDelegate(fragInstNMGtaAddress) != -1)
 				{
 					var PedIntelligenceAddr = *(ulong*)(pedAddress + PedIntelligenceOffset);
+
 					var activeTask = GetActiveTaskFunc(*(ulong*)((byte*)PedIntelligenceAddr + CTaskTreePedOffset));
 					if (activeTask != null && activeTask->taskTypeIndex == cTaskNMScriptControlTypeIndex)
 					{
@@ -3770,6 +4035,7 @@ namespace SHVDN
 		}
 
 		static bool IsPedInjured(byte* pedAddress) => *(float*)(pedAddress + 0x280) < *(float*)(pedAddress + InjuryHealthThresholdOffset);
+
 		internal class EuphoriaMessageTask : IScriptTask
 		{
 			#region Fields
@@ -3778,6 +4044,7 @@ namespace SHVDN
 			Dictionary<string, (int value, Type type)> _boolIntFloatArguments;
 			Dictionary<string, object> _stringVector3ArrayArguments;
 			#endregion
+
 			internal EuphoriaMessageTask(int target, string message, Dictionary<string, (int, Type)> boolIntFloatArguments, Dictionary<string, object> stringVector3ArrayArguments)
 			{
 				targetHandle = target;
@@ -3789,18 +4056,25 @@ namespace SHVDN
 			public void Run()
 			{
 				byte* _PedAddress = (byte*)NativeMemory.GetEntityAddress(targetHandle).ToPointer();
+
 				if (_PedAddress == null)
 					return;
+
 				ulong messageMemory = (ulong)AllocCoTaskMem(0x1218).ToInt64();
+
 				if (messageMemory == 0)
 					return;
+
 				InitMessageMemoryFunc(messageMemory, messageMemory + 0x18, 0x40);
+
 				if (_boolIntFloatArguments != null)
 				{
 					foreach (var arg in _boolIntFloatArguments)
 					{
 						IntPtr name = ScriptDomain.CurrentDomain.PinString(arg.Key);
+
 						(var argValue, var argType) = arg.Value;
+
 						if (argType == typeof(float))
 						{
 							var argValueConverted = *(float*)(&argValue);
@@ -3823,6 +4097,7 @@ namespace SHVDN
 					foreach (var arg in _stringVector3ArrayArguments)
 					{
 						IntPtr name = ScriptDomain.CurrentDomain.PinString(arg.Key);
+
 						var argValue = arg.Value;
 						if (argValue is float[] vector3ArgValue)
 							NativeMemory.SetNmVector3Address(messageMemory, name, vector3ArgValue[0], vector3ArgValue[1], vector3ArgValue[2]);
@@ -3845,8 +4120,10 @@ namespace SHVDN
 		public static void SendEuphoriaMessage(int targetHandle, string message, Dictionary<string, (int, Type)> boolIntFloatArguments, Dictionary<string, object> stringVector3ArrayArguments)
 		{
 			var task = new EuphoriaMessageTask(targetHandle, message, boolIntFloatArguments, stringVector3ArrayArguments);
+
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
 		}
+
 		#endregion
 	}
 }

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1237,7 +1237,6 @@ namespace SHVDN
 
 		#region -- Game Data --
 
-
 		static delegate* unmanaged[Stdcall]<IntPtr, uint, uint> GetHashKeyFunc;
 
 		public static uint GetHashKey(string key)
@@ -1247,7 +1246,6 @@ namespace SHVDN
 		}
 
 		static ulong GetLabelTextByHashAddress;
-
 		static delegate* unmanaged[Stdcall]<ulong, int, ulong> GetLabelTextByHashFunc;
 
 		public static string GetGXTEntryByHash(int entryLabelHash)
@@ -1454,8 +1452,6 @@ namespace SHVDN
 
 		#region -- CEntity Functions --
 
-
-
 		static delegate* unmanaged[Stdcall]<float*, ulong, int, float*> GetRotationFromMatrixFunc;
 		static delegate* unmanaged[Stdcall]<float*, ulong, int> GetQuaternionFromMatrixFunc;
 
@@ -1489,13 +1485,9 @@ namespace SHVDN
 
 		#region -- CPhysical Functions --
 
-
 		// return value will be the address of the temporary 4 float storage
 
-
 		// Only 2 virtural functions are present (one for peds and objects and one for vehicles)
-
-
 
 		internal class SetEntityAngularVelocityTask : IScriptTask
 		{
@@ -1541,8 +1533,6 @@ namespace SHVDN
 			var task = new SetEntityAngularVelocityTask(entityAddress, setEntityAngularVelocityDelegate, x, y, z);
 			ScriptDomain.CurrentDomain.ExecuteTask(task);
 		}
-
-
 
 
 
@@ -1733,11 +1723,6 @@ namespace SHVDN
 		#endregion
 
 		#region -- Vehicle Wheel Data --
-
-
-
-
-
 
 
 		static delegate* unmanaged[Stdcall]<IntPtr, void> FixVehicleWheelFunc;
@@ -2195,8 +2180,6 @@ namespace SHVDN
 		public static ReadOnlyCollection<int> PedModels { get; }
 
 
-
-
 		static delegate* unmanaged[Stdcall]<IntPtr, ulong> GetHandlingDataByHash;
 		static delegate* unmanaged[Stdcall]<int, ulong> GetHandlingDataByIndex;
 
@@ -2415,10 +2398,6 @@ namespace SHVDN
 
 		static ulong* ProjectilePoolAddress;
 		static int* ProjectileCountAddress;
-
-
-
-
 
 
 		// if the entity is a ped and they are in a vehicle, the vehicle position will be returned instead (just like GET_ENTITY_COORDS does)
@@ -3238,7 +3217,6 @@ namespace SHVDN
 
 		static ulong* CheckpointPoolAddress;
 
-
 		static delegate* unmanaged[Stdcall]<ulong> GetCGameScriptHandlerAddressFunc;
 
 		public static int[] GetCheckpointHandles()
@@ -3262,7 +3240,6 @@ namespace SHVDN
 		#endregion
 
 		#region -- Waypoint Info Array --
-
 
 		static ulong* waypointInfoArrayStartAddress;
 		static ulong* waypointInfoArrayEndAddress;
@@ -3297,7 +3274,6 @@ namespace SHVDN
 		#endregion
 
 		#region -- Pool Addresses --
-
 
 		static delegate* unmanaged[Stdcall]<int, ulong> GetPtfxAddressFunc;
 		static delegate* unmanaged[Stdcall]<int, ulong> GetEntityAddressFunc;
@@ -3353,7 +3329,6 @@ namespace SHVDN
 		#endregion
 
 		#region -- Projectile Functions --
-
 
 		static delegate* unmanaged[Stdcall]<IntPtr, int, void> ExplodeProjectileFunc;
 
@@ -3760,8 +3735,6 @@ namespace SHVDN
 		#region -- Fragment Object for Entity --
 
 
-
-
 		static int getFragInstVFuncOffset;
 		static delegate* unmanaged[Stdcall]<FragInst*, int, FragInst*> detachFragmentPartByIndexFunc;
 		static ulong** phSimulatorInstPtr;
@@ -3769,7 +3742,6 @@ namespace SHVDN
 		static int colliderCountOffset;
 
 		// Only 3 virtural functions are present (one for peds and objects and one for vehicles)
-
 
 		[StructLayout(LayoutKind.Explicit, Size = 0xC0)]
 		internal unsafe struct FragInst
@@ -4041,23 +4013,9 @@ namespace SHVDN
 		}
 
 
-
 		#endregion
 
 		#region -- NaturalMotion Euphoria --
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -4075,7 +4033,6 @@ namespace SHVDN
 		static int fragInstNMGtaOffset;
 		static int cTaskNMScriptControlTypeIndex;
 		static int cEventSwitch2NMTypeIndex;
-
 
 
 		[StructLayout(LayoutKind.Explicit, Size = 0x38)]
@@ -4136,7 +4093,6 @@ namespace SHVDN
 		}
 
 		static bool IsPedInjured(byte* pedAddress) => *(float*)(pedAddress + 0x280) < *(float*)(pedAddress + InjuryHealthThresholdOffset);
-
 
 
 		internal class EuphoriaMessageTask : IScriptTask


### PR DESCRIPTION
This should give a performance boost to all direct function calls, the SuppressGCTransition attribute, however, is absent in .NET Framework, so the improvement might be limited.

I use Roslyn API to analyze and convert all codes, ~~and normalized the whitespaces~~, so this PR got massive as the result.
The calling convention used is Stdcall, which is the one winapi and `Marshal.GetDelegateForFunctionPointer()` uses, but GTAV is probaly using Cdecl as it's the default calling convention for C and C++ programs.

#1135 might need to be merged first.