### PR TITLE
Add several properties for entity bone matrices

### DIFF
--- a/source/scripting_v3/GTA/Entities/EntityBone.cs
+++ b/source/scripting_v3/GTA/Entities/EntityBone.cs
@@ -107,7 +107,7 @@ namespace GTA
 		/// </summary>
 		/// <remarks>
 		/// While you can change appearance for <see cref="Vehicle"/>s by modifying this property,
-		/// you cannot change appearrance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property.
+		/// you cannot change appearance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property.
 		/// </remarks>
 		public Matrix PoseMatrix
 		{

--- a/source/scripting_v3/GTA/Entities/EntityBone.cs
+++ b/source/scripting_v3/GTA/Entities/EntityBone.cs
@@ -138,7 +138,7 @@ namespace GTA
 		/// </summary>
 		/// <remarks>
 		/// While you can change appearance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property,
-		/// you cannot change appearrance for <see cref="Vehicle"/>s by modifying this property.
+		/// you cannot change appearance for <see cref="Vehicle"/>s by modifying this property.
 		/// </remarks>
 		public Matrix RelativeMatrix
 		{
@@ -169,7 +169,7 @@ namespace GTA
 		/// </summary>
 		/// <remarks>
 		/// While you can change appearance for <see cref="Vehicle"/>s by modifying this property,
-		/// you cannot change appearrance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property.
+		/// you cannot change appearance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property.
 		/// </remarks>
 		public Vector3 Pose
 		{
@@ -201,7 +201,7 @@ namespace GTA
 		/// <remarks>
 		/// <para>
 		/// While you can change appearance for <see cref="Vehicle"/>s by modifying this property,
-		/// you cannot change appearrance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property.
+		/// you cannot change appearance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property.
 		/// </para>
 		/// <para>
 		/// Remember to normalize the value you are going to set before setting it to this property as the setter does not normalize the value, just like <c>SET_ENTITY_QUATERNION</c> does not.
@@ -248,7 +248,7 @@ namespace GTA
 		/// </summary>
 		/// <remarks>
 		/// While you can change appearance for <see cref="Vehicle"/>s by modifying this property,
-		/// you cannot change appearrance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property.
+		/// you cannot change appearance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property.
 		/// </remarks>
 		public Vector3 PoseRotation
 		{
@@ -331,7 +331,7 @@ namespace GTA
 		/// </summary>
 		/// <remarks>
 		/// While you can change appearance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property,
-		/// you cannot change appearrance for <see cref="Vehicle"/>s by modifying this property.
+		/// you cannot change appearance for <see cref="Vehicle"/>s by modifying this property.
 		/// </remarks>
 		public Vector3 RelativePosition
 		{
@@ -363,7 +363,7 @@ namespace GTA
 		/// <remarks>
 		/// <para>
 		/// While you can change appearance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property,
-		/// you cannot change appearrance for <see cref="Vehicle"/>s by modifying this property.
+		/// you cannot change appearance for <see cref="Vehicle"/>s by modifying this property.
 		/// </para>
 		/// <para>
 		/// Remember to normalize the value you are going to set before setting it to this property as the setter does not normalize the value, just like <c>SET_ENTITY_QUATERNION</c> does not.
@@ -406,11 +406,11 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets the rotation of this <see cref="EntityBone"/> relative to the <see cref="Entity"/> its part of  from <see cref="RelativeMatrix"/>.
+		/// Gets the rotation of this <see cref="EntityBone"/> relative to the <see cref="Entity"/> its part of from <see cref="RelativeMatrix"/>.
 		/// </summary>
 		/// <remarks>
 		/// While you can change appearance for <see cref="Ped"/>s or <see cref="Prop"/>s by modifying this property,
-		/// you cannot change appearrance for <see cref="Vehicle"/>s by modifying this property.
+		/// you cannot change appearance for <see cref="Vehicle"/>s by modifying this property.
 		/// </remarks>
 		public Vector3 RelativeRotation
 		{

--- a/source/scripting_v3/GTA/Entities/EntityBoneCollection.cs
+++ b/source/scripting_v3/GTA/Entities/EntityBoneCollection.cs
@@ -3,6 +3,7 @@
 // License: https://github.com/crosire/scripthookvdotnet#license
 //
 
+using GTA.Math;
 using GTA.Native;
 using System;
 using System.Collections;
@@ -86,6 +87,26 @@ namespace GTA
 		/// Gets the number of bones that this <see cref="Entity"/> has.
 		/// </summary>
 		public int Count => SHVDN.NativeMemory.GetEntityBoneCount(_owner.Handle);
+
+		/// <summary>
+		/// Gets the transform matrix that represents the same matrix as <see cref="Entity.Matrix"/> on this <see cref="Entity"/> unless this matrix is modified by some external programs.
+		/// </summary>
+		/// <remarks>
+		/// The matrix that this property reads is used in <see cref="EntityBone.Position"/>, <see cref="EntityBone.Quaternion"/>, and <see cref="EntityBone.Rotation"/>.
+		/// </remarks>
+		public Matrix TransformMatrix
+		{
+			get
+			{
+				IntPtr address = SHVDN.NativeMemory.GetEntityBoneTransformMatrixAddress(_owner.Handle);
+				if (address == IntPtr.Zero)
+				{
+					return Matrix.Zero;
+				}
+
+				return new Matrix(SHVDN.NativeMemory.ReadMatrix(address));
+			}
+		}
 
 		/// <summary>
 		/// Determines whether this <see cref="Entity"/> has a bone with the specified bone name


### PR DESCRIPTION
You could do what `EntityBone.PoseQuaternion`, `EntityBone.PoseRotation` and the getter of `EntityBone.RelativeQuaternion` offer with existing properties, but no need to leave unimplemented as deticated properties.