### PR TITLE
Fix warnings in NativeMemory

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -3947,7 +3947,7 @@ namespace SHVDN
 			[FieldOffset(0x44)]
 			internal ushort boneId;
 
-			internal string Name => namePtr == null ? null : Marshal.PtrToStringAnsi(namePtr);
+			internal string Name => namePtr == default ? null : Marshal.PtrToStringAnsi(namePtr);
 		};
 
 		[StructLayout(LayoutKind.Explicit)]

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -3044,14 +3044,13 @@ namespace SHVDN
 			var returnHandles = new List<int>();
 			var poolSize = pool->size;
 			float radiusSquared = radius * radius;
+			float* entityPosition = stackalloc float[4];
 			for (uint i = 0; i < poolSize; i++)
 			{
 				if (!pool->IsValid(i))
 					continue;
 
 				var address = pool->GetAddress(i);
-
-				float* entityPosition = stackalloc float[4];
 
 				NativeMemory.EntityPosFunc(address, entityPosition);
 				float x = entityPosition[0] - position[0];


### PR DESCRIPTION
Apparently CsCompile doesn't show any warning during build, here're the two discovered when compiling for SHVDNC

fae4eef7876053764823ae028beb1e8071f6c2e3:
> warning CS0472: The result of the expression is always 'false' since a value of type 'nint' is never equal to 'null' of type 'nint?'

423061fd4a70cded681f324fa506ac80e739d017:
> warning CA2014: Potential stack overflow. Move the stackalloc out of the loop.
