### PR TITLE
fix PedBoneCollection.LastDamaged not returning boneID correctly

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/PedBoneCollection.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedBoneCollection.cs
@@ -86,12 +86,12 @@ namespace GTA
 		{
 			get
 			{
-				int outBone;
+				Bone outBone;
 				unsafe
 				{
 					if (Function.Call<bool>(Hash.GET_PED_LAST_DAMAGE_BONE, _owner.Handle, &outBone))
 					{
-						return this[(Bone)outBone];
+						return this[(int)outBone];
 					}
 				}
 				return this[Bone.SkelRoot];


### PR DESCRIPTION
with `return this[(Bone)outBone];` this was always returning 0;