### PR TITLE
Enhance ScriptSettings for entry existence check and clearance and get/set methods with specified culture

### DIFF
--- a/source/scripting_v3/GTA/ScriptSettings.cs
+++ b/source/scripting_v3/GTA/ScriptSettings.cs
@@ -497,12 +497,12 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Deletes all of the keys of the specified section this <see cref="ScriptSettings"/> has the key.
+		/// Removes all of the keys of the specified section this <see cref="ScriptSettings"/> has the key.
 		/// </summary>
 		/// <param name="sectionName">The section name.</param>
 		/// <param name="keyName">The name of the key.</param>
-		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contained the specified key at the specified section and deleted the key; otherwise, <see langword="false"/>.</returns>
-		public bool DeleteKey(string sectionName, string keyName)
+		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contained the specified key at the specified section and removed the key; otherwise, <see langword="false"/>.</returns>
+		public bool RemoveKey(string sectionName, string keyName)
 		{
 			if (!_values.TryGetValue(sectionName, out var keyValuePairs))
 			{
@@ -513,17 +513,17 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Deletes the specified section if this <see cref="ScriptSettings"/> has the section.
+		/// Removes the specified section if this <see cref="ScriptSettings"/> has the section.
 		/// </summary>
 		/// <param name="sectionName">The section name where the value is.</param>
-		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contained the specified section and deleted the section; otherwise, <see langword="false"/>.</returns>
-		public bool DeleteSection(string sectionName)
+		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contained the specified section and removed the section; otherwise, <see langword="false"/>.</returns>
+		public bool RemoveSection(string sectionName)
 			=> _values.Remove(sectionName);
 
 		/// <summary>
-		/// Deletes all sections this <see cref="ScriptSettings"/> has.
+		/// Removes all sections this <see cref="ScriptSettings"/> has.
 		/// </summary>
-		public void DeleteAllSections()
+		public void RemoveAllSections()
 			=> _values.Clear();
 	}
 }

--- a/source/scripting_v3/GTA/ScriptSettings.cs
+++ b/source/scripting_v3/GTA/ScriptSettings.cs
@@ -516,8 +516,8 @@ namespace GTA
 		public bool RemoveSection(string sectionName) => _values.Remove(sectionName);
 
 		/// <summary>
-		/// Removes all sections this <see cref="ScriptSettings"/> has.
+		/// Clears all sections this <see cref="ScriptSettings"/> has.
 		/// </summary>
-		public void RemoveAllSections() => _values.Clear();
+		public void Clear() => _values.Clear();
 	}
 }

--- a/source/scripting_v3/GTA/ScriptSettings.cs
+++ b/source/scripting_v3/GTA/ScriptSettings.cs
@@ -257,8 +257,7 @@ namespace GTA
 		/// otherwise, the default value for the type of the value parameter.
 		/// </param>
 		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contains a value with the specified section and key; otherwise, <see langword="false"/>.</returns>
-		public bool TryGetValue<T>(string sectionName, string keyName, out T value)
-			=> TryGetValue(sectionName, keyName, out value, CultureInfo.InvariantCulture);
+		public bool TryGetValue<T>(string sectionName, string keyName, out T value) => TryGetValue(sectionName, keyName, out value, CultureInfo.InvariantCulture);
 
 		/// <summary>
 		/// Reads a value from this <see cref="ScriptSettings"/> using <paramref name="formatProvider"/>.
@@ -381,8 +380,7 @@ namespace GTA
 		/// such as not recognizing a decimal points as a decimal separator for floating-point numbers.
 		/// </para>
 		/// </remarks>
-		public T[] GetAllValues<T>(string section, string name)
-			=> GetAllValues<T>(section, name, null);
+		public T[] GetAllValues<T>(string section, string name) => GetAllValues<T>(section, name, null);
 
 		/// <summary>
 		/// Reads all the values at a specified key and section from this <see cref="ScriptSettings"/>.
@@ -457,19 +455,17 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets a value that indicates whether this <see cref="ScriptSettings"/> has the specified section.
+		/// Gets a value that indicates whether this <see cref="ScriptSettings"/> contains the specified section.
 		/// </summary>
