### PR TITLE
Add obsolete flags for VehicleWindowIndex

### DIFF
--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWindowIndex.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWindowIndex.cs
@@ -3,6 +3,8 @@
 // License: https://github.com/crosire/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
 	public enum VehicleWindowIndex

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWindowIndex.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWindowIndex.cs
@@ -15,5 +15,13 @@ namespace GTA
 		MiddleRightWindow,
 		Windshield,
 		BackWindshield,
+		[Obsolete("ExtraWindow1 is obsolete, please use MiddleLeftWindow instead.")]
+		ExtraWindow1 = 4,
+		[Obsolete("ExtraWindow2 is obsolete, please use MiddleRightWindow instead.")]
+		ExtraWindow2 = 5,
+		[Obsolete("ExtraWindow3 is obsolete, please use Windshield instead.")]
+		ExtraWindow3 = 6,
+		[Obsolete("ExtraWindow4 is obsolete, please use BackWindshield instead.")]
+		ExtraWindow4 = 7,
 	}
 }


### PR DESCRIPTION
Updated change broke compatibility with BTTFV and will therefore likely break compatibility with several available scripts. As such, it is pertinent to include the obsoleted values with the appropriate tags.