### PR TITLE
Rewrite most of internal methods that use ValueTuple to ones that use out params

### DIFF
--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -471,7 +471,7 @@ namespace GTA
 		{
 			get
 			{
-				var (rearBottomLeft, _) = Model.Dimensions;
+				Model.GetDimensions(out var rearBottomLeft, out _);
 				return GetOffsetPosition(new Vector3(rearBottomLeft.X, 0, 0));
 			}
 		}
@@ -483,7 +483,7 @@ namespace GTA
 		{
 			get
 			{
-				var (_, frontTopRight) = Model.Dimensions;
+				Model.GetDimensions(out _, out var frontTopRight);
 				return GetOffsetPosition(new Vector3(frontTopRight.X, 0, 0));
 			}
 		}
@@ -495,7 +495,7 @@ namespace GTA
 		{
 			get
 			{
-				var (rearBottomLeft, _) = Model.Dimensions;
+				Model.GetDimensions(out var rearBottomLeft, out _);
 				return GetOffsetPosition(new Vector3(0, rearBottomLeft.Y, 0));
 			}
 		}
@@ -507,7 +507,7 @@ namespace GTA
 		{
 			get
 			{
-				var (_, frontTopRight) = Model.Dimensions;
+				Model.GetDimensions(out _, out var frontTopRight);
 				return GetOffsetPosition(new Vector3(0, frontTopRight.Y, 0));
 			}
 		}
@@ -519,7 +519,7 @@ namespace GTA
 		{
 			get
 			{
-				var (_, frontTopRight) = Model.Dimensions;
+				Model.GetDimensions(out _, out var frontTopRight);
 				return GetOffsetPosition(new Vector3(0, 0, frontTopRight.Z));
 			}
 		}
@@ -531,7 +531,7 @@ namespace GTA
 		{
 			get
 			{
-				var (rearBottomLeft, _) = Model.Dimensions;
+				Model.GetDimensions(out var rearBottomLeft, out _);
 				return GetOffsetPosition(new Vector3(0, 0, rearBottomLeft.Z));
 			}
 		}

--- a/source/scripting_v3/GTA/Entities/EntityBone.cs
+++ b/source/scripting_v3/GTA/Entities/EntityBone.cs
@@ -69,7 +69,7 @@ namespace GTA
 		{
 			get
 			{
-				(int boneIndex, int boneTag) = SHVDN.NativeMemory.GetNextSiblingBoneIndexAndIdOfEntityBoneIndex(Owner.Handle, Index);
+				SHVDN.NativeMemory.GetNextSiblingBoneIndexAndIdOfEntityBoneIndex(Owner.Handle, Index, out var boneIndex, out var boneTag);
 				return new EntityBone(Owner, boneIndex, boneTag);
 			}
 		}
@@ -82,7 +82,7 @@ namespace GTA
 		{
 			get
 			{
-				(int boneIndex, int boneTag) = SHVDN.NativeMemory.GetParentBoneIndexAndIdOfEntityBoneIndex(Owner.Handle, Index);
+				SHVDN.NativeMemory.GetParentBoneIndexAndIdOfEntityBoneIndex(Owner.Handle, Index, out var boneIndex, out var boneTag);
 				return new EntityBone(Owner, boneIndex, boneTag);
 			}
 		}

--- a/source/scripting_v3/GTA/Entities/EntityDamageRecordCollection.cs
+++ b/source/scripting_v3/GTA/Entities/EntityDamageRecordCollection.cs
@@ -32,11 +32,9 @@ namespace GTA
 				}
 
 				var returnDamageRecord = SHVDN.NativeMemory.GetEntityDamageRecordEntryAtIndex(_owner.MemoryAddress, i);
+				var attackerEntity = returnDamageRecord.attackerEntityHandle != 0 ? Entity.FromHandle(returnDamageRecord.attackerEntityHandle) : null;
 