-		public bool HasSection(string section)
-			=> _values.ContainsKey(section);
+		public bool ContainsSection(string section) => _values.ContainsKey(section);
 
 		/// <summary>
-		/// Gets a value that indicates whether this <see cref="ScriptSettings"/> has the specified key at the specified section.
+		/// Gets a value that indicates whether this <see cref="ScriptSettings"/> contains the specified key at the specified section.
 		/// </summary>
-		public bool HasKey(string sectionName, string keyName)
-			=> _values.TryGetValue(sectionName, out var keyValuePairs) && keyValuePairs.ContainsKey(keyName);
+		public bool ContainsKey(string sectionName, string keyName) => _values.TryGetValue(sectionName, out var keyValuePairs) && keyValuePairs.ContainsKey(keyName);
 
 		/// <summary>
-		/// Gets all of the section names this <see cref="ScriptSettings"/> has.
+		/// Gets all of the section names this <see cref="ScriptSettings"/> contains.
 		/// </summary>
 		public string[] GetAllSectionNames()
 		{
@@ -480,7 +476,7 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets all of the key names at the specified section name this <see cref="ScriptSettings"/> has.
+		/// Gets all of the key names at the specified section name this <see cref="ScriptSettings"/> contains.
 		/// </summary>
 		/// <param name="sectionName">The section name.</param>
 		public string[] GetAllKeyNames(string sectionName)
@@ -517,13 +513,11 @@ namespace GTA
 		/// </summary>
 		/// <param name="sectionName">The section name where the value is.</param>
 		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contained the specified section and removed the section; otherwise, <see langword="false"/>.</returns>
-		public bool RemoveSection(string sectionName)
-			=> _values.Remove(sectionName);
+		public bool RemoveSection(string sectionName) => _values.Remove(sectionName);
 
 		/// <summary>
 		/// Removes all sections this <see cref="ScriptSettings"/> has.
 		/// </summary>
-		public void RemoveAllSections()
-			=> _values.Clear();
+		public void RemoveAllSections() => _values.Clear();
 	}
 }

--- a/source/scripting_v3/GTA/ScriptSettings.cs
+++ b/source/scripting_v3/GTA/ScriptSettings.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 namespace GTA
@@ -168,6 +169,11 @@ namespace GTA
 		/// <param name="name">The name of the key the value is saved at.</param>
 		/// <param name="defaultvalue">The fall-back value if the key doesn't exist or casting to type <typeparamref name="T"/> fails.</param>
 		/// <returns>The value at <see paramref="name"/> in <see paramref="section"/>.</returns>
+		/// <remarks>
+		/// This overload parses using the current culture for the compatibility with scripts built against v3.6.0 or earlier.
+		/// Consider using the overload <see cref="GetValue{T}(string, string, T, IFormatProvider)"/> or call this overload with string type and parse the return value with a format provider later
+		/// to avoid users having trouble with culture-dependent issues, such as not recognizing a decimal points as a decimal separator for floating-point numbers.
+		/// </remarks>
 		public T GetValue<T>(string section, string name, T defaultvalue)
 		{
 			if (!_values.TryGetValue(section, out var keyValuePairs))
@@ -201,14 +207,124 @@ namespace GTA
 			}
 		}
 		/// <summary>
