### PR TITLE
Add NavMeshBlockingObject

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/NavMeshBlockingObject.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/NavMeshBlockingObject.cs
@@ -13,7 +13,7 @@ namespace GTA
 	/// Does not create any dynamic objects or <see cref="Prop"/>s.
 	/// </summary>
 	/// <remarks>If SHVDN runtime stops working, all the <see cref="NavMeshBlockingObject"/> will get removed from the game.</remarks>
-	public class NavMeshBlockingObject : PoolObject, INativeValue
+	public sealed class NavMeshBlockingObject : PoolObject, INativeValue
 	{
 		internal NavMeshBlockingObject(int handle) : base(handle)
 		{

--- a/source/scripting_v3/GTA/Entities/Peds/NavMeshBlockingObject.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/NavMeshBlockingObject.cs
@@ -12,7 +12,7 @@ namespace GTA
 	/// Represents a blocking object that blocks <see cref="Ped"/>s using navigation mesh paths in the area the object covers when new <see cref="Ped"/> tasks that use navigation meshes (e.g. <see cref="TaskInvoker.WanderAround()"/>) start for them.
 	/// Does not create any dynamic objects or <see cref="Prop"/>s.
 	/// </summary>
-	/// <remarks>If SHVDN runtime stops working, all the <see cref="NavMeshBlockingObject"/> will get removed from the game.</remarks>
+	/// <remarks>If SHVDN runtime stops working, all the <see cref="NavMeshBlockingObject"/>s created via SHVDN will get removed from the game.</remarks>
 	public sealed class NavMeshBlockingObject : PoolObject, INativeValue
 	{
 		internal NavMeshBlockingObject(int handle) : base(handle)
@@ -36,27 +36,6 @@ namespace GTA
 			return Function.Call<bool>(Hash.DOES_NAVMESH_BLOCKING_OBJECT_EXIST, Handle);
 		}
 
-		const float DEG_2_RAD = (float)(System.Math.PI / 180);
-
-		/// <summary>
-		/// Creates a new <see cref="NavMeshBlockingObject"/>. 
-		/// </summary>
-		/// <param name="position">The origin position.</param>
-		/// <param name="size">The size.</param>
-		/// <param name="headingDegrees">The heading in degrees.</param>
-		/// <param name="flags">The flags that specify what types of paths the blocking object will block new <see cref="Ped"/> tasks that use navigation meshes (e.g. <see cref="TaskInvoker.WanderAround()"/>) from using.</param>
-		/// <returns>The new <see cref="NavMeshBlockingObject"/> if successfully created; otherwise, <see langword="null"/>.</returns>
-		/// <remarks>The new <see cref="NavMeshBlockingObject"/> won't block existing <see cref="Ped"/> tasks that use navigation mesh paths in the area the blocking object covers from using.</remarks>
-		public static NavMeshBlockingObject Create(Vector3 position, Vector3 size, float headingDegrees, NavMeshBlockingObjectFlags flags = NavMeshBlockingObjectFlags.AllPaths)
-		{
-			float headingRadians = headingDegrees * DEG_2_RAD;
-
-			// Set the second parameter is bPermanent to false, which determines whether the blocking object will last outside the lifetime of the calling script (scrThread)
-			// If the SHVDN runtime stops working, the blocking object will get deleted (stopping any SHVDN scripts working will not automatically remove any blocking objects)
-			var result = Function.Call<int>(Hash.ADD_NAVMESH_BLOCKING_OBJECT, position.X, position.Y, position.Z, size.X, size.Y, size.Z, headingRadians, false, flags);
-			return result != -1 ? new NavMeshBlockingObject(result) : null;
-		}
-
 		/// <summary>
 		/// Updates the <see cref="NavMeshBlockingObject"/>. 
 		/// </summary>
@@ -68,6 +47,7 @@ namespace GTA
 		/// <remarks>The updated <see cref="NavMeshBlockingObject"/> won't affect existing <see cref="Ped"/> tasks.</remarks>
 		public void Update(Vector3 position, Vector3 size, float headingDegrees, NavMeshBlockingObjectFlags flags)
 		{
+			const float DEG_2_RAD = (float)(System.Math.PI / 180);
 			Function.Call(Hash.UPDATE_NAVMESH_BLOCKING_OBJECT, Handle, position.X, position.Y, position.Z, size.X, size.Y, size.Z, headingDegrees * DEG_2_RAD, flags);
 		}
 
@@ -78,9 +58,9 @@ namespace GTA
 		/// <returns><see langword="true"/> if the <paramref name="obj"/> is the same navigation mesh blocking object as this <see cref="NavMeshBlockingObject"/>; otherwise, <see langword="false"/>.</returns>
 		public override bool Equals(object obj)
 		{
-			if (obj is NavMeshBlockingObject blip)
+			if (obj is NavMeshBlockingObject navMeshBlockingObject)
 			{
-				return Handle == blip.Handle;
+				return Handle == navMeshBlockingObject.Handle;
 			}
 
 			return false;

--- a/source/scripting_v3/GTA/Entities/Peds/NavMeshBlockingObject.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/NavMeshBlockingObject.cs
@@ -1,0 +1,123 @@
+﻿//
+// Copyright (C) 2015 crosire & contributors
+// License: https://github.com/crosire/scripthookvdotnet#license
+//
+
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+	/// <summary>
+	/// Represents a blocking object that blocks <see cref="Ped"/>s using navigation mesh paths in the area the object covers when new <see cref="Ped"/> tasks that use navigation meshes (e.g. <see cref="TaskInvoker.WanderAround()"/>) start for them.
+	/// Does not create any dynamic objects or <see cref="Prop"/>s.
+	/// </summary>
+	/// <remarks>If SHVDN runtime stops working, all the <see cref="NavMeshBlockingObject"/> will get removed from the game.</remarks>
+	public class NavMeshBlockingObject : PoolObject, INativeValue
+	{
+		internal NavMeshBlockingObject(int handle) : base(handle)
+		{
+		}
+
+		/// <summary>
+		/// Removes this <see cref="NavMeshBlockingObject"/>.
+		/// </summary>
+		public override void Delete()
+		{
+			Function.Call(Hash.REMOVE_NAVMESH_BLOCKING_OBJECT, Handle);
+		}
+
+		/// <summary>
+		/// Determines if this <see cref="NavMeshBlockingObject"/> exists.
+		/// </summary>
+		/// <returns><see langword="true" /> if this <see cref="NavMeshBlockingObject"/> exists; otherwise, <see langword="false"/></returns>.
+		public override bool Exists()
+		{
+			return Function.Call<bool>(Hash.DOES_NAVMESH_BLOCKING_OBJECT_EXIST, Handle);
+		}
+
+		const float DEG_2_RAD = (float)(System.Math.PI / 180);
+
+		/// <summary>
+		/// Creates a new <see cref="NavMeshBlockingObject"/>. 
+		/// </summary>
+		/// <param name="position">The origin position.</param>
+		/// <param name="size">The size.</param>
+		/// <param name="headingDegrees">The heading in degrees.</param>
+		/// <param name="flags">The flags that specify what types of paths the blocking object will block new <see cref="Ped"/> tasks that use navigation meshes (e.g. <see cref="TaskInvoker.WanderAround()"/>) from using.</param>
+		/// <returns>The new <see cref="NavMeshBlockingObject"/> if successfully created; otherwise, <see langword="null"/>.</returns>
+		/// <remarks>The new <see cref="NavMeshBlockingObject"/> won't block existing <see cref="Ped"/> tasks that use navigation mesh paths in the area the blocking object covers from using.</remarks>
+		public static NavMeshBlockingObject Create(Vector3 position, Vector3 size, float headingDegrees, NavMeshBlockingObjectFlags flags = NavMeshBlockingObjectFlags.AllPaths)
+		{
+			float headingRadians = headingDegrees * DEG_2_RAD;
+
+			// Set the second parameter is bPermanent to false, which determines whether the blocking object will last outside the lifetime of the calling script (scrThread)
+			// If the SHVDN runtime stops working, the blocking object will get deleted (stopping any SHVDN scripts working will not automatically remove any blocking objects)
+			var result = Function.Call<int>(Hash.ADD_NAVMESH_BLOCKING_OBJECT, position.X, position.Y, position.Z, size.X, size.Y, size.Z, headingRadians, false, flags);
+			return result != -1 ? new NavMeshBlockingObject(result) : null;
+		}
+
+		/// <summary>
+		/// Updates the <see cref="NavMeshBlockingObject"/>. 
+		/// </summary>
+		/// <param name="position">The origin position.</param>
+		/// <param name="size">The size.</param>
+		/// <param name="headingDegrees">The heading in degrees.</param>
+		/// <param name="flags">The flags that specify what types of paths the blocking object will block new peds task that use navigation meshes from using.</param>
+		/// <returns>The new <see cref="NavMeshBlockingObject"/> if successfully created; otherwise, <see langword="null"/>.</returns>
+		/// <remarks>The updated <see cref="NavMeshBlockingObject"/> won't affect existing <see cref="Ped"/> tasks.</remarks>
+		public void Update(Vector3 position, Vector3 size, float headingDegrees, NavMeshBlockingObjectFlags flags)
+		{
+			Function.Call(Hash.UPDATE_NAVMESH_BLOCKING_OBJECT, Handle, position.X, position.Y, position.Z, size.X, size.Y, size.Z, headingDegrees * DEG_2_RAD, flags);
+		}
+
+		/// <summary>
+		/// Determines if an <see cref="object"/> refers to the same navigation mesh blocking object as this <see cref="NavMeshBlockingObject"/>.
+		/// </summary>
+		/// <param name="obj">The <see cref="object"/> to check.</param>
+		/// <returns><see langword="true"/> if the <paramref name="obj"/> is the same navigation mesh blocking object as this <see cref="NavMeshBlockingObject"/>; otherwise, <see langword="false"/>.</returns>
+		public override bool Equals(object obj)
+		{
+			if (obj is NavMeshBlockingObject blip)
+			{
+				return Handle == blip.Handle;
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Determines if two <see cref="NavMeshBlockingObject"/>s refer to the same navigation mesh blocking object.
+		/// </summary>
+		/// <param name="left">The left <see cref="NavMeshBlockingObject"/>.</param>
+		/// <param name="right">The right <see cref="NavMeshBlockingObject"/>.</param>
+		/// <returns><see langword="true"/> if <paramref name="left"/> is the same navigation mesh blocking object as <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
+		public static bool operator ==(NavMeshBlockingObject left, NavMeshBlockingObject right)
+		{
+			return left is null ? right is null : left.Equals(right);
+		}
+		/// <summary>
+		/// Determines if two <see cref="NavMeshBlockingObject"/>s don't refer to the navigation mesh blocking object.
+		/// </summary>
+		/// <param name="left">The left <see cref="NavMeshBlockingObject"/>.</param>
+		/// <param name="right">The right <see cref="NavMeshBlockingObject"/>.</param>
+		/// <returns><see langword="true"/> if <paramref name="left"/> is not the navigation mesh blocking object as <paramref name="right"/>; otherwise, <see langword="false"/>.</returns>
+		public static bool operator !=(NavMeshBlockingObject left, NavMeshBlockingObject right)
+		{
+			return !(left == right);
+		}
+
+		/// <summary>
+		/// Converts an <see cref="NavMeshBlockingObject"/> to a native input argument.
+		/// </summary>
+		public static implicit operator InputArgument(NavMeshBlockingObject value)
+		{
+			return new InputArgument((ulong)value.Handle);
+		}
+
+		public override int GetHashCode()
+		{
+			return Handle.GetHashCode();
+		}
+	}
+}

--- a/source/scripting_v3/GTA/Entities/Peds/NavMeshBlockingObjectFlags.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/NavMeshBlockingObjectFlags.cs
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2015 crosire & contributors
+// License: https://github.com/crosire/scripthookvdotnet#license
+//
+
+using System;
+
+namespace GTA
+{
+    [Flags]
+    public enum NavMeshBlockingObjectFlags
+    {
+        Default = 0,
+        /// <summary>
+        /// Blocking object will block wander paths.
+        /// </summary>
+        WanderPath = 1,
+        /// <summary>
+        /// Blocking object will block (regular) shortest-paths.
+        /// </summary>
+        ShortestPath = 2,
+        /// <summary>
+        /// Blocking object will block flee paths.
+        /// </summary>
+        FleePath = 4,
+        AllPaths = WanderPath | ShortestPath | FleePath,
+    }
+}

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -1310,8 +1310,8 @@ namespace GTA
 
 			// Set the second last parameter bPermanent to false, which determines whether the blocking object will last outside the lifetime of the calling script (scrThread)
 			// If the SHVDN runtime stops working, all the blocking objects created via SHVDN will get deleted (stopping any SHVDN scripts working will not automatically remove any blocking objects)
-			var result = Function.Call<int>(Hash.ADD_NAVMESH_BLOCKING_OBJECT, position.X, position.Y, position.Z, size.X, size.Y, size.Z, headingRadians, false, flags);
-			return result != -1 ? new NavMeshBlockingObject(result) : null;
+			var handle = Function.Call<int>(Hash.ADD_NAVMESH_BLOCKING_OBJECT, position.X, position.Y, position.Z, size.X, size.Y, size.Z, headingRadians, false, flags);
+			return handle != -1 ? new NavMeshBlockingObject(handle) : null;
 		}
 
 		#region Particle Effects

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -1294,6 +1294,26 @@ namespace GTA
 
 		#endregion
 
+		/// <summary>
+		/// Creates a new <see cref="NavMeshBlockingObject"/>.
+		/// </summary>
+		/// <param name="position">The origin position.</param>
+		/// <param name="size">The size.</param>
+		/// <param name="headingDegrees">The heading in degrees.</param>
+		/// <param name="flags">The flags that specify what types of paths the blocking object will block new <see cref="Ped"/> tasks that use navigation meshes (e.g. <see cref="TaskInvoker.WanderAround()"/>) from using.</param>
+		/// <returns>The new <see cref="NavMeshBlockingObject"/> if successfully created; otherwise, <see langword="null"/>.</returns>
+		/// <remarks>The new <see cref="NavMeshBlockingObject"/> won't block existing <see cref="Ped"/> tasks that use navigation mesh paths in the area the blocking object covers from using.</remarks>
+		public static NavMeshBlockingObject CreateNavMeshBlockingObject(Vector3 position, Vector3 size, float headingDegrees, NavMeshBlockingObjectFlags flags = NavMeshBlockingObjectFlags.AllPaths)
+		{
+			const float DEG_2_RAD = (float)(System.Math.PI / 180);
+			float headingRadians = headingDegrees * DEG_2_RAD;
+
+			// Set the second last parameter bPermanent to false, which determines whether the blocking object will last outside the lifetime of the calling script (scrThread)
+			// If the SHVDN runtime stops working, all the blocking objects created via SHVDN will get deleted (stopping any SHVDN scripts working will not automatically remove any blocking objects)
+			var result = Function.Call<int>(Hash.ADD_NAVMESH_BLOCKING_OBJECT, position.X, position.Y, position.Z, size.X, size.Y, size.Z, headingRadians, false, flags);
+			return result != -1 ? new NavMeshBlockingObject(result) : null;
+		}
+
 		#region Particle Effects
 
 		/// <summary>

--- a/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
+++ b/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
@@ -103,6 +103,8 @@
     <Compile Include="GTA\Entities\Building.cs" />
     <Compile Include="GTA\Entities\Peds\DecisionMaker.cs" />
     <Compile Include="GTA\Entities\Peds\DecisionMakerTypeHash.cs" />
+    <Compile Include="GTA\Entities\Peds\NavMeshBlockingObject.cs" />
+    <Compile Include="GTA\Entities\Peds\NavMeshBlockingObjectFlags.cs" />
     <Compile Include="GTA\Entities\Peds\NavMeshRouteResult.cs" />
     <Compile Include="GTA\Entities\Peds\LookAtPriority.cs" />
     <Compile Include="GTA\Entities\Peds\LookAtFlags.cs" />


### PR DESCRIPTION
I saw the doc for `DISABLE_NAVMESH_IN_AREA` say *Please only use this command if you want to completely disable a large area of navmesh* and *"ADD_NAVMESH_BLOCKING_OBJECT" should be used instead for small or precise blocking areas*. So I wondered how `ADD_NAVMESH_BLOCKING_OBJECT` is different from `DISABLE_NAVMESH_IN_AREA`. I disassembled them to see how the 2 natives achieve the tasks and I found `ADD_NAVMESH_BLOCKING_OBJECT` doesn't touch any of `CNavMesh` instances (which you can mess around with using CodeWalker).