-				(int attackerHandle, int weaponHash, int gameTime) = returnDamageRecord;
-				var attackerEntity = attackerHandle != 0 ? Entity.FromHandle(attackerHandle) : null;
-
-				yield return new EntityDamageRecord(_owner, attackerEntity, (WeaponHash)weaponHash, gameTime);
+				yield return new EntityDamageRecord(_owner, attackerEntity, (WeaponHash)returnDamageRecord.weaponHash, returnDamageRecord.gameTime);
 			}
 		}
 
@@ -59,9 +57,9 @@ namespace GTA
 
 			for (int i = 0; i < returnDamageRecords.Length; i++)
 			{
-				(int attackerHandle, int weaponHash, int gameTime) = damageEntries[i];
-				var attackerEntity = attackerHandle != 0 ? Entity.FromHandle(attackerHandle) : null;
-				returnDamageRecords[i] = new EntityDamageRecord(_owner, attackerEntity, (WeaponHash)weaponHash, gameTime);
+				var damageRecord = damageEntries[i];
+				var attackerEntity = damageRecord.attackerEntityHandle != 0 ? Entity.FromHandle(damageRecord.attackerEntityHandle) : null;
+				returnDamageRecords[i] = new EntityDamageRecord(_owner, attackerEntity, (WeaponHash)damageRecord.weaponHash, damageRecord.gameTime);
 			}
 
 			return returnDamageRecords;

--- a/source/scripting_v3/GTA/Entities/Model.cs
+++ b/source/scripting_v3/GTA/Entities/Model.cs
@@ -348,21 +348,42 @@ namespace GTA
 		/// Gets the dimensions of this <see cref="Model"/>.
 		/// </summary>
 		/// <returns>
-		/// rearBottomLeft is the minimum dimensions, which contains the rear bottom left relative offset from the origin of the model,
-		///  frontTopRight is the maximum dimensions, which contains the front top right relative offset from the origin of the model.
+		/// <c>rearBottomLeft</c> is the minimum dimensions, which contains the rear bottom left relative offset from the origin of the model,
+		/// <c>frontTopRight</c> is the maximum dimensions, which contains the front top right relative offset from the origin of the model.
 		/// </returns>
+		/// <remarks>
+		/// When you need to fetch dimensions info from large amount of <see cref="Model"/>s in a short time,
+		/// it may be better to use <see cref="GetDimensions(out Vector3, out Vector3)"/> instead because creating <see cref="ValueTuple"/> costs much (about 10x) more than
+		/// using out parameters in .NET Framework and this property creates a <see cref="ValueTuple"/> instance.
+		/// </remarks>
 		public (Vector3 rearBottomLeft, Vector3 frontTopRight) Dimensions
 		{
 			get
 			{
-				NativeVector3 min, max;
-				unsafe
-				{
-					Function.Call(Native.Hash.GET_MODEL_DIMENSIONS, Hash, &min, &max);
-				}
-
-				return (min, max);
+				GetDimensions(out var rearBottomLeft, out var frontTopRight);
+				return (rearBottomLeft, frontTopRight);
 			}
+		}
+
+		/// <summary> 
+		/// <para>Gets the dimensions of this <see cref="Model"/>.</para>
+		/// <para>
+		/// When you need to fetch dimensions info from large amount of <see cref="Model"/>s in a short time, it may be better to use this method instead of <see cref="Dimensions"/>
+		/// because creating <see cref="ValueTuple"/> costs much (about 10x) more than using out parameters in .NET Framework.
+		/// </para>
+		/// </summary>
+		/// <param name="rearBottomLeft">The rear bottom left relative offset from the origin of the model.</param>
+		/// <param name="frontTopRight">The front top right relative offset from the origin of the model.</param>
+		public void GetDimensions(out Vector3 rearBottomLeft, out Vector3 frontTopRight)
+		{
+			NativeVector3 min, max;
+			unsafe
+			{
+				Function.Call(Native.Hash.GET_MODEL_DIMENSIONS, Hash, &min, &max);
+			}
+
+			rearBottomLeft = min;
+			frontTopRight = max;
 		}
 
 		/// <summary>