+		/// Reads a value from this <see cref="ScriptSettings"/>.
+		/// </summary>
+		/// <param name="sectionName">The section name where the value is.</param>
+		/// <param name="keyName">The name of the key the value is saved at.</param>
+		/// <param name="defaultValue">The fall-back value if the key doesn't exist or casting to type <typeparamref name="T"/> fails.</param>
+		/// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
+		/// <returns>The value at <see paramref="name"/> in <see paramref="section"/>.</returns>
+		public T GetValue<T>(string sectionName, string keyName, T defaultValue, IFormatProvider formatProvider)
+		{
+			if (!_values.TryGetValue(sectionName, out var keyValuePairs))
+			{
+				return defaultValue;
+			}
+			if (!keyValuePairs.TryGetValue(keyName, out var valueList))
+			{
+				return defaultValue;
+			}
+
+			try
+			{
+				if (typeof(T) == typeof(string))
+				{
+					// Performs more than 10x better than converting type via Convert.ChangeType
+					return (T)(object)valueList[0];
+				}
+				if (typeof(T).IsEnum)
+				{
+					return (T)Enum.Parse(typeof(T), valueList[0], true);
+				}
+				else
+				{
+					return formatProvider != null ? (T)Convert.ChangeType(valueList[0], typeof(T), formatProvider) : (T)Convert.ChangeType(valueList[0], typeof(T));
+				}
+			}
+			catch (Exception)
+			{
+				return defaultValue;
+			}
+		}
+
+		/// <summary>
+		/// Reads a value from this <see cref="ScriptSettings"/> using <see cref="CultureInfo.InvariantCulture"/>.
+		/// </summary>
+		/// <param name="sectionName">The section name where the value is.</param>
+		/// <param name="keyName">The name of the key the value is saved at.</param>
+		/// <param name="value">
+		/// When this method returns, contains the value associated with the specified section and key, if the key is found;
+		/// otherwise, the default value for the type of the value parameter.
+		/// </param>
+		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contains a value with the specified section and key; otherwise, <see langword="false"/>.</returns>
+		public bool TryGetValue<T>(string sectionName, string keyName, out T value)
+			=> TryGetValue(sectionName, keyName, out value, CultureInfo.InvariantCulture);
+
+		/// <summary>
+		/// Reads a value from this <see cref="ScriptSettings"/> using <paramref name="formatProvider"/>.
+		/// </summary>
+		/// <param name="sectionName">The section name where the value is.</param>
+		/// <param name="keyName">The name of the key the value is saved at.</param>
+		/// <param name="value">
+		/// When this method returns, contains the value associated with the specified section and key, if the key is found;
+		/// otherwise, the default value for the type of the value parameter.
+		/// </param>
+		/// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
+		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contains a value with the specified section and key; otherwise, <see langword="false"/>.</returns>
+		public bool TryGetValue<T>(string sectionName, string keyName, out T value, IFormatProvider formatProvider)
+		{
+			if (!_values.TryGetValue(sectionName, out var keyValuePairs))
+			{
+				value = default(T);
+				return false;
+			}
+			if (!keyValuePairs.TryGetValue(keyName, out var valueList))
+			{
+				value = default(T);
+				return false;
+			}
+
+			try
+			{
+				if (typeof(T) == typeof(string))
+				{
+					value = (T)(object)valueList[0];
+					return true;
+				}
+				if (typeof(T).IsEnum)
+				{
+					value = (T)Enum.Parse(typeof(T), valueList[0], true);
+					return true;
+				}
+				else
+				{
+					value = (T)Convert.ChangeType(valueList[0], typeof(T), formatProvider);
+					return true;
+				}
+			}
+			catch (Exception)
+			{
+				value = default(T);
+				return false;
+			}
+		}
+
+		/// <summary>
 		/// Sets a value in this <see cref="ScriptSettings"/>.
 		/// </summary>
 		/// <param name="section">The section where the value is.</param>
 		/// <param name="name">The name of the key the value is saved at.</param>
 		/// <param name="value">The value to set the key to.</param>
 		/// <remarks>
+		/// <para>
 		/// Overwrites the first value at a specified section and name and ignore the other values
 		/// if multiple values are set at a specified section and name.
+		/// </para>
+		/// <para>
+		/// This overload parses using the current culture for the compatibility with scripts built against v3.6.0 or earlier.
+		/// Consider using the overload <see cref="SetValue{T}(string, string, T, string, IFormatProvider)"/> or call this overload with string type and format the return value later
+		/// to avoid users having trouble with culture-dependent issues, such as not recognizing a decimal points as a decimal separator for floating-point numbers.
+		/// </para>
 		/// </remarks>
 		public void SetValue<T>(string section, string name, T value)
 		{
@@ -223,6 +339,31 @@ namespace GTA
 
 			AddNewValueInternal(section, name, internalValue);
 		}
