### PR TITLE
Add properties for parent entity of props detached from 

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -767,6 +767,12 @@ namespace SHVDN
 				VisualFieldCenterAngleOffset = SeeingRangeOffset + 0x1C;
 			}
 
+			address = FindPattern("\x48\x8B\x87\x00\x00\x00\x00\x48\x85\xC0\x0F\x84\x8B\x00\x00\x00", "xxx????xxxxxxxxx");
+			if (address != null)
+			{
+				objParentEntityAddressDetachedFromOffset = *(int*)(address + 3);
+			}
+
 			address = FindPattern("\x48\x8D\x1D\x00\x00\x00\x00\x4C\x8B\x0B\x4D\x85\xC9\x74\x67", "xxx????xxxxxxxx");
 			if (address != null)
 			{
@@ -1843,6 +1849,34 @@ namespace SHVDN
 		public static int FirstVehicleFlagsOffset { get; }
 
 		#endregion
+
+		#region -- Prop Data --
+
+		static int objParentEntityAddressDetachedFromOffset;
+
+		static IntPtr GetParentEntityOfPropDetachedFrom(int objHandle)
+		{
+			var entityAddress = GetEntityAddress(objHandle);
+			if (entityAddress == IntPtr.Zero)
+			{
+				return IntPtr.Zero;
+			}
+
+			return (entityAddress + objParentEntityAddressDetachedFromOffset);
+		}
+		public static int GetParentEntityHandleOfPropDetachedFrom(int objHandle)
+		{
+			var parentEntityAddr = GetParentEntityOfPropDetachedFrom(objHandle);
+			if (parentEntityAddr == IntPtr.Zero)
+			{
+				return 0;
+			}
+
+			return GetEntityHandleFromAddress(parentEntityAddr);
+		}
+		public static bool IsPropBrokenOffPart(int objHandle) => GetParentEntityOfPropDetachedFrom(objHandle) != IntPtr.Zero;
+
+		#endregion -- Prop Data --
 
 		#region -- Vehicle Wheel Data --
 

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1874,7 +1874,7 @@ namespace SHVDN
 
 			return GetEntityHandleFromAddress(parentEntityAddr);
 		}
-		public static bool IsPropBrokenOffPart(int objHandle) => GetParentEntityOfPropDetachedFrom(objHandle) != IntPtr.Zero;
+		public static bool HasPropBeenDetachedFromParentEntity(int objHandle) => GetParentEntityOfPropDetachedFrom(objHandle) != IntPtr.Zero;
 
 		#endregion -- Prop Data --
 

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1857,7 +1857,7 @@ namespace SHVDN
 		static IntPtr GetParentEntityOfPropDetachedFrom(int objHandle)
 		{
 			var entityAddress = GetEntityAddress(objHandle);
-			if (entityAddress == IntPtr.Zero)
+			if (objParentEntityAddressDetachedFromOffset == 0 || entityAddress == IntPtr.Zero)
 			{
 				return IntPtr.Zero;
 			}

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1862,7 +1862,7 @@ namespace SHVDN
 				return IntPtr.Zero;
 			}
 
-			return (entityAddress + objParentEntityAddressDetachedFromOffset);
+			return new IntPtr(*(long*)(entityAddress + objParentEntityAddressDetachedFromOffset));
 		}
 		public static int GetParentEntityHandleOfPropDetachedFrom(int objHandle)
 		{

--- a/source/scripting_v3/GTA/Entities/Prop.cs
+++ b/source/scripting_v3/GTA/Entities/Prop.cs
@@ -2,6 +2,8 @@
 // Copyright (C) 2015 crosire & contributors
 // License: https://github.com/crosire/scripthookvdotnet#license
 //
+using GTA.Native;
+using SHVDN;
 
 namespace GTA
 {
@@ -10,6 +12,31 @@ namespace GTA
 		internal Prop(int handle) : base(handle)
 		{
 		}
+
+		#region Fragment
+
+		/// <summary>
+		/// Determines if this <see cref="Prop"/> is a broken off (detached) child fragment part of some <see cref="Entity"/>.
+		/// </summary>
+		public bool IsBrokenOffChildFragmentPart => NativeMemory.IsPropBrokenOffPart(Handle);
+
+		/// <summary>
+		/// Gets the <see cref="Entity"/> this <see cref="Prop"/> is detached from.
+		/// Will return a <see cref="Vehicle"/> or <see cref="Prop"/> instance if found, and will return <see langword="null"/> if not found.
+		/// </summary>
+		public Entity ParentEntityDetachedFrom
+		{
+			get
+			{
+				var parentEntityHandle = NativeMemory.GetParentEntityHandleOfPropDetachedFrom(Handle);
+				if (parentEntityHandle == 0)
+					return null;
+
+				return FromHandle(parentEntityHandle);
+			}
+		}
+
+		#endregion
 
 		/// <summary>
 		/// Determines if this <see cref="Prop"/> exists.

--- a/source/scripting_v3/GTA/Entities/Prop.cs
+++ b/source/scripting_v3/GTA/Entities/Prop.cs
@@ -16,13 +16,16 @@ namespace GTA
 		#region Fragment
 
 		/// <summary>
-		/// Determines if this <see cref="Prop"/> is a broken off (detached) child fragment part of some <see cref="Entity"/>.
+		/// Determines if this <see cref="Prop"/> has been created as a <see cref="Prop"/> detached from the parent <see cref="Entity"/>.
+		/// Will return <see langword="true"/> when the <see cref="Prop"/> has been detached from parent <see cref="Ped"/> and has been created as a separate <see cref="Prop"/>
+		/// or when the <see cref="Prop"/> is a fragment part detached from parent <see cref="Vehicle"/> or <see cref="Prop"/> and has been created as a separate <see cref="Prop"/>
 		/// </summary>
-		public bool IsBrokenOffChildFragmentPart => NativeMemory.IsPropBrokenOffPart(Handle);
+		public bool HasBeenDetachedFromParentEntity => NativeMemory.HasPropBeenDetachedFromParentEntity(Handle);
 
 		/// <summary>
 		/// Gets the <see cref="Entity"/> this <see cref="Prop"/> is detached from.
-		/// Will return a <see cref="Vehicle"/> or <see cref="Prop"/> instance if found, and will return <see langword="null"/> if not found.
+		/// If found, will return an instance of any one of <see cref="Ped"/>, <see cref="Vehicle"/>, or <see cref="Prop"/>.
+		/// If not found, will return <see langword="null"/>.
 		/// </summary>
 		public Entity ParentEntityDetachedFrom
 		{


### PR DESCRIPTION
-SkyZ- said this message in 5Mods Discord (probably the same person as [SkyJumpZ](https://www.gta5-mods.com/users/SkyJumpZ) on 5Mods) about broken off fragment parts.
> No, when prop like this blow up, i can assign every of these parts into variable in exact same way as if they were regular not destroyed pumps 
> So GetClosestProp and i enter same model name, and I found a native 0x2542269291C6AC84 that outputs true if that Prop is destroyed
> would be cool to know origin of the destroyed part, so when i blow up two pumps I could get all props that lay around from Pump1 into Array1 and parts from Pump2 put into Array2

So I searched for the offset of parent entity of `CObject` and made a memory pattern for the offset. Would be useful to find the parent entity of a child fragment part prop or detect if some prop is a broken off child fragment part. I found that the offset is at `0x400` in b2699 and `0x3E0` in b2824 btw.