--- a/source/scripting_v3/GTA/Entities/Peds/PedBone.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedBone.cs
@@ -54,7 +54,7 @@ namespace GTA
 		{
 			get
 			{
-				(int boneIndex, int boneTag) = SHVDN.NativeMemory.GetNextSiblingBoneIndexAndIdOfEntityBoneIndex(Owner.Handle, Index);
+				SHVDN.NativeMemory.GetNextSiblingBoneIndexAndIdOfEntityBoneIndex(Owner.Handle, Index, out var boneIndex, out var boneTag);
 				return new PedBone(Owner, boneIndex, boneTag);
 			}
 		}
@@ -67,7 +67,7 @@ namespace GTA
 		{
 			get
 			{
-				(int boneIndex, int boneTag) = SHVDN.NativeMemory.GetParentBoneIndexAndIdOfEntityBoneIndex(Owner.Handle, Index);
+				SHVDN.NativeMemory.GetParentBoneIndexAndIdOfEntityBoneIndex(Owner.Handle, Index, out var boneIndex, out var boneTag);
 				return new PedBone(Owner, boneIndex, boneTag);
 			}
 		}


### PR DESCRIPTION
## Summary
- Rewrite most of internal methods that use `ValueTuple` to ones that use out params (via a temp struct for methods that returns entity damage info)
- Add `Model.GetDimensions` for scripts that wants model dimensions
frequently. That's why I didn't directly push commits for changes this PR addresses.
- (Fix `NextSibling` and `Parent` of `EntityBone` not actually using sibling/parent bone id)

I'm just thinking we should give up returning `ValueTuple` values from internal methods that can be frequently called, not from public APIs. Before #1172 was merged, native function calls would cost most of the time a script spends in one tick, but now this PR might be worth merging.

I don't touch `ValueTuple` for NaturalMotion for now, since only like 5 peds can ragdoll at the same time and I think few script devs would send new NM behaviors 50 times a frame.

## How much is creating ValueTuple slower than returning values via out/ref params?
### Test benchmark class (with BenchmarkDotNet)
```cs
[MemoryDiagnoser]
public class GetValuesWithRefOrValueTuple
{
    const int ELEM_VAL = 10000;

    int[] val1 = new int[ELEM_VAL];
    int[] val2 = new int[ELEM_VAL];

    public GetValuesWithRefOrValueTuple()
    {
        var rand = new Random();

        for (int i = 0; i < val1.Length; i++)
        {
            val1[i] = rand.Next();
        }

        for (int i = 0; i < val2.Length; i++)
        {
            val2[i] = rand.Next();
        }
    }

    public (int x, int y) GetValuesWithValueTupleInternal(int i)
    {
        return (val1[i], val2[i]);
    }

    public void GetValuesWithOutInternal(int i, out int x, out int y)
    {
        x = val1[i];
        y = val2[i];
    }

    [Benchmark]
    public void GetValuesWithValueTuple()
    {
        (int x, int y) aa;
        for (int i = 0; i < ELEM_VAL; i++)
        {
            aa = GetValuesWithValueTupleInternal(i);
        }
    }

     [Benchmark]
    public void GetValuesWithOut()
    {
        int x;
        int y;
        for (int i = 0; i < ELEM_VAL; i++)
        {
            GetValuesWithOutInternal(i, out x, out y);
        }
    }
}
```
### Result
#### in .NET Framework 4.8
|                  Method |      Mean |     Error |    StdDev | Allocated |
|------------------------ |----------:|----------:|----------:|----------:|
| GetValuesWithValueTuple | 54.136 us | 0.1106 us | 0.1035 us |         - |
|        GetValuesWithOut |  6.666 us | 0.0158 us | 0.0147 us |         - |

#### in .NET 7
|                  Method |     Mean |     Error |    StdDev | Allocated |
|------------------------ |---------:|----------:|----------:|----------:|
| GetValuesWithValueTuple | 4.507 us | 0.0101 us | 0.0090 us |         - |
|        GetValuesWithOut | 4.511 us | 0.0133 us | 0.0118 us |         - |