+		/// <summary>
+		/// Sets a value in this <see cref="ScriptSettings"/>.
+		/// </summary>
+		/// <param name="sectionName">The section where the value is.</param>
+		/// <param name="keyName">The name of the key the value is saved at.</param>
+		/// <param name="value">The value to set the key to.</param>
+		/// <param name="format">The format to use.</param>
+		/// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
+		/// <remarks>
+		/// Overwrites the first value at a specified section and name and ignore the other values
+		/// if multiple values are set at a specified section and name.
+		/// </remarks>
+		public void SetValue<T>(string sectionName, string keyName, T value, string format, IFormatProvider formatProvider) where T : IFormattable
+		{
+			string internalValue = formatProvider != null ? value.ToString(format, formatProvider) : value.ToString();
+
+			if (_values.TryGetValue(sectionName, out var keyAndValuePairs) && keyAndValuePairs.TryGetValue(keyName, out var valueList))
+			{
+				// Assume the value list already occupies the index 0
+				valueList[0] = internalValue;
+				return;
+			}
+
+			AddNewValueInternal(sectionName, keyName, internalValue);
+		}
 
 		/// <summary>
 		/// Reads all the values at a specified key and section from this <see cref="ScriptSettings"/>.
@@ -230,16 +371,36 @@ namespace GTA
 		/// <param name="section">The section where the value is.</param>
 		/// <param name="name">The name of the key the values are saved at.</param>
 		/// <remarks>
+		/// <para>
+		/// You can set multiple values at a specified section and key by writing key and value pairs
+		/// at the same section and key in multiple lines.
+		/// </para>
+		/// <para>
+		/// This overload parses using the current culture for the compatibility with scripts built against v3.6.0 or earlier.
+		/// Consider using the overload <see cref="GetValue{T}(string, string, T, IFormatProvider)"/> to avoid users having trouble with culture-dependent issues,
+		/// such as not recognizing a decimal points as a decimal separator for floating-point numbers.
+		/// </para>
+		/// </remarks>
+		public T[] GetAllValues<T>(string section, string name)
+			=> GetAllValues<T>(section, name, null);
+
+		/// <summary>
+		/// Reads all the values at a specified key and section from this <see cref="ScriptSettings"/>.
+		/// </summary>
+		/// <param name="sectionName">The section name where the value is.</param>
+		/// <param name="keyName">The name of the key the values are saved at.</param>
+		/// <param name="formatProvider">An object that supplies culture-specific formatting information.</param>
+		/// <remarks>
 		/// You can set multiple values at a specified section and key by writing key and value pairs
 		/// at the same section and key in multiple lines.
 		/// </remarks>
-		public T[] GetAllValues<T>(string section, string name)
+		public T[] GetAllValues<T>(string sectionName, string keyName, IFormatProvider formatProvider)
 		{
-			if (!_values.TryGetValue(section, out var keyValuePairs))
+			if (!_values.TryGetValue(sectionName, out var keyValuePairs))
 			{
 				return Array.Empty<T>();
 			}
-			if (!keyValuePairs.TryGetValue(name, out var stringValueList))
+			if (!keyValuePairs.TryGetValue(keyName, out var stringValueList))
 			{
 				return Array.Empty<T>();
 			}
@@ -259,7 +420,8 @@ namespace GTA
 					}
 					else
 					{
-						values.Add((T)Convert.ChangeType(stringValue, typeof(T)));
+						var parsedValue = formatProvider != null ? (T)Convert.ChangeType(stringValue, typeof(T), formatProvider) : (T)Convert.ChangeType(stringValue, typeof(T));
+						values.Add(parsedValue);
 					}
 				}
 				catch
@@ -293,5 +455,75 @@ namespace GTA
 				_values.Add(sectionName, newKeyAndValuePairs);
 			}
 		}
