### PR TITLE
Add Game.LocalPlayerPed

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -3721,10 +3721,19 @@ namespace SHVDN
 		{
 			return new IntPtr((long)GetPlayerPedAddressFunc(handle));
 		}
+		public static IntPtr GetLocalPlayerPedAddress()
+		{
+			return new IntPtr((long)GetLocalPlayerPedAddressFunc());
+		}
 		public static int GetPlayerPedHandle(int handle)
 		{
 			var playerPedAddress = GetPlayerAddress(handle);
 			return playerPedAddress != IntPtr.Zero ? GetEntityHandleFromAddress(playerPedAddress) : 0;
+		}
+		public static int GetLocalPlayerPedHandle()
+		{
+			var localPlayerPedAddress = GetLocalPlayerPedAddress();
+			return localPlayerPedAddress != IntPtr.Zero ? GetEntityHandleFromAddress(localPlayerPedAddress) : 0;
 		}
 		public static int GetLocalPlayerIndex()
 		{

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -15,6 +15,7 @@ namespace GTA
 	{
 		#region Fields
 		static Player cachedPlayer = null;
+		static Ped cachedLocalPlayerPed = null;
 
 		internal static readonly string[] radioNames = {
 			"RADIO_01_CLASS_ROCK",
@@ -82,6 +83,26 @@ namespace GTA
 				}
 
 				return cachedPlayer;
+			}
+		}
+
+		/// <summary>
+		/// Gets the local player <see cref="Ped"/> that you are controlling.
+		/// Use this property instead of <see cref="GTA.Player.Character"/> when you are only interested in the player <see cref="Ped"/>
+		/// and not the <see cref="GTA.Player"/> instance where a lot of player specific states are stored.
+		/// </summary>
+		public static Ped LocalPlayerPed
+		{
+			get
+			{
+				var handle = SHVDN.NativeMemory.GetLocalPlayerPedHandle();
+
+				if (cachedLocalPlayerPed == null || handle != cachedLocalPlayerPed.Handle)
+				{
+					cachedLocalPlayerPed = new Ped(handle);
+				}
+
+				return cachedLocalPlayerPed;
 			}
 		}
 


### PR DESCRIPTION
Fetching the player ped with this `Game.LocalPlayerPed` is like fetching the player ped handle with `PLAYER_PED_ID` in ysc scripts. And `Game.LocalPlayerPed` has more obvious intention, isn't it? I would like to see a lot of scripts calling `Game.LocalPlayerPed` more than that `Game.Player.Character` in the future, too.

In performance wise, There's not as much of a difference between `Game.LocalPlayerPed` and `Game.Player.Character` as the difference between `Function.Call<int>(Hash.GET_PLAYER_PED, Function.Call<int>(Hash.PLAYER_ID))` and `Function.Call<int>(Hash.PLAYER_PED_ID)` in the build bcd71ea (where the former takes about 5x more time, right before 089869e). Still `Game.LocalPlayerPed` performs a bit faster as expected since there's no need to evaluate the multiplayer flag and it can directly fetch the player ped address from `CPedFactory`.