### PR TITLE
Tick ScriptDomain in a seperate thread

### DIFF
--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -288,7 +288,7 @@ static void ScriptHookVDotNet_ManagedKeyboardMessage(unsigned long keycode, bool
 static DWORD CLRThreadProc(LPVOID lparam)
 {
 	LPVOID tlsContextOrg = GetTlsContext();
-	while (true) {
+	while (hCLRContinueEvent) {
 		WaitForSingleObject(hCLRContinueEvent, INFINITE);
 		SetTlsContext(GameTls);
 		ScriptHookVDotNet_ManagedInit();
@@ -296,7 +296,7 @@ static DWORD CLRThreadProc(LPVOID lparam)
 		sGameReloaded = false;
 		SetEvent(hCLRWaitEvent);
 
-		while (!sGameReloaded) {
+		while (!sGameReloaded && hCLRContinueEvent) {
 			WaitForSingleObject(hCLRContinueEvent, INFINITE);
 			SetTlsContext(GameTls);
 			ScriptHookVDotNet_ManagedTick();
@@ -358,6 +358,8 @@ BOOL WINAPI DllMain(HMODULE hModule, DWORD fdwReason, LPVOID lpvReserved)
 		// Cleanup events
 		CloseHandle(hCLRContinueEvent);
 		CloseHandle(hCLRWaitEvent);
+		hCLRContinueEvent = NULL;
+		hCLRWaitEvent = NULL;
 		break;
 	}
 

--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -150,9 +150,13 @@ static void ScriptHookVDotNet_ManagedInit()
 		if (console != nullptr)
 		{
 			stashedConsoleCommandHistory = console->CommandHistory;
+			console = nullptr;
 		}
 
-		SHVDN::ScriptDomain::Unload(domain);
+		// Set remoting object to null first to avoid AppDomainUnloadedException in keyboard handler
+		SHVDN::ScriptDomain ^tmp = domain;
+		domain = nullptr;
+		SHVDN::ScriptDomain::Unload(tmp);
 	}
 
 

--- a/source/core/ScriptDomain.cs
+++ b/source/core/ScriptDomain.cs
@@ -566,9 +566,18 @@ namespace SHVDN
 		/// Execute a script task in this script domain.
 		/// </summary>
 		/// <param name="task">The task to execute.</param>
-		public void ExecuteTask(IScriptTask task)
+		public unsafe void ExecuteTask(IScriptTask task)
 		{
-			if (Thread.CurrentThread.ManagedThreadId == executingThreadId)
+			if (GetTlsContext == null || SetTlsContext == null)
+			{
+				// Need to pass the task to the domain thread and execute it there as a fallback
+				// This is an edge case and is only needed when one of the function pointers for TLS context management is not set in the script domain
+				taskQueue.Enqueue(task);
+				SignalAndWait(executingScript.waitEvent, executingScript.continueEvent);
+				return;
+			}
+			var tlsOrg = GetTlsContext();
+			if (tlsOrg == tlsContextOfMainThread)
 			{
 				// Request came from the main thread, so can just execute it right away
 				task.Run();
@@ -576,30 +585,17 @@ namespace SHVDN
 			else
 			{
 				// Request came from the script thread
-				unsafe
+				SetTlsContext(tlsContextOfMainThread);
+
+				try
 				{
-					if (GetTlsContext != null && SetTlsContext != null)
-					{
-						IntPtr tlsContextOfScriptThread = GetTlsContext();
-						SetTlsContext(tlsContextOfMainThread);
-
-						try
-						{
-							task.Run();
-						}
-						finally
-						{
-							// Need to revert TLS context to the real one of the script thread
-							SetTlsContext(tlsContextOfScriptThread);
-						}
-						return;
-					}
+					task.Run();
 				}
-
-				// Need to pass the task to the domain thread and execute it there as a fallback
-				// This is an edge case and is only needed when one of the function pointers for TLS context management is not set in the script domain
-				taskQueue.Enqueue(task);
-				SignalAndWait(executingScript.waitEvent, executingScript.continueEvent);
+				finally
+				{
+					// Need to revert TLS context to the real one of the script thread
+					SetTlsContext(tlsOrg);
+				}
 			}
 		}
 


### PR DESCRIPTION
Eliminate the need of the `ForceCLRInit` hack, which can sometimes cause crash during first session load as mentioned in [#1169 (comment)](https://github.com/crosire/scripthookvdotnet/issues/1169#issuecomment-1448368054). Performance may be slightly impacted.