+
+		/// <summary>
+		/// Gets a value that indicates whether this <see cref="ScriptSettings"/> has the specified section.
+		/// </summary>
+		public bool HasSection(string section)
+			=> _values.ContainsKey(section);
+
+		/// <summary>
+		/// Gets a value that indicates whether this <see cref="ScriptSettings"/> has the specified key at the specified section.
+		/// </summary>
+		public bool HasKey(string sectionName, string keyName)
+			=> _values.TryGetValue(sectionName, out var keyValuePairs) && keyValuePairs.ContainsKey(keyName);
+
+		/// <summary>
+		/// Gets all of the section names this <see cref="ScriptSettings"/> has.
+		/// </summary>
+		public string[] GetAllSectionNames()
+		{
+			var result = new string[_values.Count];
+			_values.Keys.CopyTo(result, 0);
+
+			return result;
+		}
+
+		/// <summary>
+		/// Gets all of the key names at the specified section name this <see cref="ScriptSettings"/> has.
+		/// </summary>
+		/// <param name="sectionName">The section name.</param>
+		public string[] GetAllKeyNames(string sectionName)
+		{
+			if (!_values.TryGetValue(sectionName, out var keyValuePairs))
+			{
+				return Array.Empty<string>();
+			}
+
+			var result = new string[keyValuePairs.Count];
+			keyValuePairs.Keys.CopyTo(result, 0);
+
+			return result;
+		}
+
+		/// <summary>
+		/// Deletes all of the keys of the specified section this <see cref="ScriptSettings"/> has the key.
+		/// </summary>
+		/// <param name="sectionName">The section name.</param>
+		/// <param name="keyName">The name of the key.</param>
+		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contained the specified key at the specified section and deleted the key; otherwise, <see langword="false"/>.</returns>
+		public bool DeleteKey(string sectionName, string keyName)
+		{
+			if (!_values.TryGetValue(sectionName, out var keyValuePairs))
+			{
+				return false;
+			}
+
+			return keyValuePairs.Remove(keyName);
+		}
+
+		/// <summary>
+		/// Deletes the specified section if this <see cref="ScriptSettings"/> has the section.
+		/// </summary>
+		/// <param name="sectionName">The section name where the value is.</param>
+		/// <returns><see langword="true"/> if the <see cref="ScriptSettings"/> contained the specified section and deleted the section; otherwise, <see langword="false"/>.</returns>
+		public bool DeleteSection(string sectionName)
+			=> _values.Remove(sectionName);
+
+		/// <summary>
+		/// Deletes all sections this <see cref="ScriptSettings"/> has.
+		/// </summary>
+		public void DeleteAllSections()
+			=> _values.Clear();
 	}
 }


### PR DESCRIPTION
Resolves #1214, resolves #1215

## Summary
- Add `ScriptSettings.TryGetValue`. To avoid that nasty variant culture issues, uses `CultureInfo.InvariantCulture` by default.
- Add overloads with `IFormatProvider` `ScriptSettings.GetValue`, `ScriptSettings.SetValue`, and `ScriptSettings.GetAllValues`
- Add methods for entry existence and deletion so scripts can make sure they can create clean settings without unintended sections or keys

Now you don't have to do these hacks when the locale for a user specifies a decimal comma as a decimal separator and the ini file has a floating-point value where a decimal point is used as a decimal separator, like:
```cs
float someFloatValue = 1.0f;
var originalCulture = CultureInfo.CurrentCulture;
CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;

someFloatValue = scriptSettings.GetValue("section", "key", someFloatValue);

CultureInfo.CurrentCulture = originalCulture;
```
or:
```cs
float someFloatValue = 1.0f;
string strForSomeFloatValue = scriptSettings.GetValue("section", "key", string.Empty);

if (float.TryParse(strForSomeFloatValue, CultureInfo.InvariantCulture, out var parsedSomeFloatValue)
{
    someFloatValue = parsedSomeFloatValue;
}
```

I don't think many scripts use `ScriptSettings.GetAllValues` and I'm not a fan of `ScriptSettings.GetAllValues` (since INI files don't have standard support for arrays) either, but [`ScriptSettings.GetAllValues`](https://github.com/crosire/scripthookvdotnet/blob/5adbb9fd3c9b41c4d38af4e9f7491d394c8d16b1/source/Settings.cpp#LL172C43-L172C55) exists since v0.3, so I wouldn't say much about that method being in v3 API.
If you want config file formats with standard support of arrays or dictionaries, you can use ones like [YAML](https://yaml.org/spec/1.2.2/#10214-floating-point), [TOML](https://toml.io/en/v1.0.0#float), and [KDL](https://github.com/kdl-org/kdl/blob/main/SPEC.md) anyway. Or you could read arrays and dictionaries with XML files with less hassle than INI, I guess.