### PR TITLE
Add VehicleWheel.SurfaceNormalVector

### DIFF
--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
@@ -160,6 +160,23 @@ namespace GTA
 		}
 
 		/// <summary>
+		/// Gets the normal vector of surface this <see cref="VehicleWheel"/> is contacting.
+		/// </summary>
+		public Vector3 SurfaceNormalVector
+		{
+			get
+			{
+				var address = MemoryAddress;
+				if (address == IntPtr.Zero)
+				{
+					return Vector3.Zero;
+				}
+
+				return new Vector3(SHVDN.NativeMemory.ReadVector3(address + 0x70));
+			}
+		}
+
+		/// <summary>
 		/// Gets or sets the limit multiplier that affects how much this <see cref="VehicleWheel"/> can turn.
 		/// </summary>
 		public float SteeringLimitMultiplier


### PR DESCRIPTION
Simple, this property is one of the values mentioned in [`BikeHandlingData.WheelieBalancePoint`](https://github.com/crosire/scripthookvdotnet/blob/da63afd74bbf986e541101674cbd03262cad24be/source/scripting_v3/GTA/Entities/Vehicles/BikeHandlingData.cs#L304).