### PR TITLE
Add PedConfigFlags and PedResetFlags and relevant configuration methods

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -319,24 +319,49 @@ namespace GTA
 		/// <summary>
 		/// Gets the config flag bit on this <see cref="Ped"/>.
 		/// </summary>
-		public bool GetConfigFlag(int flagID)
+		public bool GetConfigFlag(PedConfigFlags configFlag)
 		{
-			return Function.Call<bool>(Hash.GET_PED_CONFIG_FLAG, Handle, flagID, true);
+			return Function.Call<bool>(Hash.GET_PED_CONFIG_FLAG, Handle, (int)configFlag, false);
 		}
-
 		/// <summary>
 		/// Sets the config flag bit on this <see cref="Ped"/>.
 		/// </summary>
-		public void SetConfigFlag(int flagID, bool value)
+		public void SetConfigFlag(PedConfigFlags configFlag, bool value)
 		{
-			Function.Call(Hash.SET_PED_CONFIG_FLAG, Handle, flagID, value);
+			Function.Call(Hash.SET_PED_CONFIG_FLAG, Handle, (int)configFlag, value);
 		}
 
 		/// <summary>
-		/// Do not use this method as <c>SET_PED_RESET_FLAG</c> uses different flag IDs from the IDs <see cref="GetConfigFlag(int)"/> and <see cref="SetConfigFlag(int, bool)"/> use.
+		/// Gets the reset flag bit on this <see cref="Ped"/>.
+		/// You will need to call this method every frame you want to get, since the values of <see cref="PedConfigFlags"/> are reset every frame.
+		/// </summary>
+		public bool GetResetFlag(PedResetFlags configFlag)
+		{
+			return Function.Call<bool>(Hash.GET_PED_RESET_FLAG, Handle, (int)configFlag, false);
+		}
+		/// <summary>
+		/// Sets the reset flag bit on this <see cref="Ped"/>.
+		/// You will need to call this method every frame you want to set, since the values of <see cref="PedConfigFlags"/> are reset every frame.
+		/// </summary>
+		public void SetResetFlag(PedResetFlags configFlag, bool value)
+		{
+			Function.Call(Hash.SET_PED_RESET_FLAG, Handle, (int)configFlag, value);
+		}
+
+
+		[Obsolete("The Ped.GetConfigFlag overload with int parameter is obsolete, use the overload with PedConfigFlags instead.")]
+		/// <inheritdoc cref="GetConfigFlag(PedConfigFlags)"/>
+		public bool GetConfigFlag(int flagID) => GetConfigFlag((PedConfigFlags)flagID);
+		[Obsolete("The Ped.SetConfigFlag overload with int parameter is obsolete, use the overload with PedConfigFlags instead.")]
+		/// <inheritdoc cref="GetConfigFlag(PedConfigFlags)"/>
+		public void SetConfigFlag(int flagID, bool value) => SetConfigFlag((PedConfigFlags)flagID, value);
+
+		/// <summary>
+		/// Do not use this method and use <see cref="Ped.SetResetFlag(PedResetFlags, bool)"/> or <see cref="Ped.GetResetFlag(PedResetFlags)"/> instead,
+		/// because <c>SET_PED_RESET_FLAG</c> uses different flag IDs from the IDs <see cref="GetConfigFlag(int)"/> and <see cref="SetConfigFlag(int, bool)"/> use.
 		/// </summary>
 		[Obsolete("Ped.ResetConfigFlag is obsolete since SET_PED_RESET_FLAG uses different flag IDs from the IDs GET_PED_CONFIG_FLAG and SET_PED_CONFIG_FLAG use " +
-			"and the said overload always set the flag (2nd argument of SET_PED_RESET_FLAG) to true.", true)]
+			"and the said overload always set the flag (2nd argument of SET_PED_RESET_FLAG) to true. Use Ped.SetResetFlag or Ped.GetResetFlag instead", true)]
 		public void ResetConfigFlag(int flagID)
 		{
 			Function.Call(Hash.SET_PED_RESET_FLAG, Handle, flagID, true);

--- a/source/scripting_v3/GTA/Entities/Peds/PedConfigFlags.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedConfigFlags.cs
@@ -1,0 +1,937 @@
+namespace GTA
+{
+	/// <summary>
+	/// An enumeration of known config flags for <see cref="Ped"/>.
+	/// </summary>
+	/// <remarks>
+	/// You can check if names of this enum are included by searching the dumped exe for hashed values of names like <c>CPED_CONFIG_FLAG_[enum name]</c> without case conversion
+	/// (for example, search the dumped exe for 0x583B5E2D, which is the hashed value of <c>CPED_CONFIG_FLAG_AllowMedicsToReviveMe</c>).
+	/// </remarks>
+	public enum PedConfigFlags
+	{
+		CreatedByFactory = 0,
+		NoCriticalHits = 2,
+		DrownsInWater = 3,
+		DrownsInSinkingVehicle = 4,
+		DiesInstantlyWhenSwimming = 5,
+		UpperBodyDamageAnimsOnly = 7,
+		NeverLeavesGroup = 13,
+		DoesntDropWeaponsWhenDead = 14,
+		KeepTasksAfterCleanUp = 16,
+		BlockNonTemporaryEvents = 17,
+		WaitingForScriptBrainToLoad = 19,
+		/// <summary>
+		/// If the <see cref="Ped"/> dies medics will be dispatched, false by default for mission <see cref="Ped"/>s, the <see cref="Ped"/> wont be attended.
+		/// </summary>
+		/// <remarks>
+		/// Despite the "correct" enum name whose hash 0x583B5E2D (for <c>CPED_CONFIG_FLAG_AllowMedicsToReviveMe</c>) is present in the exe, medics cannot revive <see cref="Ped"/>s.
+		/// </remarks>
+		AllowMedicsToReviveMe = 20,
+		MoneyHasBeenGivenByScript = 21,
+		NotAllowedToCrouch = 22,
+		IgnoreSeenMelee = 24,
+		/// <summary>
+		/// Script can stop <see cref="Ped"/>s automatically getting out of car when it's upside down or undrivable, defaults to true.
+		/// </summary>
+		GetOutUndriveableVehicle = 29,
+		DontStoreAsPersistent = 31,
+		/// <summary>
+		/// The <see cref="Ped"/> will fly through the vehicle windscreen upon a forward impact at high velocity.
+		/// </summary>
+		WillFlyThroughWindscreen = 32,
+		DieWhenRagdoll = 33,
+		/// <summary>
+		/// The <see cref="Ped"/> has a helmet (the PedHelmetComponent has put the helmet on the <see cref="Ped"/> via "put on" animations).
+		/// </summary>
+		HasHelmet = 34,
+		UseHelmet = 35,
+		/// <summary>
+		/// Disable the <see cref="Ped"/> taking off his helmet automatically.
+		/// </summary>
+		DontTakeOffHelmet = 36,
+		HideInCutscene = 37,
+		DisableEvasiveDives = 39,
+		DontInfluenceWantedLevel = 42,
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_DisablePlayerLockon</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		DisablePlayerLockOn = 43,
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_DisableLockonToRandomPeds</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		DisableLockOnToRandomPeds = 44,
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_AllowLockonToFriendlyPlayers</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		AllowLockOnToFriendlyPlayers = 45,
+		PedBeingDeleted = 47,
+		BlockWeaponSwitching = 48,
+		ConstrainToNavMesh = 56,
+		IsFiring = 58,
+		WasFiring = 59,
+		IsStanding = 60,
+		WasStanding = 61,
+		InVehicle = 62,
+		OnMount = 63,
+		AttachedToVehicle = 64,
+		IsSwimming = 65,
+		WasSwimming = 66,
+		IsSkiing = 67,
+		IsSitting = 68,
+		KilledByStealth = 69,
+		KilledByTakedown = 70,
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_Knockedout</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>,
+		KnockedOut = 71,
+		ClearRadarBlipOnDeath = 72,
+		UsingCoverPoint = 75,
+		IsInTheAir = 76,
+		KnockedUpIntoAir = 77,
+		IsAimingGun = 78,
+		HasJustLeftCar = 79,
+		CurrLeftFootCollNM = 81,
+		PrevLeftFootCollNM = 82,
+		CurrRightFootCollNM = 83,
+		PrevRightFootCollNM = 84,
+		DontActivateRagdollFromAnyPedImpact = 89,
+		ForcePedLoadCover = 93,
+		VaultFromCover = 97,
+		UsingCrouchedPedCapsule = 99,
+		ForcedAim = 101,
+		OpenDoorArmIK = 104,
+		ForceReload = 105,
+		DontActivateRagdollFromVehicleImpact = 106,
+		DontActivateRagdollFromBulletImpact = 107,
+		DontActivateRagdollFromExplosions = 108,
+		DontActivateRagdollFromFire = 109,
+		DontActivateRagdollFromElectrocution = 110,
+		IsBeingDraggedToSafety = 111,
+		/// <summary>
+		/// Will keep the <see cref="Ped"/>s weapon holstered until they shoot or change weapons.
+		/// </summary>
+		KeepWeaponHolsteredUnlessFired = 113,
+		/// <summary>
+		/// If set, a <see cref="Ped"/> will escape a burning vehicle they are inside, defaults to true.
+		/// </summary>
+		GetOutBurningVehicle = 116,
+		BumpedByPlayer = 117,
+		/// <summary>
+		/// If set, a <see cref="Ped"/> will escape a burning vehicle they are inside, defaults to true.
+		/// </summary>
+		RunFromFiresAndExplosions = 118,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will be given the same boost a player gets in the targeting scoring system.
+		/// </summary>
+		TreatAsPlayerDuringTargeting = 119,
+		IsHandCuffed = 120,
+		IsAnkleCuffed = 121,
+		/// <summary>
+		/// Disable melee for a <see cref="Ped"/> (only supported for player right now).
+		/// </summary>
+		DisableMelee = 122,
+		/// <summary>
+		/// Disable unarmed driveby taunts for a <see cref="Ped"/>
+		/// </summary>
+		DisableUnarmedDrivebys = 123,
+		/// <summary>
+		/// MP only - if the <see cref="Ped"/> is tazed or rubber bulleted in a vehicle and a <see cref="Ped"/> jacks them, the jacker will only pull the <see cref="Ped"/> out.
+		/// </summary>
+		JustGetsPulledOutWhenElectrocuted = 124,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> won't hotwire a law enforcement vehicle.
+		/// </summary>
+		WillNotHotwireLawEnforcementVehicle = 126,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will play commandeering anims rather than jacking if available.
+		/// </summary>
+		WillCommandeerRatherThanJack = 127,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> can be agitated.
+		/// </summary>
+		CanBeAgitated = 128,
+		ForcePedToFaceLeftInCover = 129,
+		/// <summary>
+		/// If set <see cref="Ped"/> will turn to face right in cover.
+		/// </summary>
+		ForcePedToFaceRightInCover = 130,
+		BlockPedFromTurningInCover = 131,
+		/// <summary>
+		/// Ped keeps their relationship group when the mission is cleaned up or they are marked as no longer needed.
+		/// </summary>
+		KeepRelationshipGroupAfterCleanUp = 132,
+		/// <summary>
+		/// Ped will loop the try locked door anim when they get to the door in order for them to automatically be dragged along.
+		/// </summary>
+		ForcePedToBeDragged = 133,
+		/// <summary>
+		/// Ped doesn't react when being jacked.
+		/// </summary>
+		PreventPedFromReactingToBeingJacked = 134,
+		IsScuba = 135,
+		WillArrestRatherThanJack = 136,
+		/// <summary>
+		/// We must be further away before <see cref="Ped"/> population remove the <see cref="Ped"/> when it is dead.
+		/// </summary>
+		RemoveDeadExtraFarAway = 137,
+		RidingTrain = 138,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> arrest task completed successfully.
+		/// </summary>
+		ArrestResult = 139,
+		/// <summary>
+		/// True allows the <see cref="Ped"/> to attack <see cref="Ped"/>s they are friendly with.
+		/// </summary>
+		CanAttackFriendly = 140,
+		/// <summary>
+		/// MP only, if set the <see cref="Ped"/> will be allowed to jack any player <see cref="Ped"/>s, regardless of relationship.
+		/// </summary>
+		WillJackAnyPlayer = 141,
+		/// <summary>
+		/// MP only, True if this player will jack hated players rather than try to steal a car (cops arresting crims).
+		/// </summary>
+		WillJackWantedPlayersRatherThanStealCar = 144,
+		/// <summary>
+		/// If this flag is set on a <see cref="Ped"/> it will not scan for or climb ladders.
+		/// </summary>
+		DisableLadderClimbing = 146,
+		StairsDetected = 147,
+		SlopeDetected = 148,
+		HelmetHasBeenShot = 149,
+		/// <summary>
+		/// If set the <see cref="Ped"/> should cower instead of fleeing.
+		/// </summary>
+		CowerInsteadOfFlee = 150,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will be allowed to ragdoll when the vehicle they are in gets turned upside down if the seat supports it.
+		/// </summary>
+		CanActivateRagdollWhenVehicleUpsideDown = 151,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will respond to cries for help even if not friends with the injured <see cref="Ped"/>.
+		/// </summary>
+		AlwaysRespondToCriesForHelp = 152,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will not create a blood pool when dead.
+		/// </summary>
+		DisableBloodPoolCreation = 153,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will be fixed if there is no collision around.
+		/// </summary>
+		ShouldFixIfNoCollision = 154,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> can perform arrests on <see cref="Ped"/>s that can be arrested.
+		/// </summary>
+		CanPerformArrest = 155,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> can uncuff <see cref="Ped"/>s that are handcuffed.
+		/// </summary>
+		CanPerformUncuff = 156,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> can be arrested.
+		/// </summary>
+		CanBeArrested = 157,
+		MoverConstrictedByOpposingCollisions = 158,
+		/// <summary>
+		/// When true, Prefer the front seat when getting in a car with buddies.
+		/// </summary>
+		PlayerPreferFrontSeatMP = 159,
+		DontActivateRagdollFromImpactObject = 160,
+		DontActivateRagdollFromMelee = 161,
+		DontActivateRagdollFromWaterJet = 162,
+		DontActivateRagdollFromDrowning = 163,
+		DontActivateRagdollFromFalling = 164,
+		DontActivateRagdollFromRubberBullet = 165,
+		IsInjured = 166,
+		/// <summary>
+		/// When true, will follow the player around if in their group but wont enter vehicles.
+		/// </summary>
+		DontEnterVehiclesInPlayersGroup = 167,
+		SwimmingTasksRunning = 168,
+		/// <summary>
+		/// Disable all melee taunts for this particular <see cref="Ped"/>.
+		/// </summary>
+		PreventAllMeleeTaunts = 169,
+		/// <summary>
+		/// Will force the <see cref="Ped"/> to use the direct entry point for any vehicle they try to enter, or warp in.
+		/// </summary>
+		ForceDirectEntry = 170,
+		/// <summary>
+		/// This <see cref="Ped"/> will always see approaching vehicles (even from behind).
+		/// </summary>
+		AlwaysSeeApproachingVehicles = 171,
+		/// <summary>
+		/// This <see cref="Ped"/> can dive away from approaching vehicles.
+		/// </summary>
+		CanDiveAwayFromApproachingVehicles = 172,
+		/// <summary>
+		/// Will allow player to interrupt a <see cref="Ped"/>s scripted entry/exit task as if they had triggered it themselves.
+		/// </summary>
+		AllowPlayerToInterruptVehicleEntryExit = 173,
+		/// <summary>
+		/// This <see cref="Ped"/> will only attack cops if the player is wanted.
+		/// </summary>
+		OnlyAttackLawIfPlayerIsWanted = 174,
+		PlayerInContactWithKinematicPed = 175,
+		PlayerInContactWithSomethingOtherThanKinematicPed = 176,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will not get in as part of the jack.
+		/// </summary>
+		PedsJackingMeDontGetIn = 177,
+		/// <summary>
+		/// AI <see cref="Ped"/>s only, will not early out of anims, default behaviour is to exit as early as possible.
+		/// </summary>
+		PedIgnoresAnimInterruptEvents = 179,
+		/// <summary>
+		/// Any targeting LoS checks will fail if any materials with 'see through' materials found.
+		/// </summary>
+		IsInCustody = 180,
+		/// <summary>
+		/// Setting this on an armed or buddy <see cref="Ped"/> will make him more likely to perform an nm reaction when bumped by a player, friendly vehicle or ragdolling <see cref="Ped"/>.
+		/// </summary>
+		ForceStandardBumpReactionThresholds = 181,
+		/// <summary>
+		/// If set on a <see cref="Ped"/>, law <see cref="Ped"/>s will only attack if the local player is wanted.
+		/// </summary>
+		LawWillOnlyAttackIfPlayerIsWanted = 182,
+		IsAgitated = 183,
+		/// <summary>
+		/// Prevents passenger from auto shuffling over to drivers seat if it becomes free.
+		/// </summary>
+		PreventAutoShuffleToDriversSeat = 184,
+		/// <summary>
+		/// When enabled, the <see cref="Ped"/> will continually set the kinematic mode reset flag when stationary.
+		/// </summary>
+		UseKinematicModeWhenStationary = 185,
+		EnableWeaponBlocking = 186,
+		HasHurtStarted = 187,
+		/// <summary>
+		/// Set to disable the combat hurt mode.
+		/// </summary>
+		DisableHurt = 188,
+		/// <summary>
+		/// Should this player <see cref="Ped"/> periodically generate shocking events for being weird.
+		/// </summary>
+		PlayerIsWeird = 189,
+		WarpIntoLeadersVehicle = 192,
+		/// <summary>
+		/// Do nothing when on foot, by default.
+		/// </summary>
+		DoNothingWhenOnFootByDefault = 193,
+		UsingScenario = 194,
+		VisibleOnScreen = 195,
+		ActivateOnSwitchFromLowPhysicsLod = 197,
+		/// <summary>
+		/// Peds with this flag set won't be allowed to reactivate their ragdoll when hit by another ragdoll.
+		/// </summary>
+		DontActivateRagdollOnPedCollisionWhenDead = 198,
+		/// <summary>
+		/// Peds with this flag set won't be allowed to reactivate their ragdoll when hit by a vehicle.
+		/// </summary>
+		DontActivateRagdollOnVehicleCollisionWhenDead = 199,
+		/// <summary>
+		/// True if we've ever been in non-melee combat.
+		/// </summary>
+		HasBeenInArmedCombat = 200,
+		UseDiminishingAmmoRate = 201,
+		/// <summary>
+		/// True if the <see cref="Ped"/> never steer around other <see cref="Ped"/>s.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_Avoidance_Ignore_All</c> in the exe.
+		/// </remarks>
+		AvoidanceIgnoreAll = 202,
+		/// <summary>
+		/// True if other <see cref="Ped"/>s never steer around the <see cref="Ped"/>.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_Avoidance_Ignored_by_All</c> in the exe.
+		/// </remarks>
+		AvoidanceIgnoredbyAll = 203,
+		/// <summary>
+		/// True if the <see cref="Ped"/> steer around other <see cref="Ped"/>s that are members of group 1.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_Avoidance_Ignore_Group1</c> in the exe.
+		/// </remarks>
+		AvoidanceIgnoreGroup1 = 204,
+		/// <summary>
+		/// True if the <see cref="Ped"/> are members of avoidance group 1.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_Avoidance_Member_of_Group1</c> in the exe.
+		/// </remarks>
+		AvoidanceMemberofGroup1 = 205,
+		/// <summary>
+		/// Ped is forced to use specific seat index set by <c>SET_PED_GROUP_MEMBER_PASSENGER_INDEX</c>.
+		/// </summary>
+		ForcedToUseSpecificGroupSeatIndex = 206,
+		LowPhysicsLodMayPlaceOnNavMesh = 207,
+		/// <summary>
+		/// If set, <see cref="Ped"/> will ignore explosion events.
+		/// </summary>
+		DisableExplosionReactions = 208,
+		/// <summary>
+		/// Set when player switches to an ai <see cref="Ped"/> and keeps the scripted task of the ai <see cref="Ped"/>, if unset we won't check for interrupts or time out.
+		/// </summary>
+		WaitingForPlayerControlInterrupt = 210,
+		/// <summary>
+		/// If set, <see cref="Ped"/> will stay in cover (won't come out to fire or move out during combat).
+		/// </summary>
+		ForcedToStayInCover = 211,
+		/// <summary>
+		/// Does the <see cref="Ped"/> generate sound events?
+		/// </summary>
+		GeneratesSoundEvents = 212,
+		/// <summary>
+		/// Does the <see cref="Ped"/> have the ability to respond to sound events?
+		/// </summary>
+		ListensToSoundEvents = 213,
+		/// <summary>
+		/// Ped can be targeting inside a vehicle.
+		/// </summary>
+		AllowToBeTargetedInAVehicle = 214,
+		/// <summary>
+		/// When exiting a vehicle, the <see cref="Ped"/> will wait for the direct entry point to be clear before exiting.
+		/// </summary>
+		WaitForDirectEntryPointToBeFreeWhenExiting = 215,
+		/// <summary>
+		/// Force the skydive exit if we're exiting the vehicle.
+		/// </summary>
+		ForceExitToSkyDive = 217,
+		AllowPedInVehiclesOverrideTaskFlags = 219,
+		/// <summary>
+		/// Disable the skydive exit if we're exiting the vehicle.
+		/// </summary>
+		DisableExitToSkyDive = 221,
+		ScriptHasDisabledCollision = 222,
+		UseAmbientModelScaling = 223,
+		DisablePotentialToBeWalkedIntoResponse = 225,
+		/// <summary>
+		/// This <see cref="Ped"/> will not avoid other <see cref="Ped"/>s whilst navigating.
+		/// </summary>
+		DisablePedAvoidance = 226,
+		/// <summary>
+		/// When the <see cref="Ped"/> dies, it will ragdoll instead of potentially choosing an animated death.
+		/// </summary>
+		ForceRagdollUponDeath = 227,
+		/// <summary>
+		/// Disable panic in vehicle.
+		/// </summary>
+		DisablePanicInVehicle = 229,
+		/// <summary>
+		/// Allow the <see cref="Ped"/> to detach trailers from vehicles.
+		/// </summary>
+		AllowedToDetachTrailer = 230,
+		AllowBlockDeadPedRagdollActivation = 235,
+		IsHoldingProp = 236,
+		/// <summary>
+		/// ForceSkin character cloth on creation when flag is set.
+		/// </summary>
+		ForceSkinCharacterCloth = 240,
+		/// <summary>
+		/// Player will leave the engine on when exiting a vehicle normally.
+		/// </summary>
+		LeaveEngineOnWhenExitingVehicles = 241,
+		/// <summary>
+		/// tells taskmobile phone to not texting animations.  Currently don't play these in MP.
+		/// </summary>
+		PhoneDisableTextingAnimations = 242,
+		/// <summary>
+		/// tells taskmobile phone to not talking animations.  Currently don't play these in MP.
+		/// </summary>
+		PhoneDisableTalkingAnimations = 243,
+		/// <summary>
+		/// tells taskmobile phone to not camera animations.  Currently don't play these in SP.
+		/// </summary>
+		PhoneDisableCameraAnimations = 244,
+		/// <summary>
+		/// Stops the <see cref="Ped"/> from accidentally firing his weapon when shot.
+		/// </summary>
+		DisableBlindFiringInShotReactions = 245,
+		/// <summary>
+		/// This makes it so that OTHER <see cref="Ped"/>s are allowed to take cover at points that would otherwise be rejected due to proximity.
+		/// </summary>
+		AllowNearbyCoverUsage = 246,
+		/// <summary>
+		/// If the <see cref="Ped"/> is a law enforcement <see cref="Ped"/> then we will NOT quit combat due to a target player no longer having a wanted level.
+		/// </summary>
+		CanAttackNonWantedPlayerAsLaw = 249,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will take damage if the car they are in crashes.
+		/// </summary>
+		WillTakeDamageWhenVehicleCrashes = 250,
+		/// <summary>
+		/// If this ai <see cref="Ped"/> is driving the vehicle, if the player taps to enter, they will enter as a rear passenger, if they hold, they'll jack the driver.
+		/// </summary>
+		AICanDrivePlayerAsRearPassenger = 251,
+		/// <summary>
+		/// If a friendly player is driving the vehicle, if the player taps to enter, they will enter as a passenger, if they hold, they'll jack the driver.
+		/// </summary>
+		PlayerCanJackFriendlyPlayers = 252,
+		OnStairs = 253,
+		/// <summary>
+		/// If this ai <see cref="Ped"/> is driving the vehicle, allow players to get in passenger seats.
+		/// </summary>
+		AIDriverAllowFriendlyPassengerSeatEntry = 255,
+		ParentCarIsBeingRemoved = 256,
+		AllowMissionPedToUseInjuredMovement = 257,
+		/// <summary>
+		/// Don't use certain seats (like hanging on the side of a vehicle).
+		/// </summary>
+		PreventUsingLowerPrioritySeats = 261,
+		JustLeftVehicleNeedsReset = 262,
+		/// <summary>
+		/// If set, teleport if <see cref="Ped"/> is not in the leader's vehicle before TaskEnterVehicle::m_SecondsBeforeWarpToLeader.
+		/// </summary>
+		TeleportToLeaderVehicle = 268,
+		/// <summary>
+		/// Don't walk extra far around weird <see cref="Ped"/>s like trevor.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_Avoidance_Ignore_WeirdPedBuffer</c> in the exe.
+		/// </remarks>
+		AvoidanceIgnoreWeirdPedBuffer = 269,
+		OnStairSlope = 270,
+		/// <summary>
+		/// Don't add a blip for this cop.
+		/// </summary>
+		DontBlipCop = 272,
+		/// <summary>
+		/// Kill the <see cref="Ped"/> if it becomes trap<see cref="Ped"/> and cannot get up.
+		/// </summary>
+		KillWhenTrapped = 275,
+		EdgeDetected = 276,
+		AlwaysWakeUpPhysicsOfIntersectedPeds = 277,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will avoid tear gas.
+		/// </summary>
+		AvoidTearGas = 279,
+		StoppedSpeechUponFreezing = 280,
+		/// <summary>
+		/// If set, CPed::DAMAGED_GOTOWRITHE will no longer get set.  In particular, tazer hits wil no longer kill the <see cref="Ped"/> in one hit.
+		/// </summary>
+		DisableGoToWritheWhenInjured = 281,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will only use their forced seat index if the vehicle they're entering is a heli as part of a group.
+		/// </summary>
+		OnlyUseForcedSeatWhenEnteringHeliInGroup = 282,
+		ThrownFromVehicleDueToExhaustion = 283,
+		/// <summary>
+		/// Disables weird <see cref="Ped"/> events.
+		/// </summary>
+		DisableWeirdPedEvents = 285,
+		/// <summary>
+		/// This <see cref="Ped"/> should charge if in combat right away, for use by scripts, cleared once <see cref="Ped"/> charges.
+		/// </summary>
+		ShouldChargeNow = 286,
+		RagdollingOnBoat = 287,
+		HasBrandishedWeapon = 288,
+		PedHasBeenSeen = 291,
+		PedIsInReusePool = 292,
+		/// <summary>
+		/// This <see cref="Ped"/> should ignore shocking events.
+		/// </summary>
+		DisableShockingEvents = 294,
+		MovedUsingLowLodPhysicsSinceLastActive = 295,
+		/// <summary>
+		/// If true, the <see cref="Ped"/> will not react to a <see cref="Ped"/> standing on the roof.
+		/// </summary>
+		NeverReactToPedOnRoof = 296,
+		/// <summary>
+		/// If true, the <see cref="Ped"/> will not react to <see cref="Ped"/>s driving on pavement.
+		/// </summary>
+		DisableShockingDrivingOnPavementEvents = 299,
+		DisablePedConstraints = 301,
+		/// <summary>
+		/// If set, <see cref="Ped"/> will peek once before firing in cover. Cleared upon peeking.
+		/// </summary>
+		ForceInitialPeekInCover = 302,
+		/// <summary>
+		/// If true, disable followers jumping out of cars after their group leader.
+		/// </summary>
+		DisableJumpingFromVehiclesAfterLeader = 305,
+		DontActivateRagdollFromPlayerPedImpact = 306,
+		DontActivateRagdollFromAiRagdollImpact = 307,
+		DontActivateRagdollFromPlayerRagdollImpact = 308,
+		DisableQuadrupedSpring = 309,
+		IsInCluster = 310,
+		/// <summary>
+		/// Set this for a <see cref="Ped"/> to be ignored by the auto opened doors when checking to see if the door should be opened.
+		/// </summary>
+		IgnoredByAutoOpenDoors = 312,
+		PreferInjuredGetup = 313,
+		/// <summary>
+		/// Purposely ignore the melee active combatant role and push them into a support or inactive combatant role.
+		/// </summary>
+		ForceIgnoreMeleeActiveCombatant = 314,
+		/// <summary>
+		/// If set, <see cref="Ped"/> will ignore sound events generated by entities it can't see.
+		/// </summary>
+		CheckLoSForSoundEvents = 315,
+		JackedAbandonedCar = 316,
+		/// <summary>
+		/// If set, <see cref="Ped"/> can play FRIEND_FOLLOWED_BY_PLAYER lines.
+		/// </summary>
+		CanSayFollowedByPlayerAudio = 317,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will activate ragdoll much more easily on contact with the player.
+		/// </summary>
+		ActivateRagdollFromMinorPlayerContact = 318,
+		/// <summary>
+		/// Ped has cloth collision bounds.
+		/// </summary>
+		HasClothCollisionBounds = 321,
+		HasHighHeels = 322,
+		/// <summary>
+		/// If set on a non-law <see cref="Ped"/> that has law like behavior (i.e. security) then that <see cref="Ped"/> will not use the law like behaviors/logic.
+		/// </summary>
+		DontBehaveLikeLaw = 324,
+		SpawnedAtScenario = 325,
+		/// <summary>
+		/// If set, police will not perform the CTaskShockingPoliceInvestigate behavior on the <see cref="Ped"/>.
+		/// </summary>
+		DisablePoliceInvestigatingBody = 326,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will no longer shoot while writhing.
+		/// </summary>
+		DisableWritheShootFromGround = 327,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will only just the warp entry points if there are no animated entry points available.
+		/// </summary>
+		LowerPriorityOfWarpSeats = 328,
+		/// <summary>
+		/// If set the <see cref="Ped"/> can't be talked to.
+		/// </summary>
+		DisableTalkTo = 329,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will not be blip<see cref="Ped"/> by the wanted system.
+		/// </summary>
+		DontBlip = 330,
+		IsSwitchingWeapon = 331,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will ignore leg IK request restrictions for non-player <see cref="Ped"/>s.
+		/// </summary>
+		IgnoreLegIkRestrictions = 332,
+		JackedOutOfMyVehicle = 334,
+		WentIntoCombatAfterBeingJacked = 335,
+		DontActivateRagdollForVehicleGrab = 336,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will timeslice it's DoNothing Task when computing default task.
+		/// </summary>
+		AllowTaskDoNothingTimeslicing = 339,
+		ForcedToStayInCoverDueToPlayerSwitch = 340,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will not be allowed to jack any other players (not synced).
+		/// </summary>
+		NotAllowedToJackAnyPlayers = 342,
+		KilledByStandardMelee = 344,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will always exit the train when it stops at a station.
+		/// </summary>
+		AlwaysLeaveTrainUponArrival = 345,
+		/// <summary>
+		/// If set, Only allow <see cref="Ped"/> to writhe from weapon damage, not from other stuff, like small vehicle impacts.
+		/// </summary>
+		OnlyWritheFromWeaponDamage = 347,
+		EquipJetpack = 349,
+		ScriptHasCompletelyDisabledCollision = 351,
+		/// <summary>
+		/// Don't do distance from camera culling of the deep surface check, needed for detecting snow, mud, etc.
+		/// </summary>
+		ForceDeepSurfaceCheck = 356,
+		/// <summary>
+		/// Disable deep surface anims to prevent them slowing <see cref="Ped"/> down.
+		/// </summary>
+		DisableDeepSurfaceAnims = 357,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will not be blip<see cref="Ped"/> by the wanted system, this will not be synced and be set on clones so the behaviour can be changed per player.
+		/// </summary>
+		DontBlipNotSynced = 358,
+		/// <summary>
+		/// Query only, see if the <see cref="Ped"/> is ducking in a vehicle.
+		/// </summary>
+		IsDuckingInVehicle = 359,
+		/// <summary>
+		/// If set the <see cref="Ped"/> will not automatically shuffle to the turret seat when it becomes free.
+		/// </summary>
+		PreventAutoShuffleToTurretSeat = 360,
+		/// <summary>
+		/// Disables the ignore events based on interior status check which normally has <see cref="Ped"/>s inside ignore events from outside.
+		/// </summary>
+		DisableEventInteriorStatusCheck = 361,
+		HasReserveParachute = 362,
+		UseReserveParachute = 363,
+		/// <summary>
+		/// If the <see cref="Ped"/> this is set on is in combat then any dislike feeling they have towards other <see cref="Ped"/>s will be treated as a hate feeling.
+		/// </summary>
+		TreatDislikeAsHateWhenInCombat = 364,
+		/// <summary>
+		/// Law with this set will only update the WL is the target player is seen. This includes on combat initialization as well as during normal LOS checks (ignoring "last known position" reports).
+		/// </summary>
+		OnlyUpdateTargetWantedIfSeen = 365,
+		/// <summary>
+		/// Allows the <see cref="Ped"/> to auto shuffle to the driver seat of a vehicle if the driver is dead (law and MP <see cref="Ped"/>s would do this normally).
+		/// </summary>
+		AllowAutoShuffleToDriversSeat = 366,
+		DontActivateRagdollFromSmokeGrenade = 367,
+		/// <summary>
+		/// If set prevents the <see cref="Ped"/> from reacting to silenced bullets fired from network clone <see cref="Ped"/>s (use for <see cref="Ped"/>s where stealth kills are important).
+		/// </summary>
+		PreventReactingToSilencedCloneBullets = 372,
+		/// <summary>
+		/// Blocks <see cref="Ped"/> from creating the injured cry for help events (run over, tazed or melee would usually do this).
+		/// </summary>
+		DisableInjuredCryForHelpEvents = 373,
+		/// <summary>
+		/// Prevents <see cref="Ped"/>s riding trains from getting off them.
+		/// </summary>
+		NeverLeaveTrain = 374,
+		/// <summary>
+		/// Prevents <see cref="Ped"/> dropping jetpack when they die.
+		/// </summary>
+		DontDropJetpackOnDeath = 375,
+		/// <summary>
+		/// Prevents <see cref="Ped"/> from auto-equipping helmets when entering a bike (includes quad bikes).
+		/// </summary>
+		DisableAutoEquipHelmetsInBikes = 380,
+		/// <summary>
+		/// Prevents <see cref="Ped"/> from auto-equipping helmets when entering an aircraft.
+		/// </summary>
+		DisableAutoEquipHelmetsInAircraft = 381,
+		PreferNoPriorityRemoval = 384,
+		IsClimbingLadder = 388,
+		/// <summary>
+		/// Flag to indicate that player has no shoes(used for first person aiming camera).
+		/// </summary>
+		HasBareFeet = 389,
+		/// <summary>
+		/// It will force the <see cref="Ped"/> to abandon its vehicle (when using TaskGoToPointAnyMeans) if it is unable to get back to road.
+		/// </summary>
+		GoOnWithoutVehicleIfItIsUnableToGetBackToRoad = 391,
+		/// <summary>
+		/// This will block health pickups from being created when the <see cref="Ped"/> dies.
+		/// </summary>
+		BlockDroppingHealthSnacksOnDeath = 392,
+		ResetLastVehicleOnVehicleExit = 393,
+		/// <summary>
+		/// Forces threat response to melee actions from non friend to friend <see cref="Ped"/>s.
+		/// </summary>
+		ForceThreatResponseToNonFriendToFriendMeleeActions = 394,
+		/// <summary>
+		/// Do not respond to random <see cref="Ped"/>s damage.
+		/// </summary>
+		DontRespondToRandomPedsDamage = 395,
+		/// <summary>
+		/// Shares the same logic of PCF_OnlyUpdateTargetWantedIfSeen but will continue to check even after the initial WL is set.
+		/// </summary>
+		AllowContinuousThreatResponseWantedLevelUpdates = 396,
+		/// <summary>
+		/// The target loss response will not be reset to exit task on cleanup if this is set.
+		/// </summary>
+		KeepTargetLossResponseOnCleanup = 397,
+		/// <summary>
+		/// Similar to DontDragMeOutCar except it will still allow AI to drag the <see cref="Ped"/> out of a vehicle.
+		/// </summary>
+		PlayersDontDragMeOutOfCar = 398,
+		/// <summary>
+		/// Whenever the <see cref="Ped"/> starts shooting while going to a point, it trigger a responded to threat broadcast.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_BroadcastRepondedToThreatWhenGoingToPointShooting</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>,
+		BroadcastRespondedToThreatWhenGoingToPointShooting = 399,
+		/// <summary>
+		/// If this is set then IsFriendlyWith will ignore the <see cref="Ped"/> type checks (i.e. two PEDTYPE_COP <see cref="Ped"/>s are not automatically friendly).
+		/// </summary>
+		IgnorePedTypeForIsFriendlyWith = 400,
+		/// <summary>
+		/// Any non friendly <see cref="Ped"/> will be considered as hated instead when in combat.
+		/// </summary>
+		TreatNonFriendlyAsHateWhenInCombat = 401,
+		/// <summary>
+		/// Suppresses "LeaderExistedCarAsDriver" events. Ped won't exit vehicle if leader isn't in it as well.
+		/// </summary>
+		DontLeaveVehicleIfLeaderNotInVehicle = 402,
+		/// <summary>
+		/// Allow melee reaction to come through even if proof is on.
+		/// </summary>
+		AllowMeleeReactionIfMeleeProofIsOn = 404,
+		/// <summary>
+		/// If this is set, <see cref="Ped"/> won't be instantly killed if vehicle is blown up. Instead, they will take normal explosive damage and be forced to exit the vehicle if they're still alive.
+		/// </summary>
+		UseNormalExplosionDamageWhenBlownUpInVehicle = 407,
+		/// <summary>
+		/// Blocks locking on of the vehicle that the <see cref="Ped"/> is inside.
+		/// </summary>
+		DisableHomingMissileLockForVehiclePedInside = 408,
+		/// <summary>
+		/// Disable taking off the scuba gear. Same as PRF_DisableTakeOffScubaGear but on a config flag.
+		/// </summary>
+		DisableTakeOffScubaGear = 409,
+		/// <summary>
+		/// Melee fist weapons (ie knuckle duster) won't apply relative health damage scaler (MeleeRightFistTargetHealthDamageScaler in weapon info).
+		/// </summary>
+		IgnoreMeleeFistWeaponDamageMult = 410,
+		/// <summary>
+		/// Law <see cref="Ped"/>s will be triggered to flee if player triggers an appropriate event (even if <see cref="Ped"/> is not wanted) instead of entering combat. NB: Only synced over the network when set on players.
+		/// </summary>
+		LawPedsCanFleeFromNonWantedPlayer = 411,
+		ForceBlipSecurityPedsIfPlayerIsWanted = 412,
+		/// <summary>
+		/// Don't use nav mesh for navigating to scenario points. DLC Hack for yachts.
+		/// </summary>
+		UseGoToPointForScenarioNavigation = 414,
+		/// <summary>
+		/// Don't clear local <see cref="Ped"/>'s wanted level when remote <see cref="Ped"/> in the same car has his wanted level cleared by script.
+		/// </summary>
+		DontClearLocalPassengersWantedLevel = 415,
+		/// <summary>
+		/// Block auto weapon swaps for weapon pickups.
+		/// </summary>
+		BlockAutoSwapOnWeaponPickups = 416,
+		/// <summary>
+		/// Increase AI targeting score for <see cref="Ped"/>s with this flag.
+		/// </summary>
+		ThisPedIsATargetPriorityForAI = 417,
+		/// <summary>
+		/// Indicates <see cref="Ped"/> is using switch helmet visor up/down anim.
+		/// </summary>
+		IsSwitchingHelmetVisor = 418,
+		/// <summary>
+		/// Indicates <see cref="Ped"/> is using switch helmet visor up/down anim.
+		/// </summary>
+		ForceHelmetVisorSwitch = 419,
+		/// <summary>
+		/// Overrides <see cref="Ped"/> footstep particle effects with the overriden footstep effect.
+		/// </summary>
+		UseOverrideFootstepPtFx = 421,
+		/// <summary>
+		/// Disables vehicle combat.
+		/// </summary>
+		DisableVehicleCombat = 422,
+		TreatAsFriendlyForTargetingAndDamage = 423,
+		/// <summary>
+		/// Allows transition into bike alternate animations (PI menu option).
+		/// </summary>
+		AllowBikeAlternateAnimations = 424,
+		TreatAsFriendlyForTargetingAndDamageNonSynced = 425,
+		/// <summary>
+		/// Use Franklin's alternate lock picking animations for forced entry.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_UseLockpickVehicleEntryAnimations</c> in the exe.
+		/// </remarks>
+		UseLockPickVehicleEntryAnimations = 426,
+		/// <summary>
+		/// When set, player will be able to sprint inside interiors even if it is tagged to prevent it.
+		/// </summary>
+		IgnoreInteriorCheckForSprinting = 427,
+		/// <summary>
+		/// When set, swat helicopters will spawn within last spotted location instead of actual <see cref="Ped"/> location (and target is a player).
+		/// </summary>
+		SwatHeliSpawnWithinLastSpottedLocation = 428,
+		/// <summary>
+		/// Prevents <see cref="Ped"/> from playing start engine anims (and turning engine on).
+		/// </summary>
+		DisableStartEngine = 429,
+		/// <summary>
+		/// Makes <see cref="Ped"/> ignore being on fire (fleeing, reacting to CEventOnFire event).
+		/// </summary>
+		IgnoreBeingOnFire = 430,
+		/// <summary>
+		/// Disables turret seat and activity seat preference for vehicle entry for local player.
+		/// </summary>
+		DisableTurretOrRearSeatPreference = 431,
+		/// <summary>
+		/// Will not spawn wanted helicopters to chase after this target.
+		/// </summary>
+		DisableWantedHelicopterSpawning = 432,
+		/// <summary>
+		/// Will only create aimed at events if player is within normal perception of the target.
+		/// </summary>
+		UseTargetPerceptionForCreatingAimedAtEvents = 433,
+		/// <summary>
+		/// Will prevent homing lockon on the <see cref="Ped"/>.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_CONFIG_FLAG_DisableHomingMissileLockon</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>,
+		DisableHomingMissileLockOn = 434,
+		/// <summary>
+		/// Ignore max number of active support combatants and let <see cref="Ped"/> join them as such.
+		/// </summary>
+		ForceIgnoreMaxMeleeActiveSupportCombatants = 435,
+		/// <summary>
+		/// Will try to stay within set defensive area while driving a vehicle.
+		/// </summary>
+		StayInDefensiveAreaWhenInVehicle = 436,
+		/// <summary>
+		/// Will prevent the <see cref="Ped"/> from communicating target position to all other friendly <see cref="Ped"/>s.
+		/// </summary>
+		DontShoutTargetPosition = 437,
+		/// <summary>
+		/// Will apply full headshot damage, regardless if <see cref="Ped"/> has a helmet (or armored one).
+		/// </summary>
+		DisableHelmetArmor = 438,
+		/// <summary>
+		/// Will ignore the friendly fire setting set by NETWORK_SET_FRIENDLY_FIRE_OPTION when checking if <see cref="Ped"/> can be damaged.
+		/// </summary>
+		IgnoreNetSessionFriendlyFireCheckForAllowDamage = 442,
+		/// <summary>
+		/// Will make <see cref="Ped"/> stay in combat even if the player hes targeting starts being attacked by cops.
+		/// </summary>
+		DontLeaveCombatIfTargetPlayerIsAttackedByPolice = 443,
+		/// <summary>
+		/// Will check when entering a vehicle if it is locked before warping.
+		/// </summary>
+		CheckLockedBeforeWarp = 444,
+		/// <summary>
+		/// Will prevent a player from shuffling across to make room if another player is entering from the same side.
+		/// </summary>
+		DontShuffleInVehicleToMakeRoom = 445,
+		/// <summary>
+		/// Will give the <see cref="Ped"/> a weapon to use once their weapon is removed for getups.
+		/// </summary>
+		GiveWeaponOnGetup = 446,
+		/// <summary>
+		/// Ped fired projectiles will ignore the vehicle they are in.
+		/// </summary>
+		DontHitVehicleWithProjectiles = 447,
+		/// <summary>
+		/// Will prevent <see cref="Ped"/> from forcing entry into cars that are open from TryLockedDoor state.
+		/// </summary>
+		DisableForcedEntryForOpenVehiclesFromTryLockedDoor = 448,
+		/// <summary>
+		/// his <see cref="Ped"/> will fire rockets that explode when close to its target, and won't affect it.
+		/// </summary>
+		FiresDummyRockets = 449,
+		/// <summary>
+		/// This <see cref="Ped"/> has created a decoy.
+		/// </summary>
+		HasEstablishedDecoy = 452,
+		/// <summary>
+		/// Will prevent dispatched helicopters from landing and dropping off <see cref="Ped"/>s.
+		/// </summary>
+		BlockDispatchedHelicoptersFromLanding = 453,
+		/// <summary>
+		/// Will prevent <see cref="Ped"/>s from crying for help when shot with the stun gun.
+		/// </summary>
+		DontCryForHelpOnStun = 454,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> may be incapacitated.
+		/// </summary>
+		CanBeIncapacitated = 456,
+		/// <summary>
+		/// If set, we wont set a new target after a melee attack.
+		/// </summary>
+		DontChangeTargetFromMelee = 458,
+		/// <summary>
+		/// Prevents a dead <see cref="Ped"/> from sinking.
+		/// </summary>
+		RagdollFloatsIndefinitely = 460,
+		/// <summary>
+		/// Blocks electric weapon damage.
+		/// </summary>
+		BlockElectricWeaponDamage = 461,
+	}
+}

--- a/source/scripting_v3/GTA/Entities/Peds/PedResetFlags.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedResetFlags.cs
@@ -1,0 +1,666 @@
+namespace GTA
+{
+	/// <summary>
+	/// An enumeration of known reset flags for <see cref="Ped"/>, which will be required to set or get every frame you need to set or get.
+	/// </summary>
+	/// <remarks>
+	/// You can check if names of this enum are included by searching the dumped exe for hashed values of names like <c>CPED_RESET_FLAG_[enum name]</c> without case conversion
+	/// (for example, search the dumped exe for 0x49F290D0, which is the hashed value of <c>CPED_RESET_FLAG_DisablePlayerJumping</c>).
+	/// </remarks>
+	public enum PedResetFlags
+	{
+		/// <summary>
+		/// Disable jumping (exclusive from climbing).
+		/// </summary>
+		DisablePlayerJumping = 46,
+		/// <summary>
+		/// Disable climbing / vaulting.
+		/// </summary>
+		/// <remarks>
+		/// Does not disable auto-vault, but you can disable it with <see cref="DisablePlayerAutoVaulting"/>.
+		/// </remarks>
+		DisablePlayerVaulting = 47,
+		/// <summary>
+		/// Don't freeze the <see cref="Ped"/> for not having bounds loaded around it.
+		/// </summary>
+		AllowUpdateIfNoCollisionLoaded = 55,
+		/// <summary>
+		/// Suppresses AI generating fire events, so civilians won't be shocked or react, for use in a shooting range for example.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_SupressGunfireEvents</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		SuppressGunfireEvents = 62,
+		/// <summary>
+		/// Currently just for mounts, but could be expanded to anything with stamina.
+		/// </summary>
+		InfiniteStamina = 63,
+		/// <summary>
+		/// Stops the <see cref="Ped"/> from reacting to damage events (such as shots / fires, etc).
+		/// The <see cref="Ped"/> will still take damage while this flag is active.
+		/// </summary>
+		/// <remarks>
+		/// Does not block explosion reactions.
+		/// </remarks>
+		BlockWeaponReactionsUnlessDead = 64,
+		/// <summary>
+		/// Forces player to fire even if they aren't pressing fire
+		/// </summary>
+		ForcePlayerFiring = 65,
+		/// <summary>
+		/// Forces an actor that is in cover to continue (or start if they haven't yet) peeking
+		/// </summary>
+		ForcePeekFromCover = 67,
+		/// <summary>
+		/// Forces an actor to strafe
+		/// </summary>
+		ForcePedToStrafe = 69,
+		/// <summary>
+		/// Enables kinematic physics mode on The <see cref="Ped"/>.
+		/// This stops other physical objects from pushing The <see cref="Ped"/> around, and causes the <see cref="Ped"/>
+		/// to push any physical objects out of its way when it moves into them.
+		/// </summary>
+		UseKinematicPhysics = 71,
+		/// <summary>
+		/// Clear the players lock on target next frame
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_ClearLockonTarget</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		ClearLockOnTarget = 72,
+		/// <summary>
+		/// forces the <see cref="Ped"/> to the scripted camera heading instead of gameplay.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_ForcePedToUseScripCamHeading</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		ForcePedToUseScriptCamHeading = 77,
+		/// <summary>
+		/// When doing LOS checks to other <see cref="Ped"/>s we won't use the cover vantage position as the "target" position.
+		/// </summary>
+		IgnoreTargetsCoverForLOS = 85,
+		/// <summary>
+		/// Force the crouch flag to return true while in cover.
+		/// </summary>
+		DisableCrouchWhileInCover = 88,
+		/// <summary>
+		/// Forces the <see cref="Ped"/> to apply forces to frags as if running on contact,
+		/// to guarantee <see cref="Ped"/>s will smash through frag objects when playing custom anims.
+		/// </summary>
+		ForceRunningSpeedForFragSmashing = 91,
+		/// <summary>
+		/// Force the bullets gun range to increase to 250m.
+		/// </summary>
+		ExtraLongWeaponRange = 95,
+		/// <summary>
+		/// Forces the player to only use direct access when entering vehicles.
+		/// </summary>
+		ForcePlayerToEnterVehicleThroughDirectDoorOnly = 96,
+		/// <summary>
+		/// Disable the <see cref="Ped"/> getting cull from a vehicle from pretend occupants.
+		/// </summary>
+		TaskCullExtraFarAway = 97,
+		/// <summary>
+		/// If this flag is set on a <see cref="Ped"/>, it will not attempt to auto-vault.
+		/// </summary>
+		DisablePlayerAutoVaulting = 102,
+		/// <summary>
+		/// If this flag is set on a <see cref="Ped"/>, it will use the bullet shoot through code.
+		/// </summary>
+		UseBulletPenetration = 107,
+		/// <summary>
+		/// Force all attackers to target the head of the <see cref="Ped"/>.
+		/// </summary>
+		ForceAimAtHead = 108,
+		/// <summary>
+		/// Inform avoidance code that the <see cref="Ped"/> isn't going anywhere and should be steered around rather than waited for
+		/// </summary>
+		IsInStationaryScenario = 109,
+		/// <summary>
+		/// Any targeting LoS checks will fail if any materials with 'see through' materials found.
+		/// </summary>
+		DisableSeeThroughChecksWhenTargeting = 112,
+		/// <summary>
+		/// When set, the <see cref="Ped"/> is putting on a helmet. DONT SET THIS only query it.
+		/// </summary>
+		PuttingOnHelmet = 113,
+		/// <summary>
+		/// When set, the <see cref="Ped"/> will play panic animations if in a vehicle.
+		/// </summary>
+		PanicInVehicle = 120,
+		/// <summary>
+		/// Forces the <see cref="Ped"/> to the injured state after being stunned.
+		/// </summary>
+		ForceInjuryAfterStunned = 126,
+		/// <summary>
+		/// Prevent the <see cref="Ped"/> from shooting a weapon.
+		/// </summary>
+		BlockWeaponFire = 128,
+		/// <summary>
+		/// Set the <see cref="Ped"/> capsule radius based on skeleton.
+		/// </summary>
+		ExpandPedCapsuleFromSkeleton = 129,
+		/// <summary>
+		/// Toggle the weapon laser sight off for this frame.
+		/// </summary>
+		DisableWeaponLaserSight = 130,
+		/// <summary>
+		/// Temporarily suspend any melee actions this frame (does not include hit reactions). Use PCF_DisableMelee to turn it off completely.
+		/// </summary>
+		SuspendInitiatedMeleeActions = 149,
+		/// <summary>
+		/// Prevents the <see cref="Ped"/> from getting the in air event the next frame.
+		/// </summary>
+		SuppressInAirEvent = 150,
+		/// <summary>
+		/// If set, allows the <see cref="Ped"/> to have tasks incompatible with its current motion.
+		/// </summary>
+		AllowTasksIncompatibleWithMotion = 151,
+		/// <summary>
+		/// This will suppress any melee action that is considered lethal (RA_IS_LETHAL, defined in action_table.meta).
+		/// </summary>
+		SuppressLethalMeleeActions = 155,
+		/// <summary>
+		/// Don't auto run when this flag is set.
+		/// </summary>
+		NoAutoRunWhenFiring = 167,
+		/// <summary>
+		/// Don't let the <see cref="Ped"/> take navmesh edges into account when performing their low-level steering/avoidance code.
+		/// </summary>
+		DisableSteeringAroundNavMeshEdges = 172,
+		/// <summary>
+		/// Disable taking off the parachute pack
+		/// </summary>
+		DisableTakeOffParachutePack = 177,
+		/// <summary>
+		/// If the <see cref="Ped"/> has the INSULT special ability, and this flag is set, he will always use the combat taunt when the special is activated.
+		/// </summary>
+		ForceCombatTaunt = 179,
+		/// <summary>
+		/// The <see cref="Ped"/> will ignore combat taunts
+		/// </summary>
+		IgnoreCombatTaunts = 180,
+		/// <summary>
+		/// Will temporarily prevent any takedown from being performed on the <see cref="Ped"/>.
+		/// </summary>
+		PreventAllMeleeTakedowns = 187,
+		/// <summary>
+		/// Will temporarily prevent any failed takedown from being performed on the <see cref="Ped"/>.
+		/// </summary>
+		PreventFailedMeleeTakedowns = 188,
+		/// <summary>
+		/// Will temporarily force min avoidance on the <see cref="Ped"/>.
+		/// Will brush other <see cref="Ped"/>s but avoid a bit.
+		/// </summary>
+		UseTighterAvoidanceSettings = 190,
+		/// <summary>
+		/// Disable drop downs for the <see cref="Ped"/>.
+		/// </summary>
+		DisableDropDowns = 195,
+		/// <summary>
+		/// Disable taking off the scuba gear.
+		/// </summary>
+		DisableTakeOffScubaGear = 197,
+		/// <summary>
+		/// Disable combat anims for the <see cref="Ped"/>.
+		/// </summary>
+		DisableActionMode = 200,
+		/// <summary>
+		/// Use the <see cref="Ped"/>'s head orientation for perception tests.
+		/// </summary>
+		UseHeadOrientationForPerception = 206,
+		/// <summary>
+		/// The player will no longer auto-ragdoll when colliding with something while jumping.
+		/// </summary>
+		DisableJumpRagdollOnCollision = 210,
+		/// <summary>
+		/// Disable parachuting for the <see cref="Ped"/>.
+		/// </summary>
+		DisableParachuting = 217,
+		/// <summary>
+		/// Keep the parachute pack on after a teleport.
+		/// </summary>
+		KeepParachutePackOnAfterTeleport = 222,
+		/// <summary>
+		/// Whether or not you want the player <see cref="Ped"/> to use the new front melee logic.
+		/// </summary>
+		DontRaiseFistsWhenLockedOn = 223,
+		/// <summary>
+		/// This will prefer all melee hit reactions to use body ik hit reactions if ragdoll is not selected
+		/// </summary>
+		PreferMeleeBodyIkHitReaction = 224,
+		/// <summary>
+		/// If set, disables friendly responses to gunshots/being aimed at.
+		/// </summary>
+		DisableFriendlyGunReactAudio = 227,
+		/// <summary>
+		/// Disables agitation triggers.
+		/// </summary>
+		DisableAgitationTriggers = 228,
+		/// <summary>
+		/// Disable NM reactions to fast moving water for the <see cref="Ped"/>.
+		/// </summary>
+		DisableNMForRiverRapids = 234,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will not go into the still in vehicle pose.
+		/// </summary>
+		PreventGoingIntoStillInVehicleState = 236,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will get in and out of vehicles faster (same as in multiplayer).
+		/// </summary>
+		UseFastEnterExitVehicleRates = 237,
+		/// <summary>
+		/// Disables agitation.
+		/// </summary>
+		DisableAgitation = 239,
+		/// <summary>
+		/// Disables talking.
+		/// </summary>
+		DisableTalk = 240,
+		/// <summary>
+		/// Uses more expensive slope/stairs detection.
+		/// </summary>
+		UseProbeSlopeStairsDetection = 247,
+		/// <summary>
+		/// Disables vehicle damage reactions.
+		/// </summary>
+		DisableVehicleDamageReactions = 248,
+		/// <summary>
+		/// Disables potential blast reactions.
+		/// </summary>
+		DisablePotentialBlastReactions = 249,
+		/// <summary>
+		/// When set along side open door ik, will only use the left hand.
+		/// </summary>
+		OnlyAllowLeftArmDoorIk = 250,
+		/// <summary>
+		/// When set along side open door ik, will only use the left hand.
+		/// </summary>
+		OnlyAllowRightArmDoorIk = 251,
+		/// <summary>
+		/// When set, the flash light on a Ai weapon will be turned off.
+		/// </summary>
+		DisableFlashLight = 253,
+		/// <summary>
+		/// When set, the AI <see cref="Ped"/> will enable their flash light.
+		/// </summary>
+		ForceEnableFlashLightForAI = 258,
+		/// <summary>
+		/// Disables combat audio.
+		/// </summary>
+		DisableCombatAudio = 262,
+		/// <summary>
+		/// Disables cover audio.
+		/// </summary>
+		DisableCoverAudio = 263,
+		/// <summary>
+		/// Player has to press and hold dive button to dive in water.
+		/// </summary>
+		EnablePressAndReleaseDives = 271,
+		/// <summary>
+		/// Only allows player to exit vehicle when button is released rather than pressed or held.
+		/// </summary>
+		OnlyExitVehicleOnButtonRelease = 272,
+		/// <summary>
+		/// Considered as a threat as part of player cover search even if they can't see the player.
+		/// </summary>
+		ConsiderAsPlayerCoverThreatWithoutLOS = 282,
+		/// <summary>
+		/// Disables the <see cref="Ped"/> from using custom ai cover entry animations.
+		/// </summary>
+		BlockCustomAIEntryAnims = 283,
+		/// <summary>
+		/// Ignore the vehicle entry collision tests for this <see cref="Ped"/>.
+		/// </summary>
+		IgnoreVehicleEntryCollisionTests = 284,
+		/// <summary>
+		/// If set, the <see cref="Ped"/> will not go into the shunt in vehicle pose.
+		/// </summary>
+		PreventGoingIntoShuntInVehicleState = 287,
+		/// <summary>
+		/// If set, turn on the voice driven mouth movement
+		/// </summary>
+		EnableVoiceDrivenMouthMovement = 302,
+		/// <summary>
+		/// To have <see cref="Ped"/>ds do better vehicle entries when in a group and interfered by other <see cref="Ped"/>s, use carefully though.
+		/// </summary>
+		UseTighterEnterVehicleSettings = 304,
+		/// <summary>
+		/// Set when the player is in the races to make the player more interesting to look at.
+		/// </summary>
+		InRaceMode = 305,
+		/// <summary>
+		/// Disable ambient (initial) melee moves.
+		/// </summary>
+		DisableAmbientMeleeMoves = 306,
+		/// <summary>
+		/// Allows the player to trigger the special ability while in a vehicle.
+		/// </summary>
+		AllowSpecialAbilityInVehicle = 308,
+		/// <summary>
+		/// Prevents the <see cref="Ped"/> from doing in vehicle actions like closing door, hotwiring, starting engine, putting on helmet etc.
+		/// </summary>
+		DisableInVehicleActions = 309,
+		/// <summary>
+		/// Forces the <see cref="Ped"/> to blend in steering wheel ik instantly rather than over time.
+		/// </summary>
+		ForceInstantSteeringWheelIkBlendIn = 310,
+		/// <summary>
+		/// Ignores the bonus score for selecting cover that the player can engage the enemy at.
+		/// </summary>
+		IgnoreThreatEngagePlayerCoverBonus = 311,
+		/// <summary>
+		/// Prevents the the <see cref="Ped"/> from closing the vehicle door of the car they're inside.
+		/// </summary>
+		DontCloseVehicleDoor = 313,
+		/// <summary>
+		/// Explosions can't be blocked by map collision when damaging the <see cref="Ped"/>.
+		/// </summary>
+		SkipExplosionOcclusion = 314,
+		/// <summary>
+		/// Set when the <see cref="Ped"/> has performed a melee strike and hit any non <see cref="Ped"/> material.
+		/// </summary>
+		MeleeStrikeAgainstNonPed = 316,
+		/// <summary>
+		/// We will not attempt to walk around doors when using arm IK.
+		/// </summary>
+		IgnoreNavigationForDoorArmIK = 317,
+		/// <summary>
+		/// Disable aiming while parachuting.
+		/// </summary>
+		DisableAimingWhileParachuting = 318,
+		/// <summary>
+		/// Disable hit reaction due to colliding with a <see cref="Ped"/>.
+		/// </summary>
+		DisablePedCollisionWithPedEvent = 319,
+		/// <summary>
+		/// Will ignore the vehicle speed threshold and close the door anyway.
+		/// </summary>
+		IgnoreVelocityWhenClosingVehicleDoor = 320,
+		/// <summary>
+		/// Skip idle intro.
+		/// </summary>
+		SkipOnFootIdleIntro = 321,
+		/// <summary>
+		/// Don't walk round objects that we collide with whilst moving.
+		/// </summary>
+		DontWalkRoundObjects = 322,
+		/// <summary>
+		/// Disable the <see cref="Ped"/> entered my vehicle events.
+		/// </summary>
+		DisablePedEnteredMyVehicleEvents = 323,
+		/// <summary>
+		/// Will allow the <see cref="Ped"/> variations to be rendered in vehicles, even if marked otherwise.
+		/// </summary>
+		DisableInVehiclePedVariationBlocking = 326,
+		/// <summary>
+		/// When on a mission this reset flag will slightly reduce the amount of time the player loses control of their vehicle when hit by an AI <see cref="Ped"/>.
+		/// </summary>
+		ReduceEffectOfVehicleRamControlLoss = 327,
+		/// <summary>
+		/// Another flag to disable friendly attack from the player. Set on the opponent you would like it to be disabled on.
+		/// </summary>
+		DisablePlayerMeleeFriendlyAttacks = 328,
+		/// <summary>
+		/// Set when the melee target has been deemed unreachable (AI only).
+		/// </summary>
+		IsMeleeTargetUnreachable = 330,
+		/// <summary>
+		/// Disable automatically forcing player to exit a vehicle in a network game when blowing up vehicle.
+		/// </summary>
+		DisableAutoForceOutWhenBlowingUpCar = 331,
+		/// <summary>
+		/// Disable ambient dust off animations.
+		/// </summary>
+		DisableDustOffAnims = 334,
+		/// <summary>
+		/// The <see cref="Ped"/> will refrain from ever performing a melee hit reaction.
+		/// </summary>
+		DisableMeleeHitReactions = 335,
+		/// <summary>
+		/// This overrides PV_FLAG_NOT_IN_CAR (which is used in 3rd argument of <c>GIVE_PED_HELMET</c>) set on any head prop and stops it from being removed when getting into the vehicle.
+		/// </summary>
+		AllowHeadPropInVehicle = 337,
+		DontQuitMotionAiming = 339,
+		/// <summary>
+		/// Reset version of PCF_OpenDoorArmIK, which sets if the <see cref="Ped"/> should enable open door arm IK.
+		/// </summary>
+		OpenDoorArmIK = 342,
+		/// <summary>
+		/// Force use of tighter turn settings in locomotion task.
+		/// </summary>
+		UseTighterTurnSettingsForScript = 343,
+		/// <summary>
+		/// If set, turn off the voice driven mouth movement (overrides EnableVoiceDrivenMouthMovement).
+		/// </summary>
+		DisableVoiceDrivenMouthMovement = 346,
+		/// <summary>
+		/// If set, steer into skids while driving.
+		/// </summary>
+		SteerIntoSkids = 347,
+		/// <summary>
+		/// When set, code will ignore the logic that requires the <see cref="Ped"/> to be in CTaskHumanLocomotion::State_Moving.
+		/// </summary>
+		AllowOpenDoorIkBeforeFullMovement = 348,
+		/// <summary>
+		/// When set, code will bypass rel settings and allow a homing lock on to the <see cref="Ped"/> when they are in a vehicle.
+		/// </summary>
+		AllowHomingMissileLockOnInVehicle = 349,
+		AllowCloneForcePostCameraAIUpdate = 350,
+		/// <summary>
+		/// Force the high heels DOF to be 0.
+		/// </summary>
+		DisableHighHeels = 351,
+		/// <summary>
+		/// Player does not get tired when sprinting.
+		/// </summary>
+		DontUseSprintEnergy = 353,
+		/// <summary>
+		/// Don't be damaged by touching dangerous material (e.g. electric generator).
+		/// </summary>
+		DisableMaterialCollisionDamage = 355,
+		/// <summary>
+		/// Don't target friendly players in MP.
+		/// </summary>
+		DisableMPFriendlyLockon = 356,
+		/// <summary>
+		/// Don't melee kill friendly players in MP.
+		/// </summary>
+		DisableMPFriendlyLethalMeleeActions = 357,
+		/// <summary>
+		/// If our leader stops, try and seek cover if we can.
+		/// </summary>
+		IfLeaderStopsSeekCover = 358,
+		/// <summary>
+		/// Use Interior capsule settings.
+		/// </summary>
+		UseInteriorCapsuleSettings = 362,
+		/// <summary>
+		/// The <see cref="Ped"/> is closing a vehicle door.
+		/// </summary>
+		IsClosingVehicleDoor = 363,
+		/// <summary>
+		/// Disable stuck wall hit animation for the <see cref="Ped"/> this frame.
+		/// </summary>
+		DisableWallHitAnimation = 371,
+		/// <summary>
+		/// When set, the <see cref="Ped"/> will play panic animations if in a vehicle.
+		/// </summary>
+		PlayAgitatedAnimsInVehicle = 372,
+		/// <summary>
+		/// The <see cref="Ped"/> is shuffling seat.
+		/// </summary>
+		IsSeatShuffling = 373,
+		/// <summary>
+		/// Allows ped in any seat to control the radio (in MP only).
+		/// </summary>
+		AllowControlRadioInAnySeatInMP = 376,
+		/// <summary>
+		/// Blocks the <see cref="Ped"/> from manually transforming spy car to/from car/sub modes.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_DisableSpycarTransformation</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		DisableSpyCarTransformation = 377,
+		/// <summary>
+		/// Blocks the <see cref="Ped"/> from head bobbing to radio music in vehicles.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_BlockHeadbobbingToRadio</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		BlockHeadBobbingToRadio = 379,
+		/// <summary>
+		/// When putting a <see cref="Ped"/> directly into cover, the <see cref="Ped"/> will blend in the new cover anims slowly to prevent a pose pop.
+		/// </summary>
+		ForceExtraLongBlendInForPedSkipIdleCoverTransition = 381,
+		/// <summary>
+		/// Don't ever try to lock on to the <see cref="Ped"/> with cinematic aim.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_DisableAssistedAimLockon</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		DisableAssistedAimLockOn = 390,
+		/// <summary>
+		/// Any <see cref="Ped"/>s with this flag set on won't register damage from collisions against other <see cref="Ped"/>s.
+		/// </summary>
+		NoCollisionDamageFromOtherPeds = 394,
+		/// <summary>
+		/// For thing that inherit from boats only.
+		/// </summary>
+		DontSuppressUseNavMeshToNavigateToVehicleDoorWhenVehicleInWater = 398,
+		/// <summary>
+		/// If true it avoids playing the settle anim when aiming.
+		/// </summary>
+		InstantBlendToAimNoSettle = 401,
+		/// <summary>
+		/// For first person mode, when the player enters low cover, will orientate camera to face left or right rather than into cover.
+		/// </summary>
+		ForceScriptedCameraLowCoverAngleWhenEnteringCover = 406,
+		DisableMeleeWeaponSelection = 417,
+		/// <summary>
+		/// Allows <see cref="Ped"/>s following waypoint recordings to slow down more for corners. (Achieves same effect as the EWAYPOINT_SUPPRESS_EXACTSTOP flag, which is passed into TASK_FOLLOW_WAYPOINT_RECORDING).
+		/// </summary>
+		WaypointPlaybackSlowMoreForCorners = 418,
+		/// <summary>
+		/// <see cref="Ped"/> will use bullet penetration code when glass material is hit.
+		/// </summary>
+		UseBulletPenetrationForGlass = 420,
+		/// <summary>
+		/// If set on a <see cref="Ped"/> then they are allowed to be pinned by bullets from friendly <see cref="Ped"/>s.
+		/// </summary>
+		CanBePinnedByFriendlyBullets = 423,
+		/// <summary>
+		/// Blocks road blocks with spike strips from spawning.
+		/// </summary>
+		DisableSpikeStripRoadBlocks = 425,
+		/// <summary>
+		/// <see cref="Ped"/>s marked with this flag will only be able to be hit by the player if the player explicitly presses the melee button.
+		/// </summary>
+		IsLowerPriorityMeleeTarget = 428,
+		/// <summary>
+		/// Disable timeslicing of event scanning this frame.
+		/// </summary>
+		ForceScanForEventsThisFrame = 429,
+		/// <summary>
+		/// Forces <see cref="Ped"/> to auto-equip a helmet when entering an aircraft. Overrides PCF_DisableAutoEquipHelmetsInAicraft which is set in the interaction menu.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_ForceAutoEquipHelmetsInAicraft</c> in the exe, but this enum uses the corrected name.
+		/// </remarks>
+		ForceAutoEquipHelmetsInAircraft = 432,
+		/// <summary>
+		/// Flag used by replay editor to disable recording specified remote players.
+		/// </summary>
+		BlockRemotePlayerRecording = 433,
+		/// <summary>
+		/// allow FPS vehicle anims even if FPS camera isn't dominant.
+		/// </summary>
+		UseFirstPersonVehicleAnimsIfFPSCamNotDominant = 435,
+		/// <summary>
+		/// allow FPS vehicle anims even if FPS camera isn't dominant.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_ForceIntoStandPoseOnJetski</c> in the exe, but this enum uses the capital-corrected name.
+		/// </remarks>
+		ForceIntoStandPoseOnJetSki = 436,
+		/// <summary>
+		/// This will suppress all takedown melee actions (RA_IS_TAKEDOWN or RA_IS_STEALTH_KILL, defined in action_table.meta)
+		/// </summary>
+		SuppressTakedownMeleeActions = 438,
+		/// <summary>
+		/// Inverts lookaround controls (right stick / mouse) for this player.
+		/// </summary>
+		InvertLookAroundControls = 439,
+		/// <summary>
+		/// Allows attacking <see cref="Ped"/>s to engage another entity without waiting for its turn (if there's multiple attackers).
+		/// </summary>
+		IgnoreCombatManager = 440,
+		/// <summary>
+		/// Check if there is an active camera blending and use the blended camera frame when compute the FPS camera relative matrix.
+		/// </summary>
+		UseBlendedCamerasOnUpdateFpsCameraRelativeMatrix = 441,
+		/// <summary>
+		/// Forces the <see cref="Ped"/> to perform a dodge and a counter move if it's attacked.
+		/// </summary>
+		ForceMeleeCounter = 442,
+		/// <summary>
+		/// Suppress navmesh navigation in TaskEnterVehicle. Will use gotopoint or bail if cant use that.
+		/// </summary>
+		SuppressNavmeshForEnterVehicleTask = 444,
+		/// <summary>
+		/// Prevents the <see cref="Ped"/> from jumping out of the vehicle in shallow water if the bike is submerged.
+		/// </summary>
+		DisableShallowWaterBikeJumpOutThisFrame = 445,
+		/// <summary>
+		/// Prevents the player from performing a combat roll.
+		/// </summary>
+		DisablePlayerCombatRoll = 446,
+		/// <summary>
+		/// Will ignore safe position check on detaching the <see cref="Ped"/>.
+		/// </summary>
+		IgnoreDetachSafePositionCheck = 447,
+		/// <summary>
+		/// Prevents the more forgiving MP ladder detection settings from being used, and forces SP settings.
+		/// </summary>
+		DisableEasyLadderConditions = 448,
+		/// <summary>
+		/// Makes local player ignore certain scenario spawn restrictions on scenarios that respect this flag.
+		/// </summary>
+		PlayerIgnoresScenarioSpawnRestrictions = 449,
+		/// <summary>
+		/// Indicates player is using Drone from Battle DLC.
+		/// </summary>
+		UsingDrone = 450,
+		/// <summary>
+		/// Will use scripted firing position on the clones of the <see cref="Ped"/> on other machines.
+		/// </summary>
+		UseScriptedWeaponFirePosition = 452,
+		/// <summary>
+		/// Use extended logic for determining damage instigator for ragdoll collisions.
+		/// </summary>
+		UseExtendedRagdollCollisionCalculator = 454,
+		/// <summary>
+		/// Prevent the player locking on to friendly players.
+		/// </summary>
+		/// <remarks>
+		/// The original name is <c>CPED_RESET_FLAG_PreventLockonToFriendlyPlayers</c> in the exe, but this enum uses the capital-corrected name.
+		/// </remarks>
+		PreventLockOnToFriendlyPlayers = 455,
+		/// <summary>
+		/// Modifies AF_ABORT_ON_PED_MOVEMENT to only trigger an abort when movement would be caused by player input.
+		/// </summary>
+		OnlyAbortScriptedAnimOnMovementByInput = 456,
+		/// <summary>
+		/// Prevents stealth take downs from being preformed on a <see cref="Ped"/>.
+		/// </summary>
+		PreventAllStealthKills = 457,
+		/// <summary>
+		/// Prevents <see cref="Ped"/>s from entering a fall task if affected by explosion damage.
+		/// </summary>
+		BlockFallTaskFromExplosionDamage = 458,
+		/// <summary>
+		/// Mimics the behaviour of boss <see cref="Ped"/>s by holding the button for entering the rear seats.
+		/// </summary>
+		AllowPedRearEntry = 459,
+	}
+}


### PR DESCRIPTION
Only known names are added to `PedConfigFlags` and `PedResetFlags`. I was able to use the name list of ePedConfigFlags from [rage-parser-dumps by alexguirre and his folks](https://alexguirre.github.io/rage-parser-dumps/dump.html?game=gta5&build=2824&search=epedCon#ePedConfigFlags) and all of the known names were correct. However, I had to yoink some of the names `PedConfigFlags` from the leaked header and had to compute the hashes by my shitty private gadget tool to confirm if the names are actually present in the game.
This is the list of the `ePedResetFlag` names listed in the leaked header but not found in the dumped exe:
```
CPED_RESET_FLAG_DisableSecondaryAnimationTasks = 58,
CPED_RESET_FLAG_SearchForClosestDoor = 60,
CPED_RESET_FLAG_CannotBeTargetedByAI = 124,
CPED_RESET_FLAG_InstantBlendToAim = 156,
CPED_RESET_FLAG_MakeHeadInvisble = 166,
```