### PR TITLE
Add Entity.LocalRotationVelocity and Mark Entity.RotationVelocity obsolete

### DIFF
--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -586,6 +586,7 @@ namespace GTA
 		/// <summary>
 		/// Gets or sets the rotation velocity of this <see cref="Entity"/> in local space.
 		/// </summary>
+		[Obsolete("Entity.RotationVelocity is obsolete because GET_ENTITY_ROTATION_VELOCITY returns the world angular velocity with local to world conversion (without position translation) applied. Use Entity.LocalRotationVelocity instead.")]
 		public Vector3 RotationVelocity
 		{
 			get => Function.Call<Vector3>(Hash.GET_ENTITY_ROTATION_VELOCITY, Handle);
@@ -630,6 +631,40 @@ namespace GTA
 				}
 
 				SHVDN.NativeMemory.SetEntityAngularVelocity(address, value.X, value.Y, value.Z);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the rotation velocity of this <see cref="Entity"/> in local space.
+		/// </summary>
+		public Vector3 LocalRotationVelocity
+		{
+			get
+			{
+				var address = MemoryAddress;
+				if (address == IntPtr.Zero)
+				{
+					return Vector3.Zero;
+				}
+
+				var quaternionInverted = Quaternion;
+				quaternionInverted.Invert();
+				unsafe
+				{
+					var returnVectorPtr = SHVDN.NativeMemory.GetEntityAngularVelocity(address);
+					return (quaternionInverted * new Vector3(returnVectorPtr[0], returnVectorPtr[1], returnVectorPtr[2]));
+				}
+			}
+			set
+			{
+				var address = MemoryAddress;
+				if (address == IntPtr.Zero)
+				{
+					return;
+				}
+
+				var angularVelocityWorldSpace = Quaternion * value;
+				SHVDN.NativeMemory.SetEntityAngularVelocity(address, angularVelocityWorldSpace.X, angularVelocityWorldSpace.Y, angularVelocityWorldSpace.Z);
 			}
 		}
 

--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -586,7 +586,7 @@ namespace GTA
 		/// <summary>
 		/// Gets or sets the rotation velocity of this <see cref="Entity"/> in local space.
 		/// </summary>
-		[Obsolete("Entity.RotationVelocity is obsolete because GET_ENTITY_ROTATION_VELOCITY returns the world angular velocity with local to world conversion (without position translation) applied. Use Entity.LocalRotationVelocity instead.")]
+		[Obsolete("Entity.RotationVelocity is obsolete because GET_ENTITY_ROTATION_VELOCITY returns the world angular velocity with local to world conversion applied. Use Entity.LocalRotationVelocity instead.")]
 		public Vector3 RotationVelocity
 		{
 			get => Function.Call<Vector3>(Hash.GET_ENTITY_ROTATION_VELOCITY, Handle);


### PR DESCRIPTION
Just a wrapper property, but I think this is worth merging because `GET_ENTITY_ROTATION_VELOCITY` doesn't seem to make sense much. I looked into `GET_ENTITY_ROTATION_VELOCITY` and the return value from it is the same as this method:
```cs
private Vector3 GetEntityRotationVelocity(Entity entity)
{
    var matrix = entity.Matrix;
    var worldRot = entity.WorldRotationVelocity;

    var forwardVec1 = matrix[1, 0] * worldRot.Y;
    var forwardVec2 = matrix[1, 1] * worldRot.Y;
    var forwardVec3 = matrix[1, 2] * worldRot.Y;
    var rightVec1 = matrix[0, 0] * worldRot.X;
    var rightVec2 = matrix[0, 1] * worldRot.X;
    var rightVec3 = matrix[0, 2] * worldRot.X;
    var upVec1 = matrix[2, 0] * worldRot.Z;
    var upVec2 = matrix[2, 1] * worldRot.Z;
    var upVec3 = matrix[2, 2] * worldRot.Z;

    var resultComponentX = forwardVec1 + rightVec1 + upVec1;
    var resultComponentY = forwardVec2 + rightVec2 + upVec2;
    var resultComponentZ = forwardVec3 + rightVec3 + upVec3;

    // did the same operation as Matrix.TransformPoint but without position translation
    return new Vector3(resultComponentX, resultComponentY, resultComponentZ);
}
```
As far as I looked into decompiled scripts, even Rockstar don't seem to use `GET_ENTITY_ROTATION_VELOCITY` very well and I thought `Entity.RotationVelocity` might as well as be marked as obsolete.