### PR TITLE
Add EntityBone.RelativeRotation

### DIFF
--- a/source/scripting_v3/GTA/Entities/EntityBone.cs
+++ b/source/scripting_v3/GTA/Entities/EntityBone.cs
@@ -140,7 +140,7 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets the position of this <see cref="EntityBone"/> relative to the <see cref="Entity"/> its part of.
+		/// Gets the rotation of this <see cref="EntityBone"/> relative to the <see cref="Entity"/> its part of.
 		/// </summary>
 		public Vector3 RelativeRotation
 		{

--- a/source/scripting_v3/GTA/Entities/EntityBone.cs
+++ b/source/scripting_v3/GTA/Entities/EntityBone.cs
@@ -140,6 +140,29 @@ namespace GTA
 		}
 
 		/// <summary>
+		/// Gets the position of this <see cref="EntityBone"/> relative to the <see cref="Entity"/> its part of.
+		/// </summary>
+		public Vector3 RelativeRotation
+		{
+			get
+			{
+				IntPtr address = SHVDN.NativeMemory.GetEntityBoneGlobalMatrixAddress(Owner.Handle, Index);
+				if (address == IntPtr.Zero)
+				{
+					return Vector3.Zero;
+				}
+
+				unsafe
+				{
+					var tempRotationArray = stackalloc float[3];
+					SHVDN.NativeMemory.GetRotationFromMatrix(tempRotationArray, address);
+
+					return new Vector3(tempRotationArray[0], tempRotationArray[1], tempRotationArray[2]);
+				}
+			}
+		}
+
+		/// <summary>
 		/// Gets the vector that points above this <see cref="EntityBone"/> relative to the world.
 		/// </summary>
 		public Vector3 UpVector


### PR DESCRIPTION
The same value will be returned as `GET_ENTITY_BONE_OBJECT_POSTION` (`0xCF1247CC86961FD6`) does, but the native is not present prior to